### PR TITLE
[codex] Restore lookback window default in active PRD

### DIFF
--- a/docs/prds/phase-1/PRD-1.1-risk-summary-service-v2.md
+++ b/docs/prds/phase-1/PRD-1.1-risk-summary-service-v2.md
@@ -153,12 +153,15 @@ These apply to `get_risk_summary`, `get_risk_delta`, and `get_risk_change_profil
 
 ### Optional inputs for as-of-date retrieval
 
+The following optional inputs apply to `get_risk_summary`, `get_risk_delta`, and `get_risk_change_profile`:
+
 - `compare_to_date`
-- `lookback_window`
-- `require_complete`
 - `snapshot_id`
 
-These apply to `get_risk_summary`, `get_risk_delta`, and `get_risk_change_profile`.
+The following optional inputs apply to `get_risk_summary` and `get_risk_change_profile` only. `get_risk_delta` does not accept these inputs:
+
+- `lookback_window`
+- `require_complete`
 
 `get_risk_history` uses the dedicated request shape defined in the API surface section below.
 


### PR DESCRIPTION
- [x] Identify inconsistency: optional inputs section incorrectly said `lookback_window` and `require_complete` apply to `get_risk_delta`
- [x] Split optional inputs section into two groups: `compare_to_date`/`snapshot_id` (all three functions) and `lookback_window`/`require_complete` (get_risk_summary and get_risk_change_profile only, with get_risk_delta explicitly excluded)
- [x] Validate PRD markdown (0 lint errors)