### PR TITLE
[codex] Clarify as-of-date error semantics

### DIFF
--- a/docs/prds/phase-1/PRD-1.1-risk-summary-service-v2.md
+++ b/docs/prds/phase-1/PRD-1.1-risk-summary-service-v2.md
@@ -403,6 +403,7 @@ Rules:
 - for `get_risk_summary` and `get_risk_change_profile` in v1, reachable in-object statuses are `OK`, `DEGRADED`, `MISSING_COMPARE`, and `MISSING_HISTORY`
 - for as-of-date retrieval in v1, `UNSUPPORTED_MEASURE`, `MISSING_SNAPSHOT`, and `MISSING_NODE` are typed service-error outcomes, not partially populated `RiskDelta`, `RiskSummary`, or `RiskChangeProfile` objects
 - for as-of-date retrieval in v1, `PARTIAL` is not returned inside `RiskDelta`, `RiskSummary`, or `RiskChangeProfile`; it remains available for operation-specific use such as `RiskHistorySeries`
+- for `RiskSummary` and `RiskChangeProfile`, conditions that would produce `PARTIAL` on an underlying history retrieval, such as sparse valid points in range, must be surfaced as in-object `DEGRADED` rather than `PARTIAL`
 - as-of-date retrieval outcome precedence is:
   1. typed request validation failure
   2. typed service error `UNSUPPORTED_MEASURE`


### PR DESCRIPTION
## What changed

This PR narrows PRD-1.1-v2 to clarify as-of-date retrieval failure semantics without changing schemas.

It updates the PRD to state that:
- `get_risk_delta` returns a `RiskDelta` only when a current scoped point exists
- the same object-vs-service-error rule also applies to `get_risk_summary` and `get_risk_change_profile`
- `UNSUPPORTED_MEASURE`, `MISSING_SNAPSHOT`, and `MISSING_NODE` are typed service-error outcomes for as-of-date retrieval in v1
- request-shape and calendar-validation failures remain typed validation failures
- in-object statuses for as-of-date retrieval are limited to statuses that can be represented honestly by the existing contracts

## Why

WI-1.1.4 exposed a real canon mismatch: the current as-of-date output contracts require `current_value` and replay/version metadata, so current-point-missing outcomes cannot be represented honestly inside returned objects without fabricating fields. Coding should not invent that boundary.

## Impact

This makes WI-1.1.4 coding-ready without widening `RiskDelta` or redesigning schemas. It also clarifies the same semantics for `RiskSummary` and `RiskChangeProfile` so later slices do not re-open the same ambiguity.

## Validation

Documentation-only change. No tests were run.
