### PR TITLE
Add surface liveness drift scanner

### DIFF
--- a/.github/workflows/drift-monitor.yml
+++ b/.github/workflows/drift-monitor.yml
@@ -136,5 +136,6 @@ jobs:
             artifacts/drift/latest_report.json
             artifacts/drift/reference_integrity.json
             artifacts/drift/registry_alignment.json
+            artifacts/drift/surface_liveness.json
             artifacts/drift/summary.md
           if-no-files-found: error

--- a/agent_runtime/drift/__init__.py
+++ b/agent_runtime/drift/__init__.py
@@ -12,6 +12,7 @@ from .drift_suite import (
 from .instruction_surfaces import InstructionSurfaceReport, build_instruction_surface_report
 from .reference_integrity import ReferenceScanReport, build_reference_scan_report
 from .registry_alignment import RegistryAlignmentReport, build_registry_alignment_report
+from .surface_liveness import SurfaceLivenessReport, build_surface_liveness_report
 
 __all__ = [
     "ArchitectureBoundaryReport",
@@ -21,6 +22,7 @@ __all__ = [
     "InstructionSurfaceReport",
     "ReferenceScanReport",
     "RegistryAlignmentReport",
+    "SurfaceLivenessReport",
     "build_architecture_boundary_report",
     "build_canon_lineage_report",
     "build_dependency_hygiene_report",
@@ -28,6 +30,7 @@ __all__ = [
     "build_instruction_surface_report",
     "build_reference_scan_report",
     "build_registry_alignment_report",
+    "build_surface_liveness_report",
     "render_drift_suite_issue_body",
     "render_drift_suite_markdown_summary",
 ]

--- a/agent_runtime/drift/drift_suite.py
+++ b/agent_runtime/drift/drift_suite.py
@@ -12,6 +12,7 @@ from .dependency_hygiene import DependencyHygieneReport, build_dependency_hygien
 from .instruction_surfaces import InstructionSurfaceReport, build_instruction_surface_report
 from .reference_integrity import ReferenceScanReport, build_reference_scan_report
 from .registry_alignment import RegistryAlignmentReport, build_registry_alignment_report
+from .surface_liveness import SurfaceLivenessReport, build_surface_liveness_report
 
 
 BASELINE_VERSION = 1
@@ -26,6 +27,7 @@ _ReportT = (
     | InstructionSurfaceReport
     | ReferenceScanReport
     | RegistryAlignmentReport
+    | SurfaceLivenessReport
 )
 
 
@@ -147,6 +149,12 @@ _SCANNERS: tuple[_ScannerSpec, ...] = (
         artifact_name="registry_alignment.json",
         build_report=build_registry_alignment_report,
     ),
+    _ScannerSpec(
+        scan_name="surface_liveness",
+        title="Surface Liveness",
+        artifact_name="surface_liveness.json",
+        build_report=build_surface_liveness_report,
+    ),
 )
 
 _SIGNATURE_FIELDS: dict[str, tuple[str, ...]] = {
@@ -156,6 +164,7 @@ _SIGNATURE_FIELDS: dict[str, tuple[str, ...]] = {
     "instruction_surfaces": ("kind", "source_path", "related_paths"),
     "reference_integrity": ("kind", "source_file", "source_line", "reference"),
     "registry_alignment": ("kind", "component_id", "implementation_path", "registry_path"),
+    "surface_liveness": ("kind", "source_path", "source_line", "related_path"),
 }
 
 
@@ -512,6 +521,14 @@ def _summary_anchor(finding: DriftSuiteFinding) -> str:
         kind = raw["kind"]
         implementation_path = raw.get("implementation_path") or raw["registry_path"]
         return f"{component_id} `{kind}` `{implementation_path}`"
+    if finding.scan_name == "surface_liveness":
+        source_line = raw.get("source_line")
+        related_path = raw.get("related_path")
+        if source_line is None:
+            return f"{raw['source_path']} `{raw['kind']}`"
+        if related_path is None:
+            return f"{raw['source_path']}:{source_line} `{raw['kind']}`"
+        return f"{raw['source_path']}:{source_line} `{related_path}`"
     return finding.kind
 
 

--- a/agent_runtime/drift/surface_liveness.py
+++ b/agent_runtime/drift/surface_liveness.py
@@ -1,0 +1,391 @@
+from __future__ import annotations
+
+import ast
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+import re
+import subprocess
+
+from .registry_alignment import _load_registry_components, _module_root_from_component_id
+
+
+TEXT_SUFFIXES = {
+    ".md",
+    ".mdx",
+    ".txt",
+    ".toml",
+    ".yaml",
+    ".yml",
+}
+ROOT_TEXT_FILES = {
+    "AGENTS.md",
+    "CLAUDE.md",
+    "GEMINI.md",
+    "README.md",
+}
+ACTIVE_TEXT_ROOTS = {
+    ".github",
+    "agent_runtime",
+    "docs",
+    "prompts",
+    "src",
+    "work_items",
+}
+ACTIVE_CODE_ROOTS = (
+    Path("agent_runtime"),
+    Path("scripts"),
+    Path("src"),
+)
+LEGACY_SEGMENTS = frozenset({"archive", "archived", "deprecated", "legacy"})
+REPO_MODULE_ENTRYPOINT_ROOTS = frozenset({"agent_runtime", "src"})
+REGISTRY_PATH = Path("docs/registry/current_state_registry.yaml")
+MODULE_ENTRYPOINT_PATTERN = re.compile(r"(?:^|\s)(?:\S*python(?:\d+(?:\.\d+)*)?)\s+-m\s+([A-Za-z_][\w\.]*)")
+
+
+@dataclass(frozen=True, slots=True)
+class SurfaceLivenessFinding:
+    kind: str
+    severity: str
+    drift_class: str
+    owner: str
+    source_path: str
+    source_line: int | None
+    related_path: str | None
+    message: str
+
+
+@dataclass(frozen=True, slots=True)
+class SurfaceLivenessStats:
+    active_text_files_scanned: int
+    entrypoint_references_checked: int
+    active_code_files_scanned: int
+    imports_checked: int
+    module_roots_scanned: int
+    findings_count: int
+
+
+@dataclass(frozen=True, slots=True)
+class SurfaceLivenessReport:
+    scan_name: str
+    root: str
+    generated_at: str
+    findings: tuple[SurfaceLivenessFinding, ...]
+    stats: SurfaceLivenessStats
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "scan_name": self.scan_name,
+            "root": self.root,
+            "generated_at": self.generated_at,
+            "findings": [asdict(finding) for finding in self.findings],
+            "stats": asdict(self.stats),
+        }
+
+
+def build_surface_liveness_report(root: Path) -> SurfaceLivenessReport:
+    repo_root = root.resolve()
+    findings: list[SurfaceLivenessFinding] = []
+
+    active_text_files_scanned = 0
+    entrypoint_references_checked = 0
+    for text_path in _active_text_files(repo_root):
+        active_text_files_scanned += 1
+        try:
+            lines = text_path.read_text(encoding="utf-8").splitlines()
+        except UnicodeDecodeError:
+            continue
+        for line_number, line in enumerate(lines, start=1):
+            for module_name in _module_entrypoints_in_line(line):
+                entrypoint_references_checked += 1
+                if _repo_module_entrypoint_exists(repo_root, module_name):
+                    continue
+                findings.append(
+                    SurfaceLivenessFinding(
+                        kind="missing_repo_module_entrypoint",
+                        severity="major",
+                        drift_class="operational-instruction drift",
+                        owner="repository maintenance",
+                        source_path=text_path.relative_to(repo_root).as_posix(),
+                        source_line=line_number,
+                        related_path=module_name,
+                        message=(
+                            f"Active surface `{text_path.relative_to(repo_root).as_posix()}` references repo module entrypoint "
+                            f"`python -m {module_name}` but that module entrypoint does not exist."
+                        ),
+                    )
+                )
+
+    active_code_files_scanned = 0
+    imports_checked = 0
+    for code_path in _active_code_files(repo_root):
+        active_code_files_scanned += 1
+        module_name = _module_name_for_path(code_path.relative_to(repo_root))
+        try:
+            source_text = code_path.read_text(encoding="utf-8")
+            tree = ast.parse(source_text, filename=code_path.relative_to(repo_root).as_posix())
+        except (SyntaxError, UnicodeDecodeError):
+            continue
+        for line_number, import_target in _import_targets(tree, module_name):
+            imports_checked += 1
+            if not _imports_legacy_repo_surface(import_target):
+                continue
+            findings.append(
+                SurfaceLivenessFinding(
+                    kind="active_code_imports_legacy_surface",
+                    severity="critical",
+                    drift_class="implementation drift",
+                    owner="coding",
+                    source_path=code_path.relative_to(repo_root).as_posix(),
+                    source_line=line_number,
+                    related_path=import_target,
+                    message=(f"Active code `{code_path.relative_to(repo_root).as_posix()}` imports legacy-marked surface `{import_target}`."),
+                )
+            )
+
+    registry_module_roots = _registered_module_roots(repo_root)
+    test_signals = _test_signals(repo_root)
+    active_text_signals = _active_text_signals(repo_root)
+    module_roots = _discovered_module_roots(repo_root)
+    for module_root in module_roots:
+        if module_root in registry_module_roots:
+            continue
+        if module_root in test_signals:
+            continue
+        if module_root in active_text_signals:
+            continue
+        findings.append(
+            SurfaceLivenessFinding(
+                kind="orphaned_module_root",
+                severity="major",
+                drift_class="implementation drift",
+                owner="repository maintenance",
+                source_path=f"src/modules/{module_root}",
+                source_line=None,
+                related_path=None,
+                message=(
+                    f"Module root `src/modules/{module_root}` has no registry entry, no active canon or execution-surface reference, "
+                    "and no matching test signal."
+                ),
+            )
+        )
+
+    findings.sort(key=lambda finding: (finding.source_path, finding.source_line or 0, finding.kind, finding.related_path or ""))
+    return SurfaceLivenessReport(
+        scan_name="surface_liveness",
+        root=".",
+        generated_at=datetime.now(UTC).isoformat(),
+        findings=tuple(findings),
+        stats=SurfaceLivenessStats(
+            active_text_files_scanned=active_text_files_scanned,
+            entrypoint_references_checked=entrypoint_references_checked,
+            active_code_files_scanned=active_code_files_scanned,
+            imports_checked=imports_checked,
+            module_roots_scanned=len(module_roots),
+            findings_count=len(findings),
+        ),
+    )
+
+
+def _active_text_files(root: Path) -> tuple[Path, ...]:
+    tracked = _git_tracked_files(root)
+    if tracked is None:
+        return _fallback_active_text_files(root)
+    return tuple(path for path in tracked if _is_active_text_surface(path.relative_to(root)))
+
+
+def _active_code_files(root: Path) -> tuple[Path, ...]:
+    code_files: list[Path] = []
+    for code_root in ACTIVE_CODE_ROOTS:
+        full_root = root / code_root
+        if not full_root.exists():
+            continue
+        for full_path in sorted(full_root.rglob("*.py")):
+            rel_path = full_path.relative_to(root)
+            if any(part == "tests" for part in rel_path.parts):
+                continue
+            if not full_path.is_file():
+                continue
+            code_files.append(full_path)
+    return tuple(code_files)
+
+
+def _git_tracked_files(root: Path) -> tuple[Path, ...] | None:
+    try:
+        completed = subprocess.run(
+            ["git", "ls-files"],
+            cwd=root,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        return None
+
+    tracked_paths: list[Path] = []
+    for line in completed.stdout.splitlines():
+        if not line:
+            continue
+        tracked_paths.append(root / line)
+    return tuple(tracked_paths)
+
+
+def _fallback_active_text_files(root: Path) -> tuple[Path, ...]:
+    candidates: list[Path] = []
+    for root_name in sorted(ACTIVE_TEXT_ROOTS):
+        full_root = root / root_name
+        if not full_root.exists():
+            continue
+        for full_path in sorted(full_root.rglob("*")):
+            if not full_path.is_file():
+                continue
+            if _is_active_text_surface(full_path.relative_to(root)):
+                candidates.append(full_path)
+    for file_name in sorted(ROOT_TEXT_FILES):
+        candidate = root / file_name
+        if candidate.is_file():
+            candidates.append(candidate)
+    return tuple(dict.fromkeys(candidates))
+
+
+def _is_active_text_surface(path: Path) -> bool:
+    if path.name in ROOT_TEXT_FILES:
+        return True
+    if path.suffix not in TEXT_SUFFIXES:
+        return False
+    if not path.parts:
+        return False
+    if path.parts[0] not in ACTIVE_TEXT_ROOTS:
+        return False
+    if "archived" in path.parts or "archive" in path.parts:
+        return False
+    if path.parts[0] == "work_items" and len(path.parts) > 1 and path.parts[1] != "ready":
+        return False
+    if path.parts[0] == "tests":
+        return False
+    if path.parts[0] in {"agent_runtime", "src"} and path.name != "README.md":
+        return False
+    return True
+
+
+def _module_entrypoints_in_line(line: str) -> tuple[str, ...]:
+    matches = []
+    for match in MODULE_ENTRYPOINT_PATTERN.finditer(line):
+        module_name = match.group(1)
+        if module_name.split(".", maxsplit=1)[0] not in REPO_MODULE_ENTRYPOINT_ROOTS:
+            continue
+        matches.append(module_name)
+    return tuple(dict.fromkeys(matches))
+
+
+def _repo_module_entrypoint_exists(root: Path, module_name: str) -> bool:
+    module_path = root.joinpath(*module_name.split("."))
+    if module_path.with_suffix(".py").is_file():
+        return True
+    if module_path.is_dir() and (module_path / "__main__.py").is_file():
+        return True
+    return False
+
+
+def _module_name_for_path(source_path: Path) -> str:
+    return ".".join(source_path.with_suffix("").parts)
+
+
+def _import_targets(tree: ast.AST, module_name: str) -> tuple[tuple[int, str], ...]:
+    import_targets: list[tuple[int, str]] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                import_targets.append((node.lineno, alias.name))
+        elif isinstance(node, ast.ImportFrom):
+            resolved = _resolve_import_from(module_name, node)
+            if resolved is not None:
+                import_targets.append((node.lineno, resolved))
+    return tuple(import_targets)
+
+
+def _resolve_import_from(module_name: str, node: ast.ImportFrom) -> str | None:
+    if node.level == 0:
+        return node.module
+    module_parts = module_name.split(".")
+    package_parts = module_parts[:-1]
+    ascend = node.level - 1
+    if ascend > len(package_parts):
+        return None
+    base_parts = package_parts[: len(package_parts) - ascend]
+    if node.module is None:
+        return ".".join(base_parts)
+    return ".".join(base_parts + node.module.split("."))
+
+
+def _imports_legacy_repo_surface(import_target: str) -> bool:
+    parts = import_target.split(".")
+    if not parts or parts[0] not in REPO_MODULE_ENTRYPOINT_ROOTS:
+        return False
+    return any(part in LEGACY_SEGMENTS for part in parts[1:])
+
+
+def _registered_module_roots(root: Path) -> frozenset[str]:
+    registry_path = root / REGISTRY_PATH
+    if not registry_path.is_file():
+        return frozenset()
+    module_roots: set[str] = set()
+    for component in _load_registry_components(registry_path):
+        if component.section != "modules":
+            continue
+        module_root = _module_root_from_component_id(component.component_id)
+        if module_root is not None:
+            module_roots.add(module_root)
+    return frozenset(module_roots)
+
+
+def _test_signals(root: Path) -> frozenset[str]:
+    tests_root = root / "tests"
+    if not tests_root.is_dir():
+        return frozenset()
+    signal_text_by_root = _module_signal_text_by_root(root)
+    signaled: set[str] = set()
+    for test_path in sorted(tests_root.rglob("*.py")):
+        if not test_path.is_file():
+            continue
+        rel_path = test_path.relative_to(root).as_posix()
+        try:
+            contents = test_path.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            continue
+        for module_root, signals in signal_text_by_root.items():
+            if module_root in rel_path or any(signal in contents for signal in signals):
+                signaled.add(module_root)
+    return frozenset(signaled)
+
+
+def _active_text_signals(root: Path) -> frozenset[str]:
+    signal_text_by_root = _module_signal_text_by_root(root)
+    signaled: set[str] = set()
+    for text_path in _active_text_files(root):
+        try:
+            contents = text_path.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            continue
+        rel_path = text_path.relative_to(root).as_posix()
+        for module_root, signals in signal_text_by_root.items():
+            if any(signal in contents for signal in signals) or module_root in rel_path:
+                signaled.add(module_root)
+    return frozenset(signaled)
+
+
+def _module_signal_text_by_root(root: Path) -> dict[str, tuple[str, ...]]:
+    return {
+        module_root: (
+            f"src/modules/{module_root}",
+            f"src.modules.{module_root}",
+        )
+        for module_root in _discovered_module_roots(root)
+    }
+
+
+def _discovered_module_roots(root: Path) -> tuple[str, ...]:
+    modules_root = root / "src" / "modules"
+    if not modules_root.is_dir():
+        return ()
+    return tuple(sorted(child.name for child in modules_root.iterdir() if child.is_dir() and not child.name.startswith((".", "__"))))

--- a/artifacts/drift/README.md
+++ b/artifacts/drift/README.md
@@ -11,6 +11,7 @@ Recommended local output paths:
 - `artifacts/drift/latest_report.json`
 - `artifacts/drift/reference_integrity.json`
 - `artifacts/drift/registry_alignment.json`
+- `artifacts/drift/surface_liveness.json`
 - `artifacts/drift/summary.md`
 
 Tracked baseline:

--- a/docs/delivery/05_repo_drift_monitoring.md
+++ b/docs/delivery/05_repo_drift_monitoring.md
@@ -245,6 +245,7 @@ Initial deterministic scanners:
 - `scripts/drift/check_instruction_surfaces.py`
 - `scripts/drift/check_references.py`
 - `scripts/drift/check_registry_alignment.py`
+- `scripts/drift/check_surface_liveness.py`
 - `scripts/drift/run_all.py`
 
 Recommended usage:
@@ -259,6 +260,7 @@ These scanners check:
 - governed instruction surfaces for missing role pairs, stale README inventories, broken `AGENTS.md` linkage, freshness-rule drift, and drift-monitor entrypoint drift
 - tracked text files for broken internal file references
 - the current-state registry for mismatches between declared implementation status and the repository's actual module roots and registered implementation paths
+- repo-owned runtime entrypoints, legacy-marked import surfaces, and orphaned module roots with no registry, active canon, or test signal
 
 They let the drift monitor start from machine-generated evidence about dependency/tooling drift, stale paths, deleted files, missing targets, and maturity/status drift in the registry.
 

--- a/docs/guides/drift_detection_feature_reference.md
+++ b/docs/guides/drift_detection_feature_reference.md
@@ -237,6 +237,38 @@ Does not check:
 - deeper architectural correctness inside the module
 - whether a module implementation is complete enough for its declared semantics
 
+### Surface liveness
+
+Entry point:
+
+- `scripts/drift/check_surface_liveness.py`
+
+Implementation:
+
+- `agent_runtime/drift/surface_liveness.py`
+
+Checks:
+
+- active execution or operator surfaces that invoke repo-owned Python module entrypoints which no longer exist
+- active code importing repo-local package surfaces marked as `archive`, `archived`, `deprecated`, or `legacy`
+- discovered module roots under `src/modules/` that have no registry entry, no active canon or execution-surface reference, and no test signal
+
+Primary drift class:
+
+- implementation drift
+- operational-instruction drift
+
+Typical owner:
+
+- coding
+- repository maintenance
+
+Does not check:
+
+- whether an untested but still governed module root is high quality
+- whether a module should be deleted if it is still referenced from active canon
+- non-Python stale surfaces outside repo-owned module invocations and package imports
+
 ## Aggregate suite behavior
 
 ### Entry point
@@ -257,6 +289,7 @@ Per-scanner JSON artifacts:
 - `artifacts/drift/instruction_surfaces.json`
 - `artifacts/drift/reference_integrity.json`
 - `artifacts/drift/registry_alignment.json`
+- `artifacts/drift/surface_liveness.json`
 
 Aggregate outputs:
 

--- a/docs/guides/drift_detection_operations_guide.md
+++ b/docs/guides/drift_detection_operations_guide.md
@@ -264,6 +264,7 @@ Current scanners:
 - `agent_runtime/drift/instruction_surfaces.py`
 - `agent_runtime/drift/reference_integrity.py`
 - `agent_runtime/drift/registry_alignment.py`
+- `agent_runtime/drift/surface_liveness.py`
 
 Issue rendering:
 

--- a/scripts/drift/check_surface_liveness.py
+++ b/scripts/drift/check_surface_liveness.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import sys
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Scan repo-owned runtime entrypoints, legacy imports, and module-root liveness signals.")
+    parser.add_argument("--root", help="Repository root to scan. Defaults to the repo root containing this script.")
+    parser.add_argument("--output", help="Optional JSON report path.")
+    parser.add_argument(
+        "--fail-on-findings",
+        action="store_true",
+        help="Exit non-zero when any findings are detected.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    repo_root = Path(__file__).resolve().parents[2]
+    if str(repo_root) not in sys.path:
+        sys.path.insert(0, str(repo_root))
+
+    from agent_runtime.drift.surface_liveness import build_surface_liveness_report
+
+    args = parse_args()
+    scan_root = repo_root if args.root is None else _resolve_scan_root(repo_root, args.root)
+    report = build_surface_liveness_report(scan_root)
+    payload = json.dumps(report.to_dict(), indent=2, sort_keys=True)
+    if args.output:
+        output_path = Path(args.output)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(payload + "\n", encoding="utf-8")
+    print(payload)
+    if args.fail_on_findings and report.findings:
+        return 1
+    return 0
+
+
+def _resolve_scan_root(repo_root: Path, raw_root: str) -> Path:
+    candidate = Path(raw_root)
+    resolved = candidate if candidate.is_absolute() else (repo_root / candidate)
+    resolved = resolved.resolve()
+    if not resolved.exists():
+        raise FileNotFoundError(f"Scan root `{resolved}` does not exist.")
+    if not resolved.is_dir():
+        raise NotADirectoryError(f"Scan root `{resolved}` is not a directory.")
+    return resolved
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/agent_runtime/test_drift_suite.py
+++ b/tests/unit/agent_runtime/test_drift_suite.py
@@ -12,7 +12,7 @@ def test_drift_suite_waives_findings_present_in_baseline(tmp_path: Path) -> None
     _write_minimal_repo(tmp_path)
     initial_report = build_drift_suite_report(tmp_path)
 
-    assert initial_report.stats.scans_run == 6
+    assert initial_report.stats.scans_run == 7
     assert initial_report.stats.total_findings == 1
     assert initial_report.stats.new_findings == 1
     assert initial_report.stats.waived_findings == 0
@@ -85,7 +85,7 @@ def test_run_all_cli_writes_combined_and_per_scanner_artifacts(tmp_path: Path) -
 
     assert payload["scan_name"] == "drift_suite"
     assert payload == written_payload
-    assert payload["stats"]["scans_run"] == 6
+    assert payload["stats"]["scans_run"] == 7
     assert payload["stats"]["new_findings"] == 1
     assert (artifact_dir / "architecture_boundaries.json").is_file()
     assert (artifact_dir / "canon_lineage.json").is_file()
@@ -93,11 +93,13 @@ def test_run_all_cli_writes_combined_and_per_scanner_artifacts(tmp_path: Path) -
     assert (artifact_dir / "instruction_surfaces.json").is_file()
     assert (artifact_dir / "reference_integrity.json").is_file()
     assert (artifact_dir / "registry_alignment.json").is_file()
+    assert (artifact_dir / "surface_liveness.json").is_file()
     summary = summary_path.read_text(encoding="utf-8")
     assert "## Drift Monitor" in summary
     assert "### Architecture Boundaries" in summary
     assert "### Instruction Surfaces" in summary
     assert "### Reference Integrity" in summary
+    assert "### Surface Liveness" in summary
 
 
 def test_run_all_cli_uses_baseline_for_fail_on_findings(tmp_path: Path) -> None:

--- a/tests/unit/agent_runtime/test_surface_liveness.py
+++ b/tests/unit/agent_runtime/test_surface_liveness.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import subprocess
+import sys
+
+from agent_runtime.drift.surface_liveness import build_surface_liveness_report
+
+
+def test_surface_liveness_report_detects_missing_repo_module_entrypoint(tmp_path: Path) -> None:
+    _write_surface_liveness_repo(tmp_path)
+    (tmp_path / "agent_runtime").mkdir(parents=True, exist_ok=True)
+    (tmp_path / "agent_runtime" / "__init__.py").write_text("", encoding="utf-8")
+    (tmp_path / "docs" / "guide.md").write_text(".venv/bin/python -m agent_runtime\n", encoding="utf-8")
+
+    report = build_surface_liveness_report(tmp_path)
+
+    assert report.stats.findings_count == 1
+    finding = report.findings[0]
+    assert finding.kind == "missing_repo_module_entrypoint"
+    assert finding.related_path == "agent_runtime"
+
+
+def test_surface_liveness_report_detects_legacy_import_in_active_code(tmp_path: Path) -> None:
+    _write_surface_liveness_repo(tmp_path)
+    app_path = tmp_path / "src" / "app.py"
+    app_path.parent.mkdir(parents=True, exist_ok=True)
+    app_path.write_text("from agent_runtime.legacy.dispatch import run\n", encoding="utf-8")
+
+    report = build_surface_liveness_report(tmp_path)
+
+    assert report.stats.findings_count == 1
+    finding = report.findings[0]
+    assert finding.kind == "active_code_imports_legacy_surface"
+    assert finding.related_path == "agent_runtime.legacy.dispatch"
+
+
+def test_surface_liveness_report_detects_orphaned_module_root(tmp_path: Path) -> None:
+    _write_surface_liveness_repo(tmp_path)
+    module_root = tmp_path / "src" / "modules" / "orphaned_mod"
+    module_root.mkdir(parents=True, exist_ok=True)
+    module_root.joinpath("__init__.py").write_text("", encoding="utf-8")
+
+    report = build_surface_liveness_report(tmp_path)
+
+    assert report.stats.findings_count == 1
+    finding = report.findings[0]
+    assert finding.kind == "orphaned_module_root"
+    assert finding.source_path == "src/modules/orphaned_mod"
+
+
+def test_surface_liveness_report_allows_registered_or_referenced_module_root(tmp_path: Path) -> None:
+    _write_surface_liveness_repo(tmp_path)
+    module_root = tmp_path / "src" / "modules" / "risk_analytics"
+    module_root.mkdir(parents=True, exist_ok=True)
+    module_root.joinpath("__init__.py").write_text("", encoding="utf-8")
+    registry = tmp_path / "docs" / "registry" / "current_state_registry.yaml"
+    registry.parent.mkdir(parents=True, exist_ok=True)
+    registry.write_text(
+        "\n".join(
+            [
+                "modules:",
+                "  - id: MOD-RISK-ANALYTICS",
+                "    name: Risk Analytics",
+                "    status: proposed",
+                "    contract_status: draft",
+                "walkers:",
+                "orchestrators:",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "docs" / "implementation.md").write_text("See `src/modules/risk_analytics`.\n", encoding="utf-8")
+
+    report = build_surface_liveness_report(tmp_path)
+
+    assert report.findings == ()
+
+
+def test_check_surface_liveness_cli_writes_json_report(tmp_path: Path) -> None:
+    _write_surface_liveness_repo(tmp_path)
+    output_path = tmp_path / "artifacts" / "drift" / "surface_liveness.json"
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "scripts/drift/check_surface_liveness.py",
+            "--root",
+            str(tmp_path),
+            "--output",
+            str(output_path),
+        ],
+        cwd=Path(__file__).resolve().parents[3],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    payload = json.loads(completed.stdout)
+    written_payload = json.loads(output_path.read_text(encoding="utf-8"))
+
+    assert payload["scan_name"] == "surface_liveness"
+    assert payload["root"] == "."
+    assert payload == written_payload
+    assert payload["stats"]["findings_count"] == 0
+
+
+def test_repo_surface_liveness_scan_has_no_findings() -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+
+    report = build_surface_liveness_report(repo_root)
+
+    assert report.findings == ()
+
+
+def _write_surface_liveness_repo(root: Path) -> None:
+    (root / "README.md").write_text("# Repo\n", encoding="utf-8")
+    (root / "AGENTS.md").write_text("# AGENTS\n", encoding="utf-8")
+    (root / "docs").mkdir(parents=True, exist_ok=True)
+    (root / "docs" / "guide.md").write_text("# Guide\n", encoding="utf-8")
+    (root / "prompts").mkdir(parents=True, exist_ok=True)
+    (root / "prompts" / "agent.md").write_text("Use current entrypoints.\n", encoding="utf-8")
+    (root / "work_items" / "ready").mkdir(parents=True, exist_ok=True)
+    (root / "work_items" / "ready" / "WI-1.md").write_text("# Work item\n", encoding="utf-8")
+    (root / ".github").mkdir(parents=True, exist_ok=True)
+    (root / ".github" / "copilot-instructions.md").write_text("# Copilot\n", encoding="utf-8")


### PR DESCRIPTION
## Summary
- add a deterministic surface-liveness scanner for missing repo-owned module entrypoints, legacy-marked imports, and orphaned module roots
- wire the new scanner into the drift suite, workflow artifacts, and drift feature documentation
- add synthetic-repo coverage plus suite expectations for the seventh deterministic scanner

## Validation
- `uv run --extra dev python -m pytest -q tests/unit/agent_runtime/test_surface_liveness.py tests/unit/agent_runtime/test_architecture_boundaries.py tests/unit/agent_runtime/test_canon_lineage.py tests/unit/agent_runtime/test_instruction_surfaces.py tests/unit/agent_runtime/test_drift_suite.py tests/unit/agent_runtime/test_dependency_hygiene.py tests/unit/agent_runtime/test_registry_alignment.py tests/unit/agent_runtime/test_reference_integrity.py`
- `uvx ruff check agent_runtime/drift scripts/drift tests/unit/agent_runtime/test_surface_liveness.py tests/unit/agent_runtime/test_architecture_boundaries.py tests/unit/agent_runtime/test_canon_lineage.py tests/unit/agent_runtime/test_instruction_surfaces.py tests/unit/agent_runtime/test_drift_suite.py tests/unit/agent_runtime/test_dependency_hygiene.py tests/unit/agent_runtime/test_registry_alignment.py tests/unit/agent_runtime/test_reference_integrity.py`
- `uv run --extra dev mypy agent_runtime/drift scripts/drift/check_surface_liveness.py scripts/drift/check_architecture_boundaries.py scripts/drift/check_canon_lineage.py scripts/drift/check_instruction_surfaces.py scripts/drift/check_dependency_hygiene.py scripts/drift/check_registry_alignment.py scripts/drift/check_references.py scripts/drift/run_all.py scripts/drift/render_issue_body.py`
- `actionlint .github/workflows/drift-monitor.yml`
- `uv run --extra dev python scripts/drift/run_all.py --root . --artifact-dir artifacts/drift --output artifacts/drift/latest_report.json --summary-output artifacts/drift/summary.md`

## Notes
The live `run_all.py` pass on current `main` stayed clean after adding this scanner: 7 scanners, 0 net-new findings.