### PR TITLE
feat: add work summary block to all agent handoff outputs

### DIFF
--- a/prompts/agents/coding_agent_instruction.md
+++ b/prompts/agents/coding_agent_instruction.md
@@ -126,7 +126,7 @@ In these cases, stop the implementation, describe the blocker precisely, and rou
 
 ### Step 1 — Work summary (print first, plain text, not copy-paste)
 
-Before printing the handoff block, print a plain-text work summary so the operator has a record of what was built. Use this structure:
+Before printing the handoff block, print a plain-text work summary so the operator has a record of what was built. This step applies to all output paths — PR open, CI failing, and stop condition. Use this structure:
 
 ```text
 --- Coding Work Summary ---

--- a/prompts/agents/drift_monitor_agent_instruction.md
+++ b/prompts/agents/drift_monitor_agent_instruction.md
@@ -132,11 +132,11 @@ Return:
 
 ### Step 1 — Work summary (print first, plain text, not copy-paste)
 
-Before printing the handoff block, print a plain-text work summary so the operator has a record of the audit. Use this structure:
+Before printing the handoff block, print a plain-text work summary so the operator has a record of the audit. This step applies to all output paths — full audit, incomplete audit, and blocked. Use this structure:
 
 ```text
 --- Drift Monitor Work Summary ---
-Repo health    : GREEN | AMBER | RED
+Repo health    : HEALTHY | WATCH | DRIFTING
 Critical       : <count> findings
 Major          : <count> findings
 Minor          : <count> findings

--- a/prompts/agents/issue_planner_instruction.md
+++ b/prompts/agents/issue_planner_instruction.md
@@ -57,7 +57,7 @@ In these cases, route the blocker to PM, PRD/spec, or human decision.
 
 ### Step 1 — Work summary (print first, plain text, not copy-paste)
 
-Before printing the handoff block, print a plain-text work summary so the operator has a record of the planning pass. Use this structure:
+Before printing the handoff block, print a plain-text work summary so the operator has a record of the planning pass. This step applies to all output paths — WIs created and blocked. Use this structure:
 
 ```text
 --- Issue Planner Work Summary ---

--- a/prompts/agents/pm_agent_instruction.md
+++ b/prompts/agents/pm_agent_instruction.md
@@ -125,7 +125,7 @@ In these cases, route the blocker to PRD/spec, ADR, issue planner, or human deci
 
 ### Step 1 — Work summary (print first, plain text, not copy-paste)
 
-Before printing the handoff block, print a plain-text work summary so the operator has a record of what you found. Use this structure:
+Before printing the handoff block, print a plain-text work summary so the operator has a record of what you found. This step applies to all output paths — READY, BLOCKED, and SPLIT_REQUIRED. Use this structure:
 
 ```text
 --- PM Work Summary ---

--- a/prompts/agents/prd_spec_agent_instruction.md
+++ b/prompts/agents/prd_spec_agent_instruction.md
@@ -134,14 +134,14 @@ A well-formed PRD or specification should contain:
 
 ### Step 1 — Work summary (print first, plain text, not copy-paste)
 
-Before printing the handoff block, print a plain-text work summary so the operator has a record of what was specified. Use this structure:
+Before printing the handoff block, print a plain-text work summary so the operator has a record of what was specified. This step applies to all output paths — new PRD, gap filled, and blocked. Use this structure:
 
 ```text
 --- PRD/Spec Work Summary ---
 Document       : <filename and PRD ID>
 Scope covered  : <one-line description of what capability was specified>
 Key decisions  : <bullet list — notable design or contract choices made>
-Open questions : <resolved / <count> remaining — brief note on any blockers>
+Open questions : <resolved | N remaining; brief note on any blockers if any>
 Routing        : Issue Planner (new decomposition needed) | PM (gap filled) | BLOCKED
 --- end summary ---
 ```

--- a/prompts/agents/review_agent_instruction.md
+++ b/prompts/agents/review_agent_instruction.md
@@ -127,7 +127,7 @@ Return:
 
 ### Step 1 — Work summary (print first, plain text, not copy-paste)
 
-Before printing the handoff block, print a plain-text work summary so the operator has a record of the review. Use this structure:
+Before printing the handoff block, print a plain-text work summary so the operator has a record of the review. This step applies to all output paths — PASS, CHANGES_REQUESTED, and BLOCKED. Use this structure:
 
 ```text
 --- Review Work Summary ---


### PR DESCRIPTION
## Summary

Each agent now prints a role-specific plain-text work summary **immediately before** the copy-paste handoff prompt.

Before this change, agents produced only the relay prompt, dropping the detailed narrative of what was found and decided. Now the output is:

1. **Work summary** (plain text, operator's record) — role-specific fields
2. **Handoff block** (copy-paste, unchanged format)

## Fields by role

| Agent | Summary fields |
|---|---|
| PM | WI ID, verdict, dependencies, key findings, blockers |
| Coding | PR URL, files changed, tests added, deviations, CI status, known issues |
| Review | PR URL, WI, verdict, PRD fidelity, scope boundary, CI, comment triage, key findings |
| PRD/Spec Author | Document, scope, key decisions, open questions, routing |
| Issue Planner | Trigger, WIs created, sequence rationale, dependencies, blocked items |
| Drift Monitor | Repo health (GREEN/AMBER/RED), finding counts by severity, top issue, scope checked |

## What did not change

- The handoff block format is identical to before
- The relay structure (one block, copy-paste-ready) is unchanged
- No changes to skill or rule files

Made with [Cursor](https://cursor.com)