### PR TITLE
Add VaR methodology specialization pack

### DIFF
--- a/.github/agents/README.md
+++ b/.github/agents/README.md
@@ -6,7 +6,8 @@ They mirror the repository's governed handoff model:
 
 1. `pm.agent.md`
 2. `issue-planner.agent.md`
-3. `coding.agent.md`
-4. `review.agent.md`
+3. `risk-methodology-spec.agent.md`
+4. `coding.agent.md`
+5. `review.agent.md`
 
-Use them as separate roles. Do not ask one Copilot agent to perform all four stages in one pass.
+Use them as separate roles. Do not ask one Copilot agent to perform all stages in one pass.

--- a/.github/agents/risk-methodology-spec.agent.md
+++ b/.github/agents/risk-methodology-spec.agent.md
@@ -1,0 +1,36 @@
+---
+name: risk-methodology-spec
+description: Writes methodology-aware specifications for VaR, shocks, scenario lineage, and related market-risk capabilities
+tools: ["read", "search", "edit"]
+---
+
+You are the risk methodology spec agent for the `risk-manager` repository.
+
+Read first:
+
+1. `AGENTS.md`
+2. `docs/01_mission_and_design_principles.md`
+3. `docs/04_risk_manager_operating_model.md`
+4. `docs/03_glossary.md`
+5. `docs/methodology/01_var_methodology_overview.md`
+6. `docs/methodology/02_historical_simulation_and_shocks.md`
+7. `docs/guides/risk_methodology_review_checklist.md`
+8. `prompts/agents/risk_methodology_spec_agent_instruction.md`
+9. relevant ADRs, PRDs, and exemplars
+
+Your job is to produce methodology-correct specifications, not generic finance prose.
+
+You must:
+
+- define market-risk concepts precisely
+- make methodological caveats explicit
+- distinguish deterministic methodological truth from interpretive outputs
+- surface missing concepts such as shocks, lineage, provenance, or factor semantics when they matter
+- keep scope narrow and implementation-facing
+
+You must not:
+
+- use vague finance terminology when a precise term is needed
+- let walkers or UI own canonical methodology truth
+- hide caveats or false-signal paths
+- widen scope into implementation planning unless explicitly asked

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,12 @@ This repository uses AI agents for PRD authoring, issue decomposition, implement
 - keeps scope narrow
 - makes ambiguities explicit in Open Questions
 
+### Risk Methodology Spec Agent
+- defines market-risk concepts precisely before implementation starts
+- preserves methodological distinctions such as summary versus driver, historical versus simulated shock, and market move versus operational artifact
+- makes methodology caveats explicit
+- does not let vague finance language stand in for real risk-methodology contracts
+
 ### Coding Agent
 - implements one bounded work item at a time
 - stays within linked PRD and issue scope
@@ -49,6 +55,7 @@ Do not collapse planning, coding, review, and merge judgment into one agent pass
 Repo-visible role-specific instructions live in:
 - `prompts/agents/`
 - `docs/guides/overnight_agent_runbook.md`
+- `docs/methodology/`
 
 ## Freshness and branching rule
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,13 @@ Then read the role-specific instruction that matches the current session:
 - `prompts/agents/issue_planner_instruction.md`
 - `prompts/agents/coding_agent_instruction.md`
 - `prompts/agents/review_agent_instruction.md`
+- `prompts/agents/risk_methodology_spec_agent_instruction.md`
+
+If the session is methodology-heavy, also read:
+
+- `docs/methodology/01_var_methodology_overview.md`
+- `docs/methodology/02_historical_simulation_and_shocks.md`
+- `docs/guides/risk_methodology_review_checklist.md`
 
 ## Hard rules
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -18,6 +18,13 @@ If the task is role-specific, also read:
 - `prompts/agents/issue_planner_instruction.md`
 - `prompts/agents/coding_agent_instruction.md`
 - `prompts/agents/review_agent_instruction.md`
+- `prompts/agents/risk_methodology_spec_agent_instruction.md`
+
+If the task is methodology-heavy, also read:
+
+- `docs/methodology/01_var_methodology_overview.md`
+- `docs/methodology/02_historical_simulation_and_shocks.md`
+- `docs/guides/risk_methodology_review_checklist.md`
 
 ## Review priorities
 

--- a/docs/03_glossary.md
+++ b/docs/03_glossary.md
@@ -34,3 +34,21 @@ Managed state indicating that a desk or issue requires elevated monitoring.
 
 ### Replay
 Ability to reproduce outputs using the same inputs, snapshots, versions, and rules.
+
+### Risk Factor
+A canonical market-risk input dimension such as rate, spread, credit, FX, equity, or volatility component used in risk methodology and simulation.
+
+### Shock
+A canonical market move or factor change used in VaR or scenario-related computation.
+
+### Historical Shock
+A shock derived from an observed historical market or factor movement over a defined interval.
+
+### Simulated Shock
+A shock produced by a simulated scenario process rather than copied directly from realized history.
+
+### Shock Set
+A governed collection of shocks used together for a VaR or scenario run.
+
+### Shock Lineage
+The deterministic provenance linking source data, transformation, factor mapping, shock set, and downstream risk outputs.

--- a/docs/06_prd_authoring_standard.md
+++ b/docs/06_prd_authoring_standard.md
@@ -165,5 +165,7 @@ PRD authors should use these documents as source context:
 - `docs/01_mission_and_design_principles.md`
 - `docs/04_risk_manager_operating_model.md`
 - `docs/05_walker_charters.md`
+- `docs/methodology/01_var_methodology_overview.md`
+- `docs/methodology/02_historical_simulation_and_shocks.md`
 
 PRDs should not copy these documents in full. They should reference them and include only the local context needed for implementation.

--- a/docs/catalog/modules.md
+++ b/docs/catalog/modules.md
@@ -1,7 +1,7 @@
 # Module Catalog
 
 ## Risk Analytics
-Deterministic source for VaR, ES, P&L, contributors, concentration, tail, and related summary services.
+Deterministic source for VaR, ES, shock catalogs, shock lineage, P&L, contributors, concentration, tail, and related summary services.
 
 ## FRTB / PLA Controls
 Deterministic source for PLA, backtesting, deterioration flags, and desk control status.

--- a/docs/guides/risk_methodology_review_checklist.md
+++ b/docs/guides/risk_methodology_review_checklist.md
@@ -1,0 +1,45 @@
+# Risk Methodology Review Checklist
+
+## Purpose
+
+Use this checklist when reviewing methodology-facing PRDs, design notes, and implementation plans for market-risk capabilities.
+
+## Core questions
+
+### 1. Is the risk concept defined precisely?
+
+- Is the document clear about the underlying concept?
+- Are key terms such as VaR, shock, scenario, factor, or lineage used consistently?
+
+### 2. Does the document sound like market-risk work rather than generic software work?
+
+- Is the operating context clear?
+- Does the output support a real risk-manager decision or investigation step?
+
+### 3. Are methodology caveats explicit?
+
+- Are limitations, caveats, and false-signal pathways identified?
+- Does the document separate market behavior from data or control artifacts?
+
+### 4. Are deterministic and interpretive responsibilities separated?
+
+- Are methodology facts owned by deterministic services?
+- Are walkers or narratives prevented from inventing canonical methodological truth?
+
+### 5. Are shock and scenario concepts handled correctly where relevant?
+
+- Is the repository explicit about whether shocks are historical or simulated?
+- Is lineage or provenance preserved where the use case depends on it?
+
+### 6. Are human decision boundaries explicit?
+
+- What does the output help a risk manager decide?
+- What remains a human judgment or governance act?
+
+## Failure patterns to flag
+
+- generic finance language with no methodology precision
+- missing shock or scenario definitions where they are clearly relevant
+- unexplained assumptions about factor lineage
+- missing caveats around sparse or degraded data
+- outputs that look polished but are not methodologically grounded

--- a/docs/methodology/01_var_methodology_overview.md
+++ b/docs/methodology/01_var_methodology_overview.md
@@ -1,0 +1,132 @@
+# VaR Methodology Overview
+
+## Purpose
+
+This document provides a concise methodology reference for VaR-oriented design work in this repository.
+
+It is not intended to replace formal bank methodology documents. It exists to keep repository specs, PRDs, and AI-agent outputs aligned with real market-risk thinking.
+
+## What VaR is
+
+Value at Risk is a loss-threshold measure over a defined horizon and confidence level.
+
+For this repository, VaR-related design should always make these dimensions explicit:
+
+- confidence level
+- horizon
+- methodology family
+- source shock set or scenario set
+- aggregation scope
+- currency basis
+- snapshot and methodology version
+
+## What VaR is not
+
+VaR is not:
+
+- a full explanation of why risk moved
+- a substitute for control-quality assessment
+- a proof of model sufficiency
+- a standalone governance conclusion
+
+It is one governed fact inside a broader risk-management process.
+
+## Main methodology families
+
+### Historical simulation
+
+Uses realized historical market moves or factor moves applied to the current portfolio or risk representation.
+
+### Parametric or variance-covariance approaches
+
+Use distributional assumptions and covariance structure to estimate loss behavior.
+
+### Monte Carlo or scenario simulation
+
+Use simulated or generated market states, often with more complex model structure.
+
+This repository should keep these families conceptually separate even if early implementation focuses on historical-style deterministic outputs first.
+
+## Why methodology matters for this repository
+
+An AI-supported risk manager needs more than a summary number.
+
+To support investigation, challenge, and governance, methodology-aware designs should preserve:
+
+- where the number came from
+- which shock or scenario set drove it
+- which data and mapping assumptions apply
+- which caveats limit interpretation
+
+## Core methodological distinctions
+
+### Summary versus driver
+
+A VaR summary tells you the level or change.
+
+A methodology-aware driver layer tells you:
+
+- which shocks or scenarios matter
+- which factors moved
+- whether the result reflects market behavior, model structure, data defects, or a mixture
+
+### First-order versus second-order interpretation
+
+First-order change is a direct movement in the reported measure.
+
+Second-order interpretation concerns:
+
+- dispersion
+- instability
+- concentration
+- regime sensitivity
+
+### Market move versus operational artifact
+
+VaR movement can reflect:
+
+- genuine market conditions
+- position changes
+- mapping errors
+- stale inputs
+- methodology changes
+- control defects
+
+Specs should preserve these distinctions explicitly.
+
+## Methodology caveats that should surface in specs
+
+- lookback coverage may be sparse or unrepresentative
+- business-day calendars matter
+- shock lineage may be incomplete
+- factor mappings may drift over time
+- snapshot quality may degrade interpretation
+- comparison across scopes may not be symmetric
+
+## What should be versioned
+
+Methodology-aware services should make versioning explicit for:
+
+- data snapshot
+- methodology version
+- configuration or threshold version
+- shock-set or scenario-set version where relevant
+
+## Implementation implications
+
+Methodology-facing PRDs should say:
+
+- which methodology family is assumed
+- whether shocks are historical, simulated, or both
+- which objects represent canonical methodological truth
+- which caveats must be preserved downstream
+- what the system must not infer automatically
+
+## Relationship to future work
+
+This overview is a foundation for later deterministic services such as:
+
+- shock catalog and lineage
+- historical VaR explain support
+- scenario-set inspection
+- concentration and tail-driver services

--- a/docs/methodology/02_historical_simulation_and_shocks.md
+++ b/docs/methodology/02_historical_simulation_and_shocks.md
@@ -1,0 +1,123 @@
+# Historical Simulation And Shocks
+
+## Purpose
+
+This document defines the repository's methodology-facing view of shocks and shock lineage.
+
+It exists because future VaR explain, scenario inspection, and driver analysis depend on consistent shock terminology and deterministic shock contracts.
+
+## Why shocks matter
+
+In historical-simulation-style VaR, the underlying engine is not only the final risk number. It is also the set of historical market moves, factor moves, or transformed scenario states used in the simulation.
+
+If the repository does not define shocks explicitly, later services will drift on:
+
+- what a shock is
+- what units it uses
+- how it links to factors
+- how it links to VaR outputs
+- what caveats apply
+
+## Canonical shock concepts
+
+### Shock
+
+A canonical market move or factor change used in VaR or scenario-related computation.
+
+A shock is not the same thing as a final risk result. It is an input or explanatory object in the simulation chain.
+
+### Historical Shock
+
+A shock derived from an observed historical movement over a defined historical interval.
+
+Typical provenance:
+
+- one business-date move
+- one historical window observation
+- one realized factor or market-state change
+
+### Simulated Shock
+
+A shock produced by a simulated or generated scenario process rather than directly copied from realized historical moves.
+
+### Shock Set
+
+A governed collection of shocks used together for a VaR or scenario run.
+
+A shock set should be versioned and should have explicit methodology meaning.
+
+### Shock Lineage
+
+The deterministic lineage linking:
+
+- source time series or scenario source
+- shock transformation
+- factor mapping
+- simulation run or snapshot
+- downstream VaR or explain outputs
+
+## Shock representation
+
+Future shock-facing deterministic services should preserve fields such as:
+
+- `shock_id`
+- `shock_set_id`
+- `shock_type`
+- `source_date` or scenario reference
+- `source_interval`
+- `factor_ids` or factor-group references
+- `transformation_type`
+- `magnitude`
+- `magnitude_units`
+- `currency` if relevant
+- `methodology_version`
+- `snapshot_id`
+- `lineage_refs`
+- `caveats`
+
+Exact field names may vary by service, but these concepts should not disappear.
+
+## Common transformation types
+
+Examples include:
+
+- absolute move
+- relative return
+- log return
+- spread move
+- curve move
+- surface move
+- bucketed composite move
+
+Specs should define which transformation type is canonical for a given service.
+
+## Shock caveats
+
+A methodology-aware shock service should preserve caveats such as:
+
+- stale historical source
+- missing factor mapping
+- incomplete hierarchy coverage
+- transformed or compressed shock representation
+- methodology-version mismatch
+
+## What should not be left implicit
+
+Future PRDs should not leave these unstated:
+
+- whether shocks are historical or simulated
+- whether shock sets are replayable by identifier
+- whether lineage is point-to-point or summarized
+- whether factor granularity is preserved or aggregated
+- whether shock dates are source dates, run dates, or both
+
+## Relationship to the current roadmap
+
+Shock contracts are not required to unblock the current risk-summary history slice.
+
+They are, however, a prerequisite for serious future work in:
+
+- VaR explain
+- contributor and driver analysis
+- scenario lineage
+- methodology-aware challenge and governance output

--- a/docs/methodology/README.md
+++ b/docs/methodology/README.md
@@ -1,0 +1,16 @@
+# Risk Methodology Pack
+
+## Purpose
+
+This folder captures market-risk methodology canon that should guide PRD writing, spec work, review, and later implementation.
+
+These documents exist so the repository does not drift into generic software language when defining VaR, shocks, scenario lineage, and related market-risk concepts.
+
+## Initial contents
+
+- `01_var_methodology_overview.md`
+- `02_historical_simulation_and_shocks.md`
+
+## Rule
+
+Implementation-facing PRDs and methodology-heavy spec work should use these documents as source context rather than relying on loose remembered finance terminology.

--- a/docs/prd_exemplars/PRD-M1-shock-catalog-and-lineage.md
+++ b/docs/prd_exemplars/PRD-M1-shock-catalog-and-lineage.md
@@ -1,0 +1,66 @@
+# PRD-M1: Shock Catalog And Lineage Service
+
+## Variant
+
+Deterministic Service PRD
+
+## Purpose
+
+Provide the canonical deterministic service for retrieving governed shock definitions, shock-set metadata, and shock lineage needed for historical-simulation-style VaR explain and related investigation flows.
+
+## Risk management purpose
+
+This service helps answer:
+
+- which shocks are in scope for this run?
+- what type of shocks are they?
+- what source dates or scenario sources produced them?
+- how do those shocks link to downstream VaR or explain outputs?
+
+## In scope
+
+- shock metadata retrieval
+- shock-set metadata retrieval
+- historical versus simulated shock classification
+- source-date and snapshot lineage
+- factor or factor-group linkage
+- deterministic caveat flags
+
+## Out of scope
+
+- running VaR itself
+- ranking contributors
+- narrative generation
+- governance sign-off
+- stochastic simulation logic
+
+## Core output
+
+`ShockRecord`
+
+- `shock_id`
+- `shock_set_id`
+- `shock_type`
+- `source_date`
+- `factor_refs`
+- `transformation_type`
+- `magnitude`
+- `magnitude_units`
+- `methodology_version`
+- `snapshot_id`
+- `lineage_refs`
+- `caveats`
+
+## Core rules
+
+1. Every shock must have explicit provenance.
+2. Historical and simulated shocks must not be conflated.
+3. Shock-set identity must be explicit and versioned.
+4. The service is deterministic and replayable.
+
+## Acceptance criteria
+
+- retrieves deterministic shock metadata by id or shock-set id
+- preserves source lineage fields explicitly
+- distinguishes historical and simulated shocks correctly
+- exposes caveats without narrative invention

--- a/prompts/agents/README.md
+++ b/prompts/agents/README.md
@@ -12,6 +12,7 @@ These instructions complement the canon, PRDs, ADRs, prompts, and work items. Th
 - `coding_agent_instruction.md`
 - `review_agent_instruction.md`
 - `issue_planner_instruction.md`
+- `risk_methodology_spec_agent_instruction.md`
 
 ## Rule
 

--- a/prompts/agents/risk_methodology_spec_agent_instruction.md
+++ b/prompts/agents/risk_methodology_spec_agent_instruction.md
@@ -1,0 +1,57 @@
+# Risk Methodology Spec Agent Instruction
+
+## Mission
+
+Write methodology-aware specifications for market-risk capabilities with the judgment of a strong market-risk methodology lead.
+
+This role is not a generic product writer. It is responsible for making methodological concepts explicit before implementation begins.
+
+## Read first
+
+1. `AGENTS.md`
+2. `docs/01_mission_and_design_principles.md`
+3. `docs/04_risk_manager_operating_model.md`
+4. `docs/03_glossary.md`
+5. `docs/methodology/01_var_methodology_overview.md`
+6. `docs/methodology/02_historical_simulation_and_shocks.md`
+7. `docs/guides/risk_methodology_review_checklist.md`
+8. relevant ADRs
+9. relevant local PRDs or exemplars
+
+## Primary responsibilities
+
+- define market-risk concepts precisely
+- detect missing methodology concepts before coding starts
+- keep deterministic methodology contracts separate from interpretive layers
+- preserve operational and governance context
+- make caveats explicit
+
+## Required methodology questions
+
+Before producing a spec, answer internally:
+
+1. What exact market-risk concept is being modelled?
+2. What methodology family applies?
+3. What deterministic objects must exist?
+4. What caveats and false-signal paths matter?
+5. What should be versioned?
+6. What decision does this output support?
+7. What must remain human judgment?
+
+## Hard rules
+
+- do not use vague finance language where a precise term is needed
+- do not collapse summary outputs and methodology-driver objects into one blurred concept
+- do not hide caveats
+- do not leave shock or lineage concepts implicit when the capability depends on them
+- do not let walkers own canonical methodology truth
+
+## Expected output
+
+A good methodology-aware spec should:
+
+- define the risk concept clearly
+- identify operating context
+- define deterministic contracts and boundaries
+- state caveats and degraded states
+- identify what later implementation slices will depend on


### PR DESCRIPTION
## Summary
- add a methodology canon pack for VaR and historical-simulation shocks
- add a dedicated risk-methodology spec instruction and Copilot agent scaffold
- wire the new methodology pack into the repo's glossary, module catalog, PRD authoring standard, and tool-specific agent instructions

## Why
The repo had strong software governance but weak market-risk methodology canon. This PR gives PM/spec agents a narrower, more expert source base for VaR, shocks, lineage, and methodology-aware review without changing implementation scope.

## Included
- `docs/methodology/README.md`
- `docs/methodology/01_var_methodology_overview.md`
- `docs/methodology/02_historical_simulation_and_shocks.md`
- `docs/guides/risk_methodology_review_checklist.md`
- `prompts/agents/risk_methodology_spec_agent_instruction.md`
- `.github/agents/risk-methodology-spec.agent.md`
- `docs/prd_exemplars/PRD-M1-shock-catalog-and-lineage.md`
- glossary and catalog updates for shocks and factor terminology
- CLAUDE / GEMINI / AGENTS / prompts wiring

## Testing
- `git diff --check`

## Notes
Documentation-only change. No implementation or test behavior changed.