### PR TITLE
[codex] Add dependency hygiene drift scanner

### DIFF
--- a/.github/agents/drift-monitor.agent.md
+++ b/.github/agents/drift-monitor.agent.md
@@ -25,6 +25,7 @@ Your job is to detect and route repository drift, not to silently rewrite canon.
 
 Run these before broader repo reading when the local environment allows it:
 
+- `python scripts/drift/check_dependency_hygiene.py --root . --output artifacts/drift/dependency_hygiene.json`
 - `python scripts/drift/check_references.py --root . --output artifacts/drift/reference_integrity.json`
 - `python scripts/drift/check_registry_alignment.py --root . --output artifacts/drift/registry_alignment.json`
 

--- a/.github/workflows/drift-monitor.yml
+++ b/.github/workflows/drift-monitor.yml
@@ -47,6 +47,11 @@ jobs:
           python scripts/drift/check_references.py \
             --output artifacts/drift/reference_integrity.json
 
+      - name: Run dependency hygiene scanner
+        run: |
+          python scripts/drift/check_dependency_hygiene.py \
+            --output artifacts/drift/dependency_hygiene.json
+
       - name: Run registry alignment scanner
         run: |
           python scripts/drift/check_registry_alignment.py \
@@ -63,6 +68,20 @@ jobs:
               "",
           ]
           report_specs = (
+              (
+                  "Dependency Hygiene",
+                  Path("artifacts/drift/dependency_hygiene.json"),
+                  lambda report: (
+                      f"- Runtime files scanned: `{report['stats']['runtime_python_files_scanned']}`",
+                      f"- Dev files scanned: `{report['stats']['dev_python_files_scanned']}`",
+                      f"- Workflows scanned: `{report['stats']['workflows_scanned']}`",
+                      f"- Instruction files scanned: `{report['stats']['instruction_files_scanned']}`",
+                  ),
+                  lambda finding: (
+                      f"- `{finding['severity']}` `{finding['source_path']}` "
+                      f"`{finding['dependency_name']}` -> {finding['owner']}"
+                  ),
+              ),
               (
                   "Reference Integrity",
                   Path("artifacts/drift/reference_integrity.json"),
@@ -117,6 +136,7 @@ jobs:
         with:
           name: drift-reports
           path: |
+            artifacts/drift/dependency_hygiene.json
             artifacts/drift/reference_integrity.json
             artifacts/drift/registry_alignment.json
           if-no-files-found: error

--- a/agent_runtime/drift/__init__.py
+++ b/agent_runtime/drift/__init__.py
@@ -1,11 +1,14 @@
 """Deterministic drift scanners used by repo-health audits."""
 
+from .dependency_hygiene import DependencyHygieneReport, build_dependency_hygiene_report
 from .reference_integrity import ReferenceScanReport, build_reference_scan_report
 from .registry_alignment import RegistryAlignmentReport, build_registry_alignment_report
 
 __all__ = [
+    "DependencyHygieneReport",
     "ReferenceScanReport",
     "RegistryAlignmentReport",
+    "build_dependency_hygiene_report",
     "build_reference_scan_report",
     "build_registry_alignment_report",
 ]

--- a/agent_runtime/drift/dependency_hygiene.py
+++ b/agent_runtime/drift/dependency_hygiene.py
@@ -150,7 +150,11 @@ def _scan_imports(root: Path, scan_dirs: tuple[str, ...]) -> _ImportScanResult:
 
 
 def _third_party_imports_in_file(path: Path) -> set[str]:
-    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    try:
+        content = path.read_text(encoding="utf-8")
+        tree = ast.parse(content, filename=str(path))
+    except (SyntaxError, UnicodeDecodeError):
+        return set()
     imports: set[str] = set()
     for node in ast.walk(tree):
         if isinstance(node, ast.Import):
@@ -177,8 +181,6 @@ def _append_runtime_import_findings(
 ) -> None:
     base_dependencies = declared_dependencies.base
     all_dependencies = declared_dependencies.all
-    non_dev_optional = set().union(*(deps for extra, deps in declared_dependencies.optional.items() if extra != "dev"))
-
     for dependency_name, source_paths in runtime_imports.items():
         source_path = min(source_paths)
         if dependency_name not in all_dependencies:
@@ -194,7 +196,7 @@ def _append_runtime_import_findings(
                 )
             )
             continue
-        if dependency_name not in base_dependencies and dependency_name in non_dev_optional:
+        if dependency_name not in base_dependencies:
             findings.append(
                 DependencyHygieneFinding(
                     kind="runtime_dependency_declared_only_in_optional_extra",
@@ -237,7 +239,10 @@ def _append_workflow_tool_findings(
     repo_root: Path,
 ) -> None:
     for workflow_path in workflows:
-        contents = workflow_path.read_text(encoding="utf-8")
+        try:
+            contents = workflow_path.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            continue
         relative_path = workflow_path.relative_to(repo_root).as_posix()
         for tool_name, dependency_name in WORKFLOW_TOOL_DEPENDENCIES.items():
             if not re.search(rf"\b{re.escape(tool_name)}\b", contents):
@@ -260,7 +265,11 @@ def _append_workflow_tool_findings(
 def _append_stale_guidance_findings(findings: list[DependencyHygieneFinding], instruction_files: tuple[Path, ...], repo_root: Path) -> None:
     stale_pattern = re.compile(r"(?i)\bupdat\w*\b.*\brequirements\.txt\b|\brequirements\.txt\b.*\bupdate\b")
     for file_path in instruction_files:
-        for line_number, line in enumerate(file_path.read_text(encoding="utf-8").splitlines(), start=1):
+        try:
+            lines = file_path.read_text(encoding="utf-8").splitlines()
+        except UnicodeDecodeError:
+            continue
+        for line_number, line in enumerate(lines, start=1):
             if not stale_pattern.search(line):
                 continue
             relative_path = file_path.relative_to(repo_root).as_posix()

--- a/agent_runtime/drift/dependency_hygiene.py
+++ b/agent_runtime/drift/dependency_hygiene.py
@@ -1,0 +1,309 @@
+from __future__ import annotations
+
+import ast
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+import re
+import sys
+import tomllib
+
+
+PYPROJECT_PATH = Path("pyproject.toml")
+WORKFLOWS_DIR = Path(".github/workflows")
+INSTRUCTION_SCAN_DIRS = ("docs", "prompts", ".github")
+INSTRUCTION_SCAN_FILES = ("AGENTS.md", "CLAUDE.md", "GEMINI.md")
+RUNTIME_SCAN_DIRS = ("src", "agent_runtime")
+DEV_SCAN_DIRS = ("tests", "scripts")
+LOCAL_IMPORT_ROOTS = {"agent_runtime", "src", "tests", "scripts"}
+WORKFLOW_TOOL_DEPENDENCIES = {
+    "mypy": "mypy",
+    "pytest": "pytest",
+    "ruff": "ruff",
+}
+RUNTIME_OPTIONAL_SEVERITY = "major"
+UNDECLARED_IMPORT_SEVERITY = "critical"
+WORKFLOW_TOOL_SEVERITY = "major"
+STALE_GUIDANCE_SEVERITY = "major"
+STDLIB_MODULES = set(sys.stdlib_module_names)
+
+
+@dataclass(frozen=True, slots=True)
+class DependencyHygieneFinding:
+    kind: str
+    severity: str
+    drift_class: str
+    owner: str
+    dependency_name: str
+    source_path: str
+    message: str
+
+
+@dataclass(frozen=True, slots=True)
+class DependencyHygieneStats:
+    runtime_python_files_scanned: int
+    dev_python_files_scanned: int
+    workflows_scanned: int
+    instruction_files_scanned: int
+    runtime_imports_checked: int
+    dev_imports_checked: int
+    findings_count: int
+
+
+@dataclass(frozen=True, slots=True)
+class DependencyHygieneReport:
+    scan_name: str
+    root: str
+    generated_at: str
+    findings: tuple[DependencyHygieneFinding, ...]
+    stats: DependencyHygieneStats
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "scan_name": self.scan_name,
+            "root": self.root,
+            "generated_at": self.generated_at,
+            "findings": [asdict(finding) for finding in self.findings],
+            "stats": asdict(self.stats),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class _DeclaredDependencies:
+    base: set[str]
+    optional: dict[str, set[str]]
+
+    @property
+    def all(self) -> set[str]:
+        return self.base.union(*(values for values in self.optional.values()))
+
+
+@dataclass(frozen=True, slots=True)
+class _ImportScanResult:
+    imports: dict[str, set[str]]
+    files_scanned: int
+
+
+def build_dependency_hygiene_report(root: Path) -> DependencyHygieneReport:
+    repo_root = root.resolve()
+    declared_dependencies = _load_declared_dependencies(repo_root / PYPROJECT_PATH)
+    runtime_scan = _scan_imports(repo_root, RUNTIME_SCAN_DIRS)
+    dev_scan = _scan_imports(repo_root, DEV_SCAN_DIRS)
+    workflows = _workflow_files(repo_root)
+    instruction_files = _instruction_files(repo_root)
+    findings: list[DependencyHygieneFinding] = []
+
+    _append_runtime_import_findings(findings, declared_dependencies, runtime_scan.imports)
+    _append_dev_import_findings(findings, declared_dependencies, dev_scan.imports)
+    _append_workflow_tool_findings(findings, declared_dependencies.optional.get("dev", set()), workflows, repo_root)
+    _append_stale_guidance_findings(findings, instruction_files, repo_root)
+
+    findings.sort(key=lambda finding: (finding.kind, finding.dependency_name, finding.source_path))
+    return DependencyHygieneReport(
+        scan_name="dependency_hygiene",
+        root=".",
+        generated_at=datetime.now(UTC).isoformat(),
+        findings=tuple(findings),
+        stats=DependencyHygieneStats(
+            runtime_python_files_scanned=runtime_scan.files_scanned,
+            dev_python_files_scanned=dev_scan.files_scanned,
+            workflows_scanned=len(workflows),
+            instruction_files_scanned=len(instruction_files),
+            runtime_imports_checked=len(runtime_scan.imports),
+            dev_imports_checked=len(dev_scan.imports),
+            findings_count=len(findings),
+        ),
+    )
+
+
+def _load_declared_dependencies(pyproject_path: Path) -> _DeclaredDependencies:
+    if not pyproject_path.is_file():
+        raise FileNotFoundError(f"Dependency source `{pyproject_path}` does not exist.")
+    with pyproject_path.open("rb") as handle:
+        payload = tomllib.load(handle)
+
+    project = payload.get("project", {})
+    if not isinstance(project, dict):
+        raise ValueError(f"`{pyproject_path}` has an invalid `[project]` section.")
+    optional = project.get("optional-dependencies", {})
+    if not isinstance(optional, dict):
+        raise ValueError(f"`{pyproject_path}` has an invalid `[project.optional-dependencies]` section.")
+    dependencies = {_canonicalize_dependency_name(item) for item in project.get("dependencies", [])}
+    optional_dependencies = {extra: {_canonicalize_dependency_name(item) for item in entries} for extra, entries in optional.items()}
+    return _DeclaredDependencies(base=dependencies, optional=optional_dependencies)
+
+
+def _scan_imports(root: Path, scan_dirs: tuple[str, ...]) -> _ImportScanResult:
+    imports: dict[str, set[str]] = {}
+    files_scanned = 0
+    for directory_name in scan_dirs:
+        scan_root = root / directory_name
+        if not scan_root.exists():
+            continue
+        for path in sorted(scan_root.rglob("*.py")):
+            if not path.is_file():
+                continue
+            files_scanned += 1
+            for module_name in _third_party_imports_in_file(path):
+                imports.setdefault(module_name, set()).add(path.relative_to(root).as_posix())
+    return _ImportScanResult(imports=imports, files_scanned=files_scanned)
+
+
+def _third_party_imports_in_file(path: Path) -> set[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    imports: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                _maybe_add_third_party_import(imports, alias.name)
+        elif isinstance(node, ast.ImportFrom):
+            if node.level != 0 or node.module is None:
+                continue
+            _maybe_add_third_party_import(imports, node.module)
+    return imports
+
+
+def _maybe_add_third_party_import(imports: set[str], module_path: str) -> None:
+    top_level = module_path.partition(".")[0]
+    if top_level in STDLIB_MODULES or top_level in LOCAL_IMPORT_ROOTS or top_level == "__future__":
+        return
+    imports.add(_canonicalize_dependency_name(top_level))
+
+
+def _append_runtime_import_findings(
+    findings: list[DependencyHygieneFinding],
+    declared_dependencies: _DeclaredDependencies,
+    runtime_imports: dict[str, set[str]],
+) -> None:
+    base_dependencies = declared_dependencies.base
+    all_dependencies = declared_dependencies.all
+    non_dev_optional = set().union(*(deps for extra, deps in declared_dependencies.optional.items() if extra != "dev"))
+
+    for dependency_name, source_paths in runtime_imports.items():
+        source_path = min(source_paths)
+        if dependency_name not in all_dependencies:
+            findings.append(
+                DependencyHygieneFinding(
+                    kind="undeclared_runtime_dependency",
+                    severity=UNDECLARED_IMPORT_SEVERITY,
+                    drift_class="tooling drift",
+                    owner="repository maintenance",
+                    dependency_name=dependency_name,
+                    source_path=source_path,
+                    message=f"Runtime code imports `{dependency_name}` in `{source_path}` but it is not declared in `pyproject.toml`.",
+                )
+            )
+            continue
+        if dependency_name not in base_dependencies and dependency_name in non_dev_optional:
+            findings.append(
+                DependencyHygieneFinding(
+                    kind="runtime_dependency_declared_only_in_optional_extra",
+                    severity=RUNTIME_OPTIONAL_SEVERITY,
+                    drift_class="tooling drift",
+                    owner="repository maintenance",
+                    dependency_name=dependency_name,
+                    source_path=source_path,
+                    message=f"Runtime code imports `{dependency_name}` in `{source_path}`, but it is declared only in an optional extra rather than `[project.dependencies]`.",
+                )
+            )
+
+
+def _append_dev_import_findings(
+    findings: list[DependencyHygieneFinding],
+    declared_dependencies: _DeclaredDependencies,
+    dev_imports: dict[str, set[str]],
+) -> None:
+    all_dependencies = declared_dependencies.all
+    for dependency_name, source_paths in dev_imports.items():
+        if dependency_name in all_dependencies:
+            continue
+        findings.append(
+            DependencyHygieneFinding(
+                kind="undeclared_dev_dependency",
+                severity=UNDECLARED_IMPORT_SEVERITY,
+                drift_class="tooling drift",
+                owner="repository maintenance",
+                dependency_name=dependency_name,
+                source_path=min(source_paths),
+                message=f"Test or tooling code imports `{dependency_name}` in `{min(source_paths)}` but it is not declared in `pyproject.toml`.",
+            )
+        )
+
+
+def _append_workflow_tool_findings(
+    findings: list[DependencyHygieneFinding],
+    dev_dependencies: set[str],
+    workflows: tuple[Path, ...],
+    repo_root: Path,
+) -> None:
+    for workflow_path in workflows:
+        contents = workflow_path.read_text(encoding="utf-8")
+        relative_path = workflow_path.relative_to(repo_root).as_posix()
+        for tool_name, dependency_name in WORKFLOW_TOOL_DEPENDENCIES.items():
+            if not re.search(rf"\b{re.escape(tool_name)}\b", contents):
+                continue
+            if dependency_name in dev_dependencies:
+                continue
+            findings.append(
+                DependencyHygieneFinding(
+                    kind="workflow_tool_missing_from_dev_extra",
+                    severity=WORKFLOW_TOOL_SEVERITY,
+                    drift_class="tooling drift",
+                    owner="repository maintenance",
+                    dependency_name=dependency_name,
+                    source_path=relative_path,
+                    message=f"Workflow `{relative_path}` invokes `{tool_name}` but `pyproject.toml` does not declare `{dependency_name}` in `[project.optional-dependencies].dev`.",
+                )
+            )
+
+
+def _append_stale_guidance_findings(findings: list[DependencyHygieneFinding], instruction_files: tuple[Path, ...], repo_root: Path) -> None:
+    stale_pattern = re.compile(r"(?i)\bupdat\w*\b.*\brequirements\.txt\b|\brequirements\.txt\b.*\bupdate\b")
+    for file_path in instruction_files:
+        for line_number, line in enumerate(file_path.read_text(encoding="utf-8").splitlines(), start=1):
+            if not stale_pattern.search(line):
+                continue
+            relative_path = file_path.relative_to(repo_root).as_posix()
+            findings.append(
+                DependencyHygieneFinding(
+                    kind="stale_requirements_txt_update_guidance",
+                    severity=STALE_GUIDANCE_SEVERITY,
+                    drift_class="operational-instruction drift",
+                    owner="repository maintenance",
+                    dependency_name="requirements.txt",
+                    source_path=f"{relative_path}:{line_number}",
+                    message=f"Instruction surface `{relative_path}:{line_number}` still tells agents to update `requirements.txt` instead of treating `pyproject.toml` as the dependency source of truth.",
+                )
+            )
+
+
+def _workflow_files(root: Path) -> tuple[Path, ...]:
+    workflows_root = root / WORKFLOWS_DIR
+    if not workflows_root.is_dir():
+        return ()
+    return tuple(sorted(path for path in workflows_root.glob("*.yml")))
+
+
+def _instruction_files(root: Path) -> tuple[Path, ...]:
+    files: list[Path] = []
+    for filename in INSTRUCTION_SCAN_FILES:
+        path = root / filename
+        if path.is_file():
+            files.append(path)
+    for dirname in INSTRUCTION_SCAN_DIRS:
+        base = root / dirname
+        if not base.exists():
+            continue
+        for path in sorted(base.rglob("*")):
+            if path.suffix.lower() not in {".md", ".mdx", ".yml", ".yaml"}:
+                continue
+            if path.is_file():
+                files.append(path)
+    return tuple(files)
+
+
+def _canonicalize_dependency_name(requirement: str) -> str:
+    match = re.match(r"[A-Za-z0-9_.-]+", requirement)
+    if match is None:
+        return requirement.lower()
+    return match.group(0).lower().replace("_", "-")

--- a/artifacts/drift/README.md
+++ b/artifacts/drift/README.md
@@ -3,6 +3,7 @@
 This directory is reserved for generated repo-health artifacts.
 
 Recommended local output paths:
+- `artifacts/drift/dependency_hygiene.json`
 - `artifacts/drift/reference_integrity.json`
 - `artifacts/drift/registry_alignment.json`
 

--- a/docs/delivery/05_repo_drift_monitoring.md
+++ b/docs/delivery/05_repo_drift_monitoring.md
@@ -232,7 +232,7 @@ Do not treat it as a mandatory gate on every ordinary PR unless the repository l
 
 The repo-health loop should prefer deterministic prechecks before LLM synthesis where possible.
 
-Initial deterministic scanner:
+Initial deterministic scanners:
 
 - `scripts/drift/check_dependency_hygiene.py`
 - `scripts/drift/check_references.py`

--- a/docs/delivery/05_repo_drift_monitoring.md
+++ b/docs/delivery/05_repo_drift_monitoring.md
@@ -234,22 +234,25 @@ The repo-health loop should prefer deterministic prechecks before LLM synthesis 
 
 Initial deterministic scanner:
 
+- `scripts/drift/check_dependency_hygiene.py`
 - `scripts/drift/check_references.py`
 - `scripts/drift/check_registry_alignment.py`
 
 Recommended usage:
 
 ```bash
+python scripts/drift/check_dependency_hygiene.py --root . --output artifacts/drift/dependency_hygiene.json
 python scripts/drift/check_references.py --root . --output artifacts/drift/reference_integrity.json
 python scripts/drift/check_registry_alignment.py --root . --output artifacts/drift/registry_alignment.json
 ```
 
 These scanners check:
 
+- `pyproject.toml` dependencies and optional extras against actual Python imports, workflow tool usage, and stale dependency-instruction surfaces
 - tracked text files for broken internal file references
 - the current-state registry for mismatches between declared implementation status and the repository's actual module roots and registered implementation paths
 
-They let the drift monitor start from machine-generated evidence about stale paths, deleted files, missing targets, and maturity/status drift in the registry.
+They let the drift monitor start from machine-generated evidence about dependency/tooling drift, stale paths, deleted files, missing targets, and maturity/status drift in the registry.
 
 ## Required output shape
 

--- a/prompts/agents/drift_monitor_agent_instruction.md
+++ b/prompts/agents/drift_monitor_agent_instruction.md
@@ -66,6 +66,7 @@ Every material finding must cite the conflicting or drifting artifacts and expla
 
 Run deterministic scanners first where available. For this repository, start with:
 
+- `python scripts/drift/check_dependency_hygiene.py --root . --output artifacts/drift/dependency_hygiene.json`
 - `python scripts/drift/check_references.py --root . --output artifacts/drift/reference_integrity.json`
 - `python scripts/drift/check_registry_alignment.py --root . --output artifacts/drift/registry_alignment.json`
 

--- a/prompts/drift_monitor/repo_health_audit_prompt.md
+++ b/prompts/drift_monitor/repo_health_audit_prompt.md
@@ -25,6 +25,7 @@ Audit for:
 Rules:
 
 - run deterministic drift scanners first when they exist, starting with:
+  - `python scripts/drift/check_dependency_hygiene.py --root . --output artifacts/drift/dependency_hygiene.json`
   - `python scripts/drift/check_references.py --root . --output artifacts/drift/reference_integrity.json`
   - `python scripts/drift/check_registry_alignment.py --root . --output artifacts/drift/registry_alignment.json`
 - cite evidence for each material finding

--- a/scripts/drift/check_dependency_hygiene.py
+++ b/scripts/drift/check_dependency_hygiene.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import sys
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Scan dependency declarations, imports, workflows, and instruction surfaces for deterministic dependency drift."
+    )
+    parser.add_argument("--root", help="Repository root to scan. Defaults to the repo root containing this script.")
+    parser.add_argument("--output", help="Optional JSON report path.")
+    parser.add_argument(
+        "--fail-on-findings",
+        action="store_true",
+        help="Exit non-zero when any findings are detected.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    repo_root = Path(__file__).resolve().parents[2]
+    if str(repo_root) not in sys.path:
+        sys.path.insert(0, str(repo_root))
+
+    from agent_runtime.drift.dependency_hygiene import build_dependency_hygiene_report
+
+    args = parse_args()
+    scan_root = repo_root if args.root is None else _resolve_scan_root(repo_root, args.root)
+    report = build_dependency_hygiene_report(scan_root)
+    payload = json.dumps(report.to_dict(), indent=2, sort_keys=True)
+    if args.output:
+        output_path = Path(args.output)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(payload + "\n", encoding="utf-8")
+    print(payload)
+    if args.fail_on_findings and report.findings:
+        return 1
+    return 0
+
+
+def _resolve_scan_root(repo_root: Path, raw_root: str) -> Path:
+    candidate = Path(raw_root)
+    resolved = candidate if candidate.is_absolute() else (repo_root / candidate)
+    resolved = resolved.resolve()
+    if not resolved.exists():
+        raise FileNotFoundError(f"Scan root `{resolved}` does not exist.")
+    if not resolved.is_dir():
+        raise NotADirectoryError(f"Scan root `{resolved}` is not a directory.")
+    return resolved
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/agent_runtime/test_dependency_hygiene.py
+++ b/tests/unit/agent_runtime/test_dependency_hygiene.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import subprocess
+import sys
+
+from agent_runtime.drift.dependency_hygiene import build_dependency_hygiene_report
+
+
+def test_dependency_hygiene_reports_undeclared_runtime_dependency(tmp_path: Path) -> None:
+    _write_pyproject(tmp_path, project_dependencies=["pydantic>=2.0,<3.0"])
+    runtime_file = tmp_path / "src" / "app.py"
+    runtime_file.parent.mkdir(parents=True)
+    runtime_file.write_text("import requests\n", encoding="utf-8")
+
+    report = build_dependency_hygiene_report(tmp_path)
+
+    assert report.stats.findings_count == 1
+    finding = report.findings[0]
+    assert finding.kind == "undeclared_runtime_dependency"
+    assert finding.dependency_name == "requests"
+    assert finding.source_path == "src/app.py"
+    assert finding.severity == "critical"
+
+
+def test_dependency_hygiene_reports_runtime_dependency_declared_only_in_optional_extra(tmp_path: Path) -> None:
+    _write_pyproject(
+        tmp_path,
+        project_dependencies=["pydantic>=2.0,<3.0"],
+        optional_dependencies={"compute": ["numpy==2.4.4"], "dev": ["pytest==9.0.2"]},
+    )
+    runtime_file = tmp_path / "agent_runtime" / "service.py"
+    runtime_file.parent.mkdir(parents=True)
+    runtime_file.write_text("import numpy\n", encoding="utf-8")
+
+    report = build_dependency_hygiene_report(tmp_path)
+
+    assert report.stats.findings_count == 1
+    finding = report.findings[0]
+    assert finding.kind == "runtime_dependency_declared_only_in_optional_extra"
+    assert finding.dependency_name == "numpy"
+    assert finding.source_path == "agent_runtime/service.py"
+    assert finding.severity == "major"
+
+
+def test_dependency_hygiene_reports_workflow_tool_missing_from_dev_extra(tmp_path: Path) -> None:
+    _write_pyproject(tmp_path, project_dependencies=["pydantic>=2.0,<3.0"], optional_dependencies={"dev": ["pytest==9.0.2"]})
+    workflow = tmp_path / ".github" / "workflows" / "ci.yml"
+    workflow.parent.mkdir(parents=True)
+    workflow.write_text(
+        "\n".join(
+            [
+                "name: ci",
+                "jobs:",
+                "  test:",
+                "    steps:",
+                '      - run: pip install -e ".[dev]"',
+                "      - run: mypy src/ agent_runtime/",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    report = build_dependency_hygiene_report(tmp_path)
+
+    assert report.stats.findings_count == 1
+    finding = report.findings[0]
+    assert finding.kind == "workflow_tool_missing_from_dev_extra"
+    assert finding.dependency_name == "mypy"
+    assert finding.source_path == ".github/workflows/ci.yml"
+
+
+def test_dependency_hygiene_reports_stale_requirements_guidance(tmp_path: Path) -> None:
+    _write_pyproject(tmp_path, project_dependencies=["pydantic>=2.0,<3.0"])
+    doc_path = tmp_path / "docs" / "guide.md"
+    doc_path.parent.mkdir(parents=True)
+    doc_path.write_text("If you add a dependency, update requirements.txt.\n", encoding="utf-8")
+
+    report = build_dependency_hygiene_report(tmp_path)
+
+    assert report.stats.findings_count == 1
+    finding = report.findings[0]
+    assert finding.kind == "stale_requirements_txt_update_guidance"
+    assert finding.dependency_name == "requirements.txt"
+    assert finding.source_path == "docs/guide.md:1"
+
+
+def test_check_dependency_hygiene_cli_writes_json_report(tmp_path: Path) -> None:
+    _write_pyproject(
+        tmp_path,
+        project_dependencies=["pydantic>=2.0,<3.0"],
+        optional_dependencies={"dev": ["pytest==9.0.2", "ruff==0.15.9", "mypy"]},
+    )
+    runtime_file = tmp_path / "src" / "app.py"
+    runtime_file.parent.mkdir(parents=True)
+    runtime_file.write_text("import pydantic\n", encoding="utf-8")
+    workflow = tmp_path / ".github" / "workflows" / "ci.yml"
+    workflow.parent.mkdir(parents=True)
+    workflow.write_text(
+        "name: ci\njobs:\n  test:\n    steps:\n      - run: pytest -q\n      - run: ruff check .\n      - run: mypy src/\n", encoding="utf-8"
+    )
+    output_path = tmp_path / "artifacts" / "drift" / "dependency_hygiene.json"
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "scripts/drift/check_dependency_hygiene.py",
+            "--root",
+            str(tmp_path),
+            "--output",
+            str(output_path),
+        ],
+        cwd=Path(__file__).resolve().parents[3],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    payload = json.loads(completed.stdout)
+    written_payload = json.loads(output_path.read_text(encoding="utf-8"))
+
+    assert payload["scan_name"] == "dependency_hygiene"
+    assert payload["root"] == "."
+    assert payload == written_payload
+    assert payload["stats"]["findings_count"] == 0
+
+
+def test_repo_dependency_hygiene_scan_has_no_findings() -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+
+    report = build_dependency_hygiene_report(repo_root)
+
+    assert report.findings == ()
+
+
+def _write_pyproject(
+    root: Path,
+    *,
+    project_dependencies: list[str],
+    optional_dependencies: dict[str, list[str]] | None = None,
+) -> None:
+    optional_dependencies = optional_dependencies or {}
+    lines = [
+        "[project]",
+        'name = "risk-manager"',
+        'version = "0.0.0"',
+        'requires-python = ">=3.12"',
+        "dependencies = [",
+    ]
+    lines.extend(f'    "{dependency}",' for dependency in project_dependencies)
+    lines.append("]")
+    if optional_dependencies:
+        lines.append("")
+        lines.append("[project.optional-dependencies]")
+        for extra_name, dependencies in optional_dependencies.items():
+            lines.append(f"{extra_name} = [")
+            lines.extend(f'    "{dependency}",' for dependency in dependencies)
+            lines.append("]")
+    (root / "pyproject.toml").write_text("\n".join(lines) + "\n", encoding="utf-8")

--- a/tests/unit/agent_runtime/test_dependency_hygiene.py
+++ b/tests/unit/agent_runtime/test_dependency_hygiene.py
@@ -44,6 +44,25 @@ def test_dependency_hygiene_reports_runtime_dependency_declared_only_in_optional
     assert finding.severity == "major"
 
 
+def test_dependency_hygiene_reports_runtime_dependency_declared_only_in_dev_extra(tmp_path: Path) -> None:
+    _write_pyproject(
+        tmp_path,
+        project_dependencies=["pydantic>=2.0,<3.0"],
+        optional_dependencies={"dev": ["pytest==9.0.2"]},
+    )
+    runtime_file = tmp_path / "src" / "app.py"
+    runtime_file.parent.mkdir(parents=True)
+    runtime_file.write_text("import pytest\n", encoding="utf-8")
+
+    report = build_dependency_hygiene_report(tmp_path)
+
+    assert report.stats.findings_count == 1
+    finding = report.findings[0]
+    assert finding.kind == "runtime_dependency_declared_only_in_optional_extra"
+    assert finding.dependency_name == "pytest"
+    assert finding.source_path == "src/app.py"
+
+
 def test_dependency_hygiene_reports_workflow_tool_missing_from_dev_extra(tmp_path: Path) -> None:
     _write_pyproject(tmp_path, project_dependencies=["pydantic>=2.0,<3.0"], optional_dependencies={"dev": ["pytest==9.0.2"]})
     workflow = tmp_path / ".github" / "workflows" / "ci.yml"
@@ -85,6 +104,39 @@ def test_dependency_hygiene_reports_stale_requirements_guidance(tmp_path: Path) 
     assert finding.kind == "stale_requirements_txt_update_guidance"
     assert finding.dependency_name == "requirements.txt"
     assert finding.source_path == "docs/guide.md:1"
+
+
+def test_dependency_hygiene_skips_invalid_python_files(tmp_path: Path) -> None:
+    _write_pyproject(tmp_path, project_dependencies=["pydantic>=2.0,<3.0"])
+    runtime_file = tmp_path / "src" / "broken.py"
+    runtime_file.parent.mkdir(parents=True)
+    runtime_file.write_text("def broken(:\n", encoding="utf-8")
+
+    report = build_dependency_hygiene_report(tmp_path)
+
+    assert report.findings == ()
+
+
+def test_dependency_hygiene_skips_non_utf8_workflow_files(tmp_path: Path) -> None:
+    _write_pyproject(tmp_path, project_dependencies=["pydantic>=2.0,<3.0"], optional_dependencies={"dev": ["pytest==9.0.2"]})
+    workflow = tmp_path / ".github" / "workflows" / "ci.yml"
+    workflow.parent.mkdir(parents=True)
+    workflow.write_bytes(b"\xff\xfe\x00\x00")
+
+    report = build_dependency_hygiene_report(tmp_path)
+
+    assert report.findings == ()
+
+
+def test_dependency_hygiene_skips_non_utf8_instruction_files(tmp_path: Path) -> None:
+    _write_pyproject(tmp_path, project_dependencies=["pydantic>=2.0,<3.0"])
+    doc_path = tmp_path / "docs" / "guide.md"
+    doc_path.parent.mkdir(parents=True)
+    doc_path.write_bytes(b"\xff\xfe\x00\x00")
+
+    report = build_dependency_hygiene_report(tmp_path)
+
+    assert report.findings == ()
 
 
 def test_check_dependency_hygiene_cli_writes_json_report(tmp_path: Path) -> None:


### PR DESCRIPTION
## What changed
- add a third deterministic drift scanner for dependency and tooling hygiene
- compare `pyproject.toml` dependencies and optional extras against actual Python imports in runtime, tests, and scripts
- detect workflow tools invoked in CI but missing from `[project.optional-dependencies].dev`
- detect stale instruction surfaces that still tell agents to update `requirements.txt`
- add a CLI entrypoint at `scripts/drift/check_dependency_hygiene.py`
- add unit tests for the new scanner
- wire the scanner into the drift-monitor workflow, artifact conventions, and drift-monitor docs/prompts

## Why
- repo-health audits should start from machine-generated evidence for dependency and tooling drift, not just free-form judgment
- dependency reality, CI/tooling usage, and stale dependency guidance are all common sources of repo-wide drift that can misroute coding work or weaken repo governance
- this extends the deterministic drift-monitor stack beyond references and registry alignment

## Validation
- `python -m pytest -q tests/unit/agent_runtime/test_dependency_hygiene.py tests/unit/agent_runtime/test_registry_alignment.py tests/unit/agent_runtime/test_reference_integrity.py`
- `ruff check agent_runtime/drift scripts/drift tests/unit/agent_runtime/test_dependency_hygiene.py tests/unit/agent_runtime/test_registry_alignment.py tests/unit/agent_runtime/test_reference_integrity.py`
- `ruff format --check agent_runtime/drift scripts/drift tests/unit/agent_runtime/test_dependency_hygiene.py tests/unit/agent_runtime/test_registry_alignment.py tests/unit/agent_runtime/test_reference_integrity.py`
- `mypy agent_runtime/drift scripts/drift/check_dependency_hygiene.py scripts/drift/check_registry_alignment.py scripts/drift/check_references.py`
- `python scripts/drift/check_dependency_hygiene.py --output artifacts/drift/dependency_hygiene.json`

## Notes
- the scanner is intentionally repo-specific and deterministic rather than a generic dependency auditor
- on current `main`, the new dependency hygiene scanner returns zero findings, which is the expected baseline