### PR TITLE
[codex] Normalize workflow-state ownership canon

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -3,7 +3,7 @@
 This repository contains a governed architecture canon and an AI-mediated delivery system for a market risk platform.
 
 ## Always preserve these boundaries
-- Deterministic services in `src/modules/` own calculations, rule execution, and canonical business truth.
+- Deterministic services in `src/modules/` own calculations, rule execution, and canonical business state.
 - Walkers in `src/walkers/` interpret typed outputs and emit structured findings. They do not own raw calculations or approval logic.
 - Orchestrators in `src/orchestrators/` own workflow state and execute workflows, routing, gates, challenge, and handoff. They do not hide canonical calculations.
 - UI and presentation code must not recompute business logic or suppress caveats.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -3,9 +3,9 @@
 This repository contains a governed architecture canon and an AI-mediated delivery system for a market risk platform.
 
 ## Always preserve these boundaries
-- Deterministic services in `src/modules/` own calculations, rule execution, workflow state, and canonical truth.
+- Deterministic services in `src/modules/` own calculations, rule execution, and canonical business truth.
 - Walkers in `src/walkers/` interpret typed outputs and emit structured findings. They do not own raw calculations or approval logic.
-- Orchestrators in `src/orchestrators/` execute workflows, routing, gates, challenge, and handoff. They do not hide canonical calculations.
+- Orchestrators in `src/orchestrators/` own workflow state and execute workflows, routing, gates, challenge, and handoff. They do not hide canonical calculations.
 - UI and presentation code must not recompute business logic or suppress caveats.
 
 ## Review priorities

--- a/.github/instructions/backend.instructions.md
+++ b/.github/instructions/backend.instructions.md
@@ -9,7 +9,7 @@ Focus on deterministic correctness and boundary discipline.
 ## Rules
 - Module code owns calculations, deterministic services, and canonical business state.
 - Walker code owns typed interpretation only.
-- Orchestrator code owns workflow state, workflow transitions, routing, gating, and handoff.
+- Orchestrator code owns workflow state, workflow transitions, routing, gates, challenge, and handoff.
 - Preserve typed schemas and explicit enums.
 - Preserve evidence references, snapshot/version metadata, and replayability hooks.
 - Prefer explicit code over clever abstractions.

--- a/.github/instructions/backend.instructions.md
+++ b/.github/instructions/backend.instructions.md
@@ -7,9 +7,9 @@ applyTo: "src/**/*.py,tests/**/*.py,fixtures/**/*.py"
 Focus on deterministic correctness and boundary discipline.
 
 ## Rules
-- Module code owns calculations, deterministic services, canonical state, and workflow state.
+- Module code owns calculations, deterministic services, and canonical business state.
 - Walker code owns typed interpretation only.
-- Orchestrator code owns workflow transitions, routing, gating, and handoff only.
+- Orchestrator code owns workflow state, workflow transitions, routing, gating, and handoff.
 - Preserve typed schemas and explicit enums.
 - Preserve evidence references, snapshot/version metadata, and replayability hooks.
 - Prefer explicit code over clever abstractions.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This repository is the governed source of truth for:
 The platform is organized into:
 1. **Capability Modules**: deterministic logic, business rules, canonical business state, audit trails
 2. **Specialist Walkers**: typed interpretation over module outputs
-3. **Process Orchestrators**: workflow state, workflow execution, routing, challenge, and handoff
+3. **Process Orchestrators**: workflow state, workflow execution, routing, gates, challenge, and handoff
 
 ## Design doctrine
 

--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ This repository is the governed source of truth for:
 ## Core architecture
 
 The platform is organized into:
-1. **Capability Modules**: deterministic logic, business rules, workflow state, audit trails
+1. **Capability Modules**: deterministic logic, business rules, canonical business state, audit trails
 2. **Specialist Walkers**: typed interpretation over module outputs
-3. **Process Orchestrators**: workflow execution, routing, challenge, and handoff
+3. **Process Orchestrators**: workflow state, workflow execution, routing, challenge, and handoff
 
 ## Design doctrine
 

--- a/docs/00_tom_overview.md
+++ b/docs/00_tom_overview.md
@@ -52,4 +52,4 @@ The platform separates:
 
 ## Architectural statement
 
-Deterministic services own calculations, canonical business state, policy rules, and audit trails. Walkers interpret through typed interfaces. Orchestrators own workflow state and execute routing, gating, synthesis, challenge, and handoff. No component should silently absorb the responsibilities of another.
+Deterministic services own calculations, canonical business state, policy rules, and audit trails. Walkers interpret through typed interfaces. Orchestrators own workflow state and execute routing, gates, challenge, and handoff. No component should silently absorb the responsibilities of another.

--- a/docs/00_tom_overview.md
+++ b/docs/00_tom_overview.md
@@ -52,4 +52,4 @@ The platform separates:
 
 ## Architectural statement
 
-Deterministic services own calculations, workflow state, policy rules, and audit trails. Walkers interpret through typed interfaces. Orchestrators route, gate, synthesize, challenge, and hand off. No component should silently absorb the responsibilities of another.
+Deterministic services own calculations, canonical business state, policy rules, and audit trails. Walkers interpret through typed interfaces. Orchestrators own workflow state and execute routing, gating, synthesis, challenge, and handoff. No component should silently absorb the responsibilities of another.

--- a/src/README.md
+++ b/src/README.md
@@ -1,7 +1,7 @@
 # Source Layout
 
 ## Shared
-`src/shared/` for schemas, trace, config, workflow-state types, and utilities.
+`src/shared/` for schemas, trace, config, workflow state types, and utilities.
 
 ## Modules
 `src/modules/` for deterministic capability modules.
@@ -10,6 +10,6 @@
 `src/walkers/` for specialist agent wrappers and typed outputs.
 
 ## Orchestrators
-`src/orchestrators/` for workflow state machines, routing, gates, and handoff logic.
+`src/orchestrators/` for workflow state, routing, gates, challenge, and handoff logic.
 
 Keep module, walker, and orchestrator responsibilities separate.

--- a/src/README.md
+++ b/src/README.md
@@ -1,7 +1,7 @@
 # Source Layout
 
 ## Shared
-`src/shared/` for schemas, trace, config, workflow state, and utilities.
+`src/shared/` for schemas, trace, config, workflow-state types, and utilities.
 
 ## Modules
 `src/modules/` for deterministic capability modules.
@@ -10,6 +10,6 @@
 `src/walkers/` for specialist agent wrappers and typed outputs.
 
 ## Orchestrators
-`src/orchestrators/` for workflow state machines and routing.
+`src/orchestrators/` for workflow state machines, routing, gates, and handoff logic.
 
 Keep module, walker, and orchestrator responsibilities separate.


### PR DESCRIPTION
## What changed
- normalized workflow-state ownership wording across the main repo surfaces named in the drift report
- clarified that deterministic services own calculations and canonical business state
- clarified that orchestrators own workflow state, routing, gates, and handoff
- tightened `src/README.md` so `src/shared/` is described as holding workflow-state types rather than workflow authority

## Why it changed
The drift report identified a contradictory boundary rule: some canon and tool surfaces said modules owned workflow state, while others said orchestrators owned it. That contradiction is a high-risk governance issue because it can route future coding and review work into the wrong layer.

## Scope
This PR is intentionally narrow. It only normalizes the workflow-state ownership rule across the conflicting canon and tool-adapter documents.

It does not yet:
- move stale work items out of `work_items/ready/`
- update the current-state registry
- align CI/tooling scope

## Validation
- repo-wide wording check with `rg` against the conflicting files
- manual diff review of the normalized wording
