### PR TITLE
WI-2.1.6: Shared EvidenceRef + controls_integrity wiring

### DIFF
--- a/docs/shared_infra/adoption_matrix.md
+++ b/docs/shared_infra/adoption_matrix.md
@@ -14,6 +14,7 @@ Track shared-infrastructure usage, owners, and rollout state by layer.
 
 | Area | Shared infra item | Status | Notes |
 | --- | --- | --- | --- |
+| `src/modules/controls_integrity/` | shared evidence contract (`EvidenceRef` in `src/shared/evidence.py`) | adopted | Module imports canonical type from `src.shared`; re-exported via `controls_integrity.contracts` for stable public API (WI-2.1.6) |
 | `src/modules/risk_analytics/` | telemetry contract | planned | No module-local telemetry helper exists under `src/` today; adoption pending tracked implementation work items against `docs/shared_infra/telemetry.md` |
 | `src/walkers/` | telemetry contract | planned | Enforce once first walker telemetry WI lands |
 | `src/orchestrators/` | telemetry contract | planned | Keep orchestration concerns separate from deterministic services |

--- a/src/modules/controls_integrity/contracts/__init__.py
+++ b/src/modules/controls_integrity/contracts/__init__.py
@@ -1,6 +1,6 @@
 """Public exports for controls integrity contracts."""
 
-from src.shared.evidence import EvidenceRef
+from src.shared import EvidenceRef
 
 from .enums import (
     AssessmentStatus,

--- a/src/modules/controls_integrity/contracts/__init__.py
+++ b/src/modules/controls_integrity/contracts/__init__.py
@@ -1,5 +1,7 @@
 """Public exports for controls integrity contracts."""
 
+from src.shared.evidence import EvidenceRef
+
 from .enums import (
     AssessmentStatus,
     CheckState,
@@ -11,7 +13,6 @@ from .enums import (
 from .models import (
     REQUIRED_CHECK_ORDER,
     ControlCheckResult,
-    EvidenceRef,
     IntegrityAssessment,
     NormalizedControlRecord,
 )

--- a/src/modules/controls_integrity/contracts/models.py
+++ b/src/modules/controls_integrity/contracts/models.py
@@ -7,6 +7,8 @@ from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field, TypeAdapter, model_validator
 
+from src.shared.evidence import EvidenceRef
+
 from src.modules.risk_analytics.contracts import (
     HierarchyScope,
     MeasureType,
@@ -53,29 +55,6 @@ def _deduplicated_sorted_reason_codes(
 ) -> tuple[ReasonCode, ...]:
     """Return deduplicated, lexicographically ascending reason codes."""
     return tuple(sorted(set(codes), key=lambda c: c.value))
-
-
-class EvidenceRef(BaseModel):
-    """Typed evidence reference.
-
-    Module-local in this slice (WI-2.1.1).  A repo-wide shared extraction
-    remains an open question governed by ADR-003 and must not happen here.
-    """
-
-    model_config = ConfigDict(extra="forbid", frozen=True, str_strip_whitespace=True)
-
-    evidence_type: str
-    evidence_id: str
-    source_as_of_date: date | None = None
-    snapshot_id: str | None = None
-
-    @model_validator(mode="after")
-    def validate_fields(self) -> "EvidenceRef":
-        if not self.evidence_type:
-            raise ValueError("evidence_type must be non-empty")
-        if not self.evidence_id:
-            raise ValueError("evidence_id must be non-empty")
-        return self
 
 
 class NormalizedControlRecord(BaseModel):

--- a/src/modules/controls_integrity/contracts/models.py
+++ b/src/modules/controls_integrity/contracts/models.py
@@ -7,7 +7,7 @@ from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field, TypeAdapter, model_validator
 
-from src.shared.evidence import EvidenceRef
+from src.shared import EvidenceRef
 
 from src.modules.risk_analytics.contracts import (
     HierarchyScope,

--- a/src/shared/__init__.py
+++ b/src/shared/__init__.py
@@ -1,5 +1,6 @@
 """Shared package exports."""
 
+from .evidence import EvidenceRef
 from .service_errors import RequestValidationFailure, ServiceError
 
-__all__ = ["RequestValidationFailure", "ServiceError"]
+__all__ = ["EvidenceRef", "RequestValidationFailure", "ServiceError"]

--- a/src/shared/evidence.py
+++ b/src/shared/evidence.py
@@ -1,0 +1,30 @@
+"""Shared typed evidence reference (PRD-2.1, ADR-003).
+
+Canonical cross-module shape for pointers to supporting artifacts. Modules
+should import this type from ``src.shared`` rather than redefining it.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+from pydantic import BaseModel, ConfigDict, model_validator
+
+
+class EvidenceRef(BaseModel):
+    """Typed evidence reference with stable fields for replay and audit."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True, str_strip_whitespace=True)
+
+    evidence_type: str
+    evidence_id: str
+    source_as_of_date: date | None = None
+    snapshot_id: str | None = None
+
+    @model_validator(mode="after")
+    def validate_fields(self) -> "EvidenceRef":
+        if not self.evidence_type:
+            raise ValueError("evidence_type must be non-empty")
+        if not self.evidence_id:
+            raise ValueError("evidence_id must be non-empty")
+        return self

--- a/tests/unit/modules/controls_integrity/test_contracts.py
+++ b/tests/unit/modules/controls_integrity/test_contracts.py
@@ -16,6 +16,7 @@ from datetime import date, datetime, timezone
 
 from pydantic import ValidationError
 
+from src.shared import EvidenceRef as SharedEvidenceRef
 from src.modules.controls_integrity.contracts import (
     AssessmentStatus,
     CheckState,
@@ -165,6 +166,9 @@ def make_base_assessment_kwargs(
 
 
 class EvidenceRefTest(unittest.TestCase):
+    def test_evidence_ref_is_shared_canonical_class(self) -> None:
+        self.assertIs(EvidenceRef, SharedEvidenceRef)
+
     def test_valid_evidence_ref_instantiates(self) -> None:
         ref = make_evidence_ref()
         self.assertEqual(ref.evidence_type, "CONTROL_RECORD")

--- a/tests/unit/shared/test_evidence_ref.py
+++ b/tests/unit/shared/test_evidence_ref.py
@@ -1,0 +1,63 @@
+"""Unit tests for shared ``EvidenceRef`` validation (PRD-2.1, WI-2.1.6)."""
+
+from __future__ import annotations
+
+import unittest
+from datetime import date
+
+from pydantic import ValidationError
+
+from src.shared import EvidenceRef
+
+
+class EvidenceRefSharedTest(unittest.TestCase):
+    def test_valid_minimal(self) -> None:
+        ref = EvidenceRef(evidence_type="CONTROL_RECORD", evidence_id="CTRL-001")
+        self.assertEqual(ref.evidence_type, "CONTROL_RECORD")
+        self.assertEqual(ref.evidence_id, "CTRL-001")
+        self.assertIsNone(ref.source_as_of_date)
+        self.assertIsNone(ref.snapshot_id)
+
+    def test_valid_with_optionals(self) -> None:
+        ref = EvidenceRef(
+            evidence_type="LEDGER",
+            evidence_id="L-42",
+            source_as_of_date=date(2026, 1, 15),
+            snapshot_id="snap-abc",
+        )
+        self.assertEqual(ref.source_as_of_date, date(2026, 1, 15))
+        self.assertEqual(ref.snapshot_id, "snap-abc")
+
+    def test_rejects_empty_evidence_type(self) -> None:
+        with self.assertRaises(ValidationError):
+            EvidenceRef(evidence_type="", evidence_id="x")
+
+    def test_rejects_empty_evidence_id(self) -> None:
+        with self.assertRaises(ValidationError):
+            EvidenceRef(evidence_type="T", evidence_id="")
+
+    def test_rejects_whitespace_only_evidence_type_after_strip(self) -> None:
+        with self.assertRaises(ValidationError):
+            EvidenceRef(evidence_type="   ", evidence_id="x")
+
+    def test_rejects_whitespace_only_evidence_id_after_strip(self) -> None:
+        with self.assertRaises(ValidationError):
+            EvidenceRef(evidence_type="T", evidence_id="  \t  ")
+
+    def test_strips_and_accepts_padded_non_empty_strings(self) -> None:
+        ref = EvidenceRef(evidence_type="  TYPE  ", evidence_id="  id-1  ")
+        self.assertEqual(ref.evidence_type, "TYPE")
+        self.assertEqual(ref.evidence_id, "id-1")
+
+    def test_extra_fields_forbidden(self) -> None:
+        with self.assertRaises(ValidationError):
+            EvidenceRef(
+                evidence_type="T",
+                evidence_id="i",
+                unexpected="no",
+            )
+
+    def test_frozen_model(self) -> None:
+        ref = EvidenceRef(evidence_type="T", evidence_id="i")
+        with self.assertRaises(ValidationError):
+            ref.evidence_type = "other"  # type: ignore[misc]

--- a/work_items/done/WI-2.1.6-shared-evidence-ref-extraction.md
+++ b/work_items/done/WI-2.1.6-shared-evidence-ref-extraction.md
@@ -1,0 +1,79 @@
+# WI-2.1.6
+
+## Linked PRD
+
+PRD-2.1 (EvidenceRef schema and validation rules; gap closure in “Reuse and gap analysis” / “Open questions”)
+
+## Linked ADRs
+
+- ADR-003
+- ADR-002 (replay-stable contracts; no semantic change to evidence shape)
+
+## Linked shared infra
+
+- `docs/shared_infra/index.md`
+- `docs/shared_infra/adoption_matrix.md`
+
+## Purpose
+
+Close the documented cross-module gap: implement a **repo-wide shared** typed `EvidenceRef` in `src/shared/` per ADR-003, matching PRD-2.1 field names and validation rules, and migrate `controls_integrity` off the module-local class so walkers and future modules can import one canonical type without copy-paste.
+
+## Scope
+
+- add a small shared module under `src/shared/` (e.g. `src/shared/evidence.py` or `src/shared/contracts/evidence.py`) defining `EvidenceRef` with the **same** fields and invariants as today’s module-local model:
+  - `evidence_type`, `evidence_id`, `source_as_of_date`, `snapshot_id`
+  - non-empty `evidence_type` and `evidence_id` after strip
+  - `ConfigDict(extra="forbid", frozen=True, str_strip_whitespace=True)` consistent with existing patterns
+- remove the duplicate class from `src/modules/controls_integrity/contracts/models.py`; import shared `EvidenceRef` there so `ControlCheckResult`, `NormalizedControlRecord`, and service code keep working unchanged at the **semantic** level (JSON/schema equivalence for existing fixtures and replay artifacts)
+- re-export `EvidenceRef` from `src/modules/controls_integrity/contracts/__init__.py` and package `__init__.py` as today (import from shared under the hood) unless review prefers direct shared imports only — prefer minimal public API churn for callers
+- export `EvidenceRef` from `src/shared/__init__.py` when consistent with existing `src/shared` export style
+- update `docs/shared_infra/adoption_matrix.md` with a row for `src/modules/controls_integrity/` → shared evidence contract → `adopted` (or `partial` if only this module migrates in this slice; state honestly)
+- add or adjust **unit tests** so shared-model validation is covered (at least the non-empty field rules); keep existing `controls_integrity` contract and replay tests green
+
+## Out of scope
+
+- changing PRD-2.1 evidence rules or adding new evidence fields
+- migrating other modules (e.g. risk_analytics) to shared `EvidenceRef` in this slice
+- Data Controller Walker, orchestrators, UI
+- telemetry changes (not required for this WI)
+- FRTB / PLA or any new check types
+
+## Dependencies
+
+- WI-2.1.1-controls-integrity-contracts-and-enums (merged)
+- WI-2.1.5-shared-normalized-control-check-semantics (merged)
+
+## Target area
+
+- `src/shared/` (new evidence contract module + `__init__.py` exports as needed)
+- `src/modules/controls_integrity/contracts/models.py`
+- `src/modules/controls_integrity/contracts/__init__.py`
+- `src/modules/controls_integrity/__init__.py` (only if re-exports change)
+- `docs/shared_infra/adoption_matrix.md`
+- `tests/unit/` (shared evidence tests and/or existing controls_integrity tests)
+
+## Acceptance criteria
+
+- exactly **one** authoritative `EvidenceRef` implementation lives under `src/shared/`; no duplicate definition remains under `controls_integrity/contracts`
+- all existing tests for `controls_integrity` (unit + replay) pass without weakening PRD-2.1 semantics
+- adoption matrix reflects this module’s use of the shared evidence contract
+- no new wall-clock or non-deterministic behavior in validation
+
+## Test intent
+
+- unit tests for invalid `EvidenceRef` payloads on the shared model (empty type/id)
+- regression: full existing `controls_integrity` test suite and any replay tests touching integrity assessments
+
+## Review focus
+
+- contract fidelity to PRD-2.1 `EvidenceRef` section
+- boundary discipline: shared type only; trust aggregation and walker logic untouched
+- import hygiene: avoid circular dependencies between `src/shared` and modules
+
+## Suggested agent
+
+Coding Agent
+
+## Residual notes for PM / downstream
+
+After this lands, **Data Controller Walker** work still needs Issue Planner / PRD alignment: `docs/prd_exemplars/PRD-4.1-data-controller-walker.md` is an exemplar and names `TrustAssessment` with fields not 1:1 with `IntegrityAssessment`; do not start walker coding until a bounded WI maps service output to walker contracts without inventing semantics.

--- a/work_items/done/WI-2.1.6-shared-evidence-ref-extraction.md
+++ b/work_items/done/WI-2.1.6-shared-evidence-ref-extraction.md
@@ -20,7 +20,7 @@ Close the documented cross-module gap: implement a **repo-wide shared** typed `E
 
 ## Scope
 
-- add a small shared module under `src/shared/` (e.g. `src/shared/evidence.py` or `src/shared/contracts/evidence.py`) defining `EvidenceRef` with the **same** fields and invariants as today’s module-local model:
+- add a small shared module at `src/shared/evidence.py` defining `EvidenceRef` with the **same** fields and invariants as today’s module-local model:
   - `evidence_type`, `evidence_id`, `source_as_of_date`, `snapshot_id`
   - non-empty `evidence_type` and `evidence_id` after strip
   - `ConfigDict(extra="forbid", frozen=True, str_strip_whitespace=True)` consistent with existing patterns


### PR DESCRIPTION
## Summary
Implements [WI-2.1.6](work_items/done/WI-2.1.6-shared-evidence-ref-extraction.md): single canonical `EvidenceRef` in `src/shared/evidence.py` per PRD-2.1 / ADR-003; `controls_integrity` imports and re-exports without duplicate definition.

## Changes
- New `src/shared/evidence.py`: frozen pydantic model, `extra=forbid`, `str_strip_whitespace`, non-empty `evidence_type` / `evidence_id` after strip.
- `models.py` / `contracts/__init__.py`: import `EvidenceRef` from `src.shared`; removed local class from `models.py`.
- `src/shared/__init__.py`: export `EvidenceRef`.
- `docs/shared_infra/adoption_matrix.md`: row for controls_integrity → shared evidence contract (`adopted`).
- WI text avoids non-existent `src/shared/contracts/evidence.py` paths (keeps drift `reference_integrity` clean).
- Tests: `tests/unit/shared/test_evidence_ref.py`; `test_contracts.py` asserts contracts export is same class as `src.shared.EvidenceRef`.

## Verification
- `pytest tests/unit/shared/test_evidence_ref.py tests/unit/modules/controls_integrity/ tests/replay/controls_integrity/`
- `mypy src/ agent_runtime/`

Made with [Cursor](https://cursor.com)
