### PR TITLE
[codex] clarify risk delta current-point semantics

### DIFF
--- a/work_items/ready/WI-1.1.4-risk-summary-core-service.md
+++ b/work_items/ready/WI-1.1.4-risk-summary-core-service.md
@@ -6,7 +6,9 @@ PRD-1.1-v2
 
 ## Purpose
 
-Implement `get_risk_delta` and the shared first-order retrieval logic it requires.
+Implement `get_risk_delta` as a first-order retrieval surface that returns a `RiskDelta` only when a current point exists.
+
+Current-point failures must not fabricate partial `RiskDelta` objects. In this slice, those outcomes are returned as typed service errors rather than as partially populated `RiskDelta` responses.
 
 ## Scope
 
@@ -14,7 +16,8 @@ Implement `get_risk_delta` and the shared first-order retrieval logic it require
 - shared current/prior retrieval helper logic inside the service module
 - compare-date defaulting through the canonical business-day resolver
 - explicit compare-date validation and handling
-- first-order status derivation needed for delta retrieval
+- first-order status derivation for object-returning delta retrieval
+- typed service-error routing for current-point failures that cannot be represented honestly by the current `RiskDelta` contract
 - direct population of top-level `node_level`, `hierarchy_scope`, and `legal_entity_id` from `node_ref`
 - package export for `get_risk_delta`
 
@@ -27,6 +30,7 @@ Implement `get_risk_delta` and the shared first-order retrieval logic it require
 - volatility flags or volatility-regime logic
 - replay-suite coverage
 - new evidence/trace fields
+- widening the `RiskDelta` schema
 - service-layer refactors outside the named files
 
 ## Dependencies
@@ -47,22 +51,55 @@ Implement `get_risk_delta` and the shared first-order retrieval logic it require
 
 Create the delta-service unit test module in the existing risk-analytics unit-test package as part of this slice.
 
+## Outcome Model
+
+`get_risk_delta` returns a `RiskDelta` only when all fields required by the current contract can be populated honestly, including:
+
+- `current_value`
+- `snapshot_id`
+- `data_version`
+- `service_version`
+- `generated_at`
+
+### Returned as `RiskDelta` statuses
+
+These outcomes remain in-object statuses because a valid current point exists and a `RiskDelta` can be constructed without fabrication:
+
+- `OK`
+- `DEGRADED`
+- `MISSING_COMPARE`
+
+### Returned as typed service errors
+
+These outcomes are not returned as partial `RiskDelta` objects in this slice:
+
+- `UNSUPPORTED_MEASURE`
+- `MISSING_SNAPSHOT`
+- `MISSING_NODE`
+
+### Returned as typed validation errors
+
+These outcomes remain request-validation failures rather than `RiskDelta` responses:
+
+- invalid explicit `compare_to_date`
+- invalid or blank `snapshot_id`
+- any request that fails existing typed contract or business-day validation
+
 ## Acceptance Criteria
 
-- `get_risk_delta` returns a typed `RiskDelta` for a supported scoped node, measure, and `as_of_date`
+- `get_risk_delta` returns a typed `RiskDelta` only when a current scoped point exists for the requested `as_of_date`
 - current value is read from the pinned `as_of_date` snapshot row for the exact scoped `node_ref`
 - omitted `compare_to_date` defaults through the canonical business-day resolver from WI-1.1.6
 - explicit `compare_to_date` is honored exactly and validated through the same canonical calendar path
-- invalid explicit compare dates must fail through canonical resolver validation rather than silently falling back
-- if the current snapshot for `as_of_date` is missing, the result status is `MISSING_SNAPSHOT`
-- if the current snapshot exists but the scoped node/measure does not, the result status is `MISSING_NODE`
+- invalid explicit compare dates fail through validation rather than silently falling back
 - if the compare snapshot or compare row is missing while the current row exists, current values are returned, prior and delta fields are null, and the result status is `MISSING_COMPARE`
-- if the current snapshot or current row is degraded, the result status is `DEGRADED` and lower-precedence compare issues do not overwrite it
+- if the current snapshot and current row exist but either is degraded, the returned `RiskDelta.status` is `DEGRADED` and lower-precedence compare issues do not overwrite it
 - `delta_pct` is null when `previous_value` is null or zero
 - top-level `node_level`, `hierarchy_scope`, and `legal_entity_id` mirror `node_ref` exactly
-- reachable statuses in this slice are explicit and limited to `UNSUPPORTED_MEASURE`, `MISSING_SNAPSHOT`, `MISSING_NODE`, `DEGRADED`, `MISSING_COMPARE`, and `OK`; `PARTIAL` and `MISSING_HISTORY` remain deferred because no history or rolling-stat behavior is in scope
-- this slice introduces no `get_risk_summary` surface, no replay-suite tests, and no new evidence/trace fields beyond the approved replay/version metadata already present on the contract
-- unit tests cover compare-date defaulting, explicit compare handling, missing compare behavior, zero-prior handling, degraded-status precedence, scope fidelity, and mirrored top-level fields
+- `UNSUPPORTED_MEASURE`, `MISSING_SNAPSHOT`, and `MISSING_NODE` are surfaced as typed service errors in this slice, not as partially populated `RiskDelta` objects
+- reachable in-object delta statuses in this slice are limited to `OK`, `DEGRADED`, and `MISSING_COMPARE`
+- this slice introduces no `get_risk_summary` surface, no replay-suite tests, no new evidence/trace fields beyond the approved replay/version metadata already present on the contract, and no schema widening
+- unit tests cover compare-date defaulting, explicit compare handling, missing compare behavior, zero-prior handling, degraded-status precedence, scope fidelity, mirrored top-level fields, and the object-vs-service-error boundary for current-point failures
 
 ## Suggested Agent
 
@@ -72,6 +109,14 @@ Coding Agent
 
 - first-order delta correctness
 - compare-date semantics
-- status-precedence correctness for the statuses reachable in this slice
+- contract fidelity between object-returning and error-returning paths
 - scope fidelity and mirror-field fidelity
 - strict out-of-scope discipline
+
+## Stop Conditions
+
+- stop if implementation would need to fabricate `current_value`, `snapshot_id`, or replay/version metadata for a missing current point
+- stop if implementation would need to widen the `RiskDelta` schema
+- stop if implementation would need to return `get_risk_summary`
+- stop if rolling statistics, `history_points_used`, `RiskChangeProfile`, volatility logic, or replay work enters the PR
+- stop if a required current-point-failure error contract is not already expressible through the repository's existing typed service-error path

--- a/work_items/ready/WI-1.1.8-risk-delta-current-point-error-semantics.md
+++ b/work_items/ready/WI-1.1.8-risk-delta-current-point-error-semantics.md
@@ -1,0 +1,51 @@
+# WI-1.1.8
+
+## Linked PRD
+
+PRD-1.1-v2
+
+## Purpose
+
+Clarify current-point-failure outcome semantics for as-of-date retrieval operations so coding does not invent whether failures are returned as typed objects or typed service errors.
+
+## Scope
+
+- clarify in PRD-1.1-v2 that `get_risk_delta` returns a `RiskDelta` only when a current point exists
+- clarify whether the same object-vs-error rule also applies to `get_risk_summary` and `get_risk_change_profile`, whose contracts also require current-value and replay/version fields
+- state explicitly which canonical outcomes are object statuses versus typed service errors for as-of-date retrieval
+- align the degraded/error-cases section with the API-surface section
+- align the status-model wording so it does not imply that every listed status must always be representable inside every output object
+
+## Out of scope
+
+- contract-schema changes
+- service implementation
+- replay-suite work
+- volatility-policy changes
+
+## Dependencies
+
+- PRD-1.1-v2
+- ADR-001
+- ADR-002
+
+## Target Area
+
+- `docs/prds/phase-1/PRD-1.1-risk-summary-service-v2.md`
+
+## Acceptance Criteria
+
+- PRD explicitly distinguishes object-returning outcomes from typed service-error outcomes for `get_risk_delta`
+- PRD states whether `MISSING_SNAPSHOT`, `MISSING_NODE`, and `UNSUPPORTED_MEASURE` are object statuses, service errors, or operation-specific outcomes
+- PRD no longer requires fabricated fields for current-point-missing paths
+- PRD language is consistent across API surface, output contracts, status model, and degraded/error cases
+
+## Suggested Agent
+
+PRD Author
+
+## Review Focus
+
+- request and status semantics
+- consistency across PRD sections
+- no ambiguity pushed to coding


### PR DESCRIPTION
## What changed
- revised `WI-1.1.4` so `get_risk_delta` returns a `RiskDelta` only when a current point exists
- made current-point failures explicit as typed service-error outcomes instead of partially populated `RiskDelta` objects
- added `WI-1.1.8` as a bounded PRD-author follow-up to clarify object-vs-error semantics in the PRD

## Why
The current `RiskDelta` contract requires `current_value`, `snapshot_id`, and replay/version metadata tied to a real current snapshot. That makes `MISSING_SNAPSHOT` and `MISSING_NODE` impossible to represent honestly inside a `RiskDelta` without fabricating fields.

This keeps the next coding slice narrow and prevents coding from widening the schema or inventing misleading partial objects.

## Impact
- `WI-1.1.4` now limits in-object delta statuses to `OK`, `DEGRADED`, and `MISSING_COMPARE`
- `UNSUPPORTED_MEASURE`, `MISSING_SNAPSHOT`, and `MISSING_NODE` are routed as typed service errors for the delta slice
- a separate ready follow-up item now captures the PRD/spec clarification required for current-point failure semantics across as-of-date retrieval surfaces

## Validation
- ran `python3 scripts/drift/check_references.py --root .`
- reference scan completed with `findings_count = 0`
