### PR TITLE
[codex] Clarify WI-1.1.3 history readiness contract

### DIFF
--- a/docs/prds/phase-1/PRD-1.1-risk-summary-service-v2.md
+++ b/docs/prds/phase-1/PRD-1.1-risk-summary-service-v2.md
@@ -169,6 +169,11 @@ The same logical hierarchy levels may exist in both scopes.
 - if `hierarchy_scope = LEGAL_ENTITY`, `legal_entity_id` is required
 - node resolution must be exact within the selected scope
 - a node identifier valid in one scope must not be assumed valid in another scope
+- for `get_risk_history`, `start_date` and `end_date` define an inclusive date range
+- for `get_risk_history`, `start_date` must be on or before `end_date`
+- for `get_risk_history`, if `snapshot_id` is provided, it is the anchor snapshot for the request and must resolve to a snapshot whose `as_of_date` equals `end_date`
+- for `get_risk_history`, `snapshot_id` pins the request context, but returned `RiskHistoryPoint.snapshot_id` values remain the per-point source snapshot ids for each returned date
+- for `get_risk_history`, `require_complete=true` upgrades otherwise partial history results to `DEGRADED`
 
 ## Outputs
 
@@ -325,6 +330,16 @@ Rules:
   7. `PARTIAL`
   8. `OK`
 
+For `RiskHistorySeries`, status precedence is:
+
+1. typed request validation failure
+2. `MISSING_SNAPSHOT`
+3. `MISSING_NODE`
+4. `DEGRADED`
+5. `MISSING_HISTORY`
+6. `PARTIAL`
+7. `OK`
+
 ## Volatility-aware change concepts
 
 This service distinguishes between:
@@ -349,6 +364,19 @@ Return current summary plus comparison and rolling stats.
 
 Purpose:
 Return dated history for a node and measure.
+
+Inputs:
+
+- `node_ref`
+- `measure_type`
+- `start_date`
+- `end_date`
+- `require_complete=False`
+- `snapshot_id=None`
+
+Returns:
+
+- `RiskHistorySeries`
 
 ### `get_risk_delta`
 
@@ -380,6 +408,13 @@ Return first-order change plus second-order volatility context for consumers tha
 
 ## Degraded and error cases
 
+### Case: invalid history date range
+
+Result:
+
+- typed request validation failure
+- no `RiskHistorySeries` is returned
+
 ### Case: current point missing
 
 Result:
@@ -405,6 +440,53 @@ Result:
   - mean/min/max require at least 1 point
   - std requires at least 2 points
 - `status = MISSING_HISTORY`
+
+### Case: history snapshot missing
+
+Result:
+
+- `status = MISSING_SNAPSHOT`
+- `points = []`
+
+### Case: history node missing
+
+Result:
+
+- `status = MISSING_NODE`
+- `points = []`
+
+`MISSING_NODE` means the requested scoped node and measure cannot be resolved in the pinned dataset context.
+
+### Case: no history points in requested range
+
+Result:
+
+- `status = MISSING_HISTORY`
+- `points = []`
+
+`MISSING_HISTORY` means the node resolves, but zero valid points fall within the inclusive requested range.
+
+### Case: sparse history points in requested range
+
+Result:
+
+- available valid points returned in ascending date order
+- `status = PARTIAL`
+
+### Case: degraded history rows in requested range
+
+Result:
+
+- available points returned in ascending date order
+- `status = DEGRADED`
+- include reason codes for degraded dates or snapshots
+
+### Case: `require_complete=true` for history retrieval
+
+Result:
+
+- any history result that would otherwise be `PARTIAL` must return `status = DEGRADED`
+- available ordered points may still be returned
 
 ### Case: unsupported measure
 
@@ -440,6 +522,8 @@ Result:
   - history range bounds when relevant
   - `require_complete`
   - `snapshot_id` when provided
+- for `get_risk_history`, pinned request context must include `start_date`, `end_date`, `require_complete`, and `snapshot_id` when provided
+- for `get_risk_history`, when `snapshot_id` is provided, it is the anchor snapshot for the request and must remain explicit in replay fixtures and replay test artifacts
 - this deferral does not expand `RiskHistoryPoint` or `RiskHistorySeries` metadata beyond the fields explicitly listed in their v1 contracts
 - `status_reasons` must not be used as a substitute for structured evidence references
 

--- a/docs/prds/phase-1/PRD-1.1-risk-summary-service-v2.md
+++ b/docs/prds/phase-1/PRD-1.1-risk-summary-service-v2.md
@@ -143,18 +143,24 @@ The same logical hierarchy levels may exist in both scopes.
 
 ## Inputs
 
-### Required inputs
+### Required inputs for as-of-date retrieval
 
 - `node_ref`
 - `as_of_date`
 - `measure_type`
 
-### Optional inputs
+These apply to `get_risk_summary`, `get_risk_delta`, and `get_risk_change_profile`.
+
+### Optional inputs for as-of-date retrieval
 
 - `compare_to_date`
 - `lookback_window`
 - `require_complete`
 - `snapshot_id`
+
+These apply to `get_risk_summary`, `get_risk_delta`, and `get_risk_change_profile`.
+
+`get_risk_history` uses the dedicated request shape defined in the API surface section below.
 
 ### Input rules
 
@@ -164,7 +170,7 @@ The same logical hierarchy levels may exist in both scopes.
 - no consumer may infer business days independently
 - if `lookback_window` is omitted, use service default for rolling stats
 - if `require_complete=true`, partial results must return an explicit degraded error/status
-- if `snapshot_id` is provided, retrieval must be pinned to that snapshot
+- if `snapshot_id` is provided for as-of-date retrieval, retrieval must be pinned to that snapshot
 - if `hierarchy_scope = TOP_OF_HOUSE`, `legal_entity_id` must be null
 - if `hierarchy_scope = LEGAL_ENTITY`, `legal_entity_id` is required
 - node resolution must be exact within the selected scope

--- a/docs/prds/phase-1/PRD-1.1-risk-summary-service-v2.md
+++ b/docs/prds/phase-1/PRD-1.1-risk-summary-service-v2.md
@@ -332,7 +332,7 @@ Rules:
 
 For `RiskHistorySeries`, status precedence is:
 
-1. typed request validation failure
+1. `UNSUPPORTED_MEASURE`
 2. `MISSING_SNAPSHOT`
 3. `MISSING_NODE`
 4. `DEGRADED`

--- a/work_items/ready/WI-1.1.3-risk-summary-history-service.md
+++ b/work_items/ready/WI-1.1.3-risk-summary-history-service.md
@@ -35,16 +35,25 @@ Implement history retrieval for a node and measure.
 
 ## Target Area
 
-- `src/modules/risk_analytics/`
+- `src/modules/risk_analytics/service.py`
+- `src/modules/risk_analytics/__init__.py`
 - `tests/unit/modules/risk_analytics/`
 
 ## Acceptance Criteria
 
-- returns correct ordered history
-- invalid date ranges handled explicitly
-- missing node and missing data handled explicitly
+- `get_risk_history` uses explicit `start_date` and `end_date` inputs with inclusive range semantics
+- invalid date ranges fail explicitly and do not fabricate a `RiskHistorySeries`
+- if `snapshot_id` is provided, it is treated as the history-request anchor snapshot and must resolve to `end_date`
+- returned history points are ordered ascending by date and remain within the inclusive requested range
+- missing snapshot returns `MISSING_SNAPSHOT`
+- missing node returns `MISSING_NODE`
+- zero valid points in range returns `MISSING_HISTORY`
+- sparse valid points in range return `PARTIAL`
+- degraded snapshot rows return `DEGRADED`
+- `require_complete=true` upgrades otherwise partial history results to `DEGRADED`
 - node resolution is exact within scope
-- unit tests included
+- unit tests cover status behavior and snapshot-anchor semantics
+- dedicated replay-suite coverage is deferred to WI-1.1.5
 
 ## Suggested Agent
 
@@ -52,7 +61,9 @@ Coding Agent
 
 ## Review Focus
 
-- correctness
-- degraded handling
+- history-status correctness
+- snapshot-anchor semantics
 - scope fidelity
+- ordering and range correctness
 - no hidden aggregation logic
+- no replay-scope creep beyond WI-1.1.3

--- a/work_items/ready/WI-1.1.3-risk-summary-history-service.md
+++ b/work_items/ready/WI-1.1.3-risk-summary-history-service.md
@@ -45,6 +45,7 @@ Implement history retrieval for a node and measure.
 - invalid date ranges fail explicitly and do not fabricate a `RiskHistorySeries`
 - if `snapshot_id` is provided, it is treated as the history-request anchor snapshot and must resolve to `end_date`
 - returned history points are ordered ascending by date and remain within the inclusive requested range
+- unsupported measure handling is explicit and returns `UNSUPPORTED_MEASURE` when surfaced as a service response
 - missing snapshot returns `MISSING_SNAPSHOT`
 - missing node returns `MISSING_NODE`
 - zero valid points in range returns `MISSING_HISTORY`


### PR DESCRIPTION
## What changed
Clarifies the missing contract details that were blocking WI-1.1.3 from being implementation-ready.

- Adds the explicit `get_risk_history` request shape to PRD-1.1-v2.
- Defines what `snapshot_id` means for multi-date history requests: it is the request anchor snapshot and must resolve to `end_date`, while each `RiskHistoryPoint.snapshot_id` remains the per-point source snapshot id.
- Defines `RiskHistorySeries` status behavior for invalid ranges, missing snapshot, missing node, no points in range, sparse points, degraded rows, and `require_complete=true`.
- Narrows the intended module boundary for WI-1.1.3 to `src/modules/risk_analytics/service.py` plus package export surface.
- Makes mandatory unit-test coverage explicit and defers dedicated replay-suite coverage to WI-1.1.5.

## Why
WI-1.1.3 was still blocked by coding-agent inference. The v2 PRD kept the history output contract but dropped the concrete `get_risk_history` request shape that existed in the earlier draft. It also left multi-date `snapshot_id` semantics, history-specific status behavior, and service boundary expectations implicit.

## Impact
This is a spec-only change. No production code changes are included. The intended outcome is to make WI-1.1.3 ready for a bounded coding pass without reopening ADR scope.

## Validation
- Reviewed against `AGENTS.md`, the overnight runbook, PM and issue-planner instructions, ready criteria, the linked PRD, WI-1.1.3, and the current history/fixture/time module surface.
- Verified the branch contains only the PRD and work-item updates required for the readiness decision.

## Checks
- No tests run; documentation-only PR.