### PR TITLE
Add documentation for LLM provider configuration system

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,25 @@ The platform is organized into:
 - no raw calculations in orchestrators
 - no silent bypass of trust or challenge gates
 
+## Local setup
+
+```bash
+# 1. Create a virtual environment and install dependencies
+python3 -m venv .venv
+.venv/bin/pip install -e ".[dev]"
+
+# 2. Configure API keys
+cp .env.example .env
+# Edit .env and fill in the keys for the providers you use (all optional).
+
+# 3. Install the pre-push lint hook (once per clone)
+git config core.hooksPath .githooks
+```
+
+See `agent_runtime/config/README.md` for the full environment variable
+reference, and `docs/guides/agent_framework.md` for tool-specific setup
+(Cursor, Claude Code, Codex, Copilot).
+
 ## Initial canon
 
 See `docs/` for the current approved architecture canon.

--- a/agent_runtime/config/README.md
+++ b/agent_runtime/config/README.md
@@ -1,0 +1,169 @@
+# Configuration
+
+This directory holds the typed configuration layer for the agent runtime.
+
+All API keys and provider settings are loaded from environment variables
+and/or a `.env` file at the repository root. Secrets are stored as
+`SecretStr` and are never logged.
+
+## Quick start
+
+```bash
+cp .env.example .env
+# Open .env and fill in the keys for the providers you want to use.
+# Every key is optional; the runtime skips providers that have no key set.
+```
+
+## Provider environment variables
+
+### OpenAI
+
+| Variable | Required | Default | Notes |
+| --- | --- | --- | --- |
+| `OPENAI_API_KEY` | for OpenAI calls | — | `sk-…` key from [platform.openai.com/api-keys](https://platform.openai.com/api-keys) |
+| `OPENAI_MODEL` | no | `gpt-4o` | Default inference model |
+| `OPENAI_EMBEDDING_MODEL` | no | `text-embedding-3-small` | Embedding model |
+| `OPENAI_ORGANIZATION` | no | — | Org ID for multi-org accounts |
+| `OPENAI_BASE_URL` | no | — | Override for proxies or Azure OpenAI |
+
+### Anthropic / Claude
+
+| Variable | Required | Default | Notes |
+| --- | --- | --- | --- |
+| `ANTHROPIC_API_KEY` | for Anthropic calls | — | `sk-ant-…` key from [console.anthropic.com](https://console.anthropic.com/keys) |
+| `ANTHROPIC_MODEL` | no | `claude-opus-4-5` | Default model |
+| `ANTHROPIC_BASE_URL` | no | — | Override for proxies |
+
+### Google Gemini
+
+Accepts `GEMINI_API_KEY` (preferred) or `GOOGLE_API_KEY` (alias). If both are
+set, `GEMINI_API_KEY` takes priority.
+
+| Variable | Required | Default | Notes |
+| --- | --- | --- | --- |
+| `GEMINI_API_KEY` | for Gemini calls | — | `AIza…` key from [aistudio.google.com](https://aistudio.google.com/app/apikey) |
+| `GOOGLE_API_KEY` | for Gemini calls | — | Accepted alias for `GEMINI_API_KEY` |
+| `GEMINI_MODEL` | no | `gemini-2.0-flash` | Default model |
+| `GEMINI_EMBEDDING_MODEL` | no | `models/text-embedding-004` | Embedding model |
+
+### Cursor
+
+| Variable | Required | Default | Notes |
+| --- | --- | --- | --- |
+| `CURSOR_API_KEY` | for Cursor endpoints | — | API key for Cursor-hosted model endpoints |
+| `CURSOR_BASE_URL` | no | `https://api.cursor.sh/v1` | Endpoint override |
+| `CURSOR_MODEL` | no | `cursor-fast` | Default model |
+
+### LangChain / LangSmith
+
+Set these to enable tracing and evaluation via [LangSmith](https://smith.langchain.com).
+
+| Variable | Required | Default | Notes |
+| --- | --- | --- | --- |
+| `LANGCHAIN_API_KEY` | for tracing | — | `ls__…` key from LangSmith |
+| `LANGCHAIN_TRACING_V2` | no | `false` | Set `true` to enable LangSmith tracing |
+| `LANGCHAIN_PROJECT` | no | `risk-manager` | LangSmith project name |
+| `LANGCHAIN_ENDPOINT` | no | `https://api.smith.langchain.com` | API endpoint |
+
+### LangGraph Cloud
+
+| Variable | Required | Default | Notes |
+| --- | --- | --- | --- |
+| `LANGGRAPH_API_KEY` | for LangGraph Cloud | — | Deployment API key |
+| `LANGGRAPH_API_URL` | no | — | Your deployment URL |
+| `LANGGRAPH_GRAPH_ID` | no | — | Target graph ID |
+
+### Agent runtime backends
+
+These control whether each runner executes automatically or waits for manual
+handoff. See `agent_runtime/README.md` for full documentation.
+
+| Variable | Required | Default | Notes |
+| --- | --- | --- | --- |
+| `AGENT_RUNTIME_PM_BACKEND` | no | `prepared` | `prepared` (manual) or `codex_exec` |
+| `AGENT_RUNTIME_PM_CODEX_BIN` | no | `codex` | Codex binary path |
+| `AGENT_RUNTIME_PM_CODEX_MODEL` | no | `gpt-5` | Model for PM runs |
+| `AGENT_RUNTIME_REVIEW_BACKEND` | no | `prepared` | `prepared` or `codex_exec` |
+| `AGENT_RUNTIME_REVIEW_CODEX_BIN` | no | `codex` | Codex binary path |
+| `AGENT_RUNTIME_REVIEW_CODEX_MODEL` | no | `gpt-5` | Model for review runs |
+| `AGENT_RUNTIME_CODING_BACKEND` | no | `prepared` | `prepared` or `codex_exec` |
+| `AGENT_RUNTIME_CODING_CODEX_BIN` | no | `codex` | Codex binary path |
+| `AGENT_RUNTIME_CODING_CODEX_MODEL` | no | `gpt-5` | Model for coding runs |
+| `AGENT_RUNTIME_CODING_PR_BACKEND` | no | — | Set `gh_draft` to auto-publish draft PRs |
+| `AGENT_RUNTIME_CODING_PR_TITLE_PREFIX` | no | `[codex]` | Prefix for auto-created PR titles |
+
+## Python API
+
+Import `get_settings()` anywhere in the codebase to access the cached
+configuration object:
+
+```python
+from agent_runtime.config import get_settings
+
+cfg = get_settings()
+
+# Check which providers are ready to use
+cfg.configured_providers()          # → ["openai", "anthropic"]
+
+# Check a single provider
+cfg.is_provider_configured("gemini")  # → True / False
+
+# Retrieve a key as a plain string (only at the call site, never store it)
+cfg.openai.api_key_str              # raises ValueError if OPENAI_API_KEY not set
+cfg.anthropic.api_key_str
+cfg.gemini.api_key_str
+
+# Read non-secret settings
+cfg.openai.model                    # "gpt-4o"
+cfg.langchain.tracing_v2            # False
+cfg.agent_runtime.pm_backend        # "prepared"
+```
+
+`get_settings()` is an `@lru_cache` singleton. It parses `.env` and the
+process environment exactly once per process. All provider sub-configs
+share the same `.env` file and loading order:
+
+1. **Shell environment variables** (highest priority)
+2. **`.env` file** at the repository root
+3. **Defaults** defined in the settings classes
+
+## Rules for using `api_key_str`
+
+- Only call `api_key_str` at the point where you pass the key to an API
+  client. Do not store the plain-text value in a variable that outlives
+  the call.
+- `api_key_str` raises `ValueError` with a clear message if the key is
+  not set. Catch this at the integration boundary, not silently.
+- Blank or whitespace-only values are treated as not configured.
+
+## Testing
+
+Reset the singleton between test cases with `cache_clear()`:
+
+```python
+from agent_runtime.config import get_settings
+
+def test_something(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    get_settings.cache_clear()      # force re-parse with new env
+    cfg = get_settings()
+    assert cfg.openai.api_key_str == "sk-test"
+```
+
+See `tests/unit/agent_runtime/test_settings.py` for the full test suite.
+
+## Pre-push hook
+
+A pre-push hook in `.githooks/pre-push` runs `ruff check`, `ruff format
+--check`, and `mypy` before every push, mirroring the CI `lint-and-test`
+job. Activate it once per clone:
+
+```bash
+git config core.hooksPath .githooks
+```
+
+To bypass in an emergency:
+
+```bash
+git push --no-verify
+```

--- a/docs/guides/agent_framework.md
+++ b/docs/guides/agent_framework.md
@@ -188,6 +188,64 @@ git pull --ff-only origin main
 
 For reviews, then checkout the PR head. For coding, create a fresh branch from `main`. Agents must not work from stale local state.
 
+## Local environment setup
+
+Before using any tool with this repository, configure your local environment
+with the API keys for the providers you plan to use.
+
+### 1. Copy the environment template
+
+```bash
+cp .env.example .env
+```
+
+`.env` is gitignored and must never be committed. `.env.example` documents
+every available variable and is the committed source of truth for the
+configuration schema.
+
+### 2. Fill in your API keys
+
+Open `.env` and uncomment the keys for the providers you want to use.
+All keys are optional; the runtime and agents skip providers that have no
+key set.
+
+| Provider | Variable | Where to get it |
+| --- | --- | --- |
+| OpenAI | `OPENAI_API_KEY` | [platform.openai.com/api-keys](https://platform.openai.com/api-keys) |
+| Anthropic / Claude | `ANTHROPIC_API_KEY` | [console.anthropic.com/keys](https://console.anthropic.com/keys) |
+| Google Gemini | `GEMINI_API_KEY` or `GOOGLE_API_KEY` | [aistudio.google.com/app/apikey](https://aistudio.google.com/app/apikey) |
+| Cursor | `CURSOR_API_KEY` | Cursor account settings |
+| LangSmith (tracing) | `LANGCHAIN_API_KEY` | [smith.langchain.com](https://smith.langchain.com) |
+| LangGraph Cloud | `LANGGRAPH_API_KEY` | LangGraph Cloud console |
+
+### 3. (Optional) Enable LangSmith tracing
+
+```bash
+LANGCHAIN_TRACING_V2=true
+LANGCHAIN_API_KEY=ls__...
+LANGCHAIN_PROJECT=risk-manager
+```
+
+### 4. Install the pre-push hook
+
+The `.githooks/pre-push` hook runs `ruff`, `ruff format`, and `mypy`
+before every push, matching the CI `lint-and-test` job. Activate it once
+per clone:
+
+```bash
+git config core.hooksPath .githooks
+```
+
+### Configuration reference
+
+See `agent_runtime/config/README.md` for:
+
+- the full variable reference for all providers and agent runtime backends
+- the Python `get_settings()` API for consuming config in code
+- testing patterns with `cache_clear()`
+
+---
+
 ## Tool-specific setup
 
 ### Cursor
@@ -439,7 +497,7 @@ The relay is designed to stop and escalate rather than guess. A stopped agent wi
 ## File reference
 
 | File | Purpose |
-|------|---------|
+| --- | --- |
 | `AGENTS.md` | Master role definitions, handoff model, repo rules |
 | `CLAUDE.md` | Claude Code / Cursor role routing |
 | `GEMINI.md` | Gemini role routing |


### PR DESCRIPTION
## Summary

Documentation follow-up to #93 (merged). The configuration system shipped with no documentation beyond the module docstring and `.env.example`. This PR adds three complementary documentation surfaces.

### `agent_runtime/config/README.md` (new)

The primary reference for the config module:

- Full environment variable tables for all providers (OpenAI, Anthropic, Gemini, Cursor, LangChain, LangGraph, agent runtime backends) with required/default/notes columns
- `get_settings()` Python API with usage examples
- `api_key_str` usage rules (call-site only, raises on missing key, whitespace treated as not configured)
- Testing pattern with `cache_clear()` and a `monkeypatch` example
- Pre-push hook activation instructions

### `docs/guides/agent_framework.md`

New **Local environment setup** section inserted before the existing "Tool-specific setup" section. Covers the four setup steps every contributor needs: copy `.env.example`, fill in keys (with a provider table), optionally enable LangSmith tracing, and install the pre-push hook. Points to the config README for the full reference.

### `README.md`

New **Local setup** section at the top level with the three-step quick-start (venv, `.env`, hook), pointing to the detailed guides.

## Test plan

- [ ] Markdown lint passes (verified locally: 0 errors)
- [ ] CI green
- [ ] `.env.example` provider table in `agent_framework.md` matches `.env.example` variable names
- [ ] `agent_runtime/config/README.md` Python examples match `get_settings()` API in `settings.py`

Made with [Cursor](https://cursor.com)