### PR TITLE
chore: coding→review handoff alignment; WI-4.1.1 / WI-4.1.2 backlog

### DIFF
--- a/prompts/agents/coding_agent_instruction.md
+++ b/prompts/agents/coding_agent_instruction.md
@@ -183,7 +183,7 @@ Print a single copy-paste-ready block for the operator to paste into a fresh age
 
 ### If the PR is open and CI is passing
 
-Print one block in this shape:
+Print one block that matches `prompts/agents/invocation_templates/review_invocation.md` in full (same sections and order). Do not drop the **Work-item lifecycle** block. Example shape:
 
 ```text
 Paste this into a FRESH Review Agent session (new chat / new Codex session):
@@ -195,6 +195,8 @@ Work from current `main`, then checkout the PR head.
 Read:
 - AGENTS.md
 - prompts/agents/review_agent_instruction.md
+- docs/shared_infra/index.md
+- [relevant shared_infra docs for this slice, or omit line if none]
 - [path to work item file]
 - [path to linked PRD]
 - [ADR paths used in this slice]
@@ -214,6 +216,9 @@ Review against:
 5. replay and evidence behavior
 6. test sufficiency
 7. Gemini and Copilot review comments if present
+
+Work-item lifecycle (PASS only):
+- If your verdict is **PASS** and you **APPROVE** the PR, you must move the linked work item from `work_items/in_progress/` to `work_items/done/` **on the PR branch**, commit, and **push to the PR** so the merge includes that lifecycle update. Follow `prompts/agents/review_agent_instruction.md` → "GitHub actions required during review" → step 4. Skip if not PASS or if the WI is already in `done/`.
 
 Return:
 1. pass or fail recommendation

--- a/prompts/agents/coding_agent_instruction.md
+++ b/prompts/agents/coding_agent_instruction.md
@@ -183,7 +183,7 @@ Print a single copy-paste-ready block for the operator to paste into a fresh age
 
 ### If the PR is open and CI is passing
 
-Print one block that matches `prompts/agents/invocation_templates/review_invocation.md` in full (same sections and order). Do not drop the **Work-item lifecycle** block. Example shape:
+Print one block that matches `prompts/agents/invocation_templates/review_invocation.md` in full (same sections and order), through **Return** item 6. Do not drop the **Work-item lifecycle** block. Example (fill `[bracketed values]`; structure must not be shortened):
 
 ```text
 Paste this into a FRESH Review Agent session (new chat / new Codex session):
@@ -218,7 +218,7 @@ Review against:
 7. Gemini and Copilot review comments if present
 
 Work-item lifecycle (PASS only):
-- If your verdict is **PASS** and you **APPROVE** the PR, you must move the linked work item from `work_items/in_progress/` to `work_items/done/` **on the PR branch**, commit, and **push to the PR** so the merge includes that lifecycle update. Follow `prompts/agents/review_agent_instruction.md` → "GitHub actions required during review" → step 4. Skip if not PASS or if the WI is already in `done/`.
+- If your verdict is **PASS** and you **APPROVE** the PR, you must move the linked work item from `work_items/in_progress/` or `work_items/ready/` to `work_items/done/` **on the PR branch**, commit, and **push to the PR** so the merge includes that lifecycle update. Follow `prompts/agents/review_agent_instruction.md` → "GitHub actions required during review" → step 4. Skip if not PASS or if the WI is already in `done/`.
 
 Return:
 1. pass or fail recommendation

--- a/prompts/agents/coding_agent_instruction.md
+++ b/prompts/agents/coding_agent_instruction.md
@@ -183,7 +183,7 @@ Print a single copy-paste-ready block for the operator to paste into a fresh age
 
 ### If the PR is open and CI is passing
 
-Print one block that matches `prompts/agents/invocation_templates/review_invocation.md` in full (same sections and order), through **Return** item 6. Do not drop the **Work-item lifecycle** block. Example (fill `[bracketed values]`; structure must not be shortened):
+Print one block that matches `prompts/agents/invocation_templates/review_invocation.md` in full (same sections and order), through **Return** item 6. Do not drop the **Work-item lifecycle** block. The body (after the paste header below) must be a **verbatim** copy of the template from “You are the Review Agent…” through item 6 under **Return**; only substitute the `<…>` placeholders (and `PR #<PR_NUMBER>` / `branch: <BRANCH_NAME>`) with concrete values—do not paraphrase headings or bullet labels.
 
 ```text
 Paste this into a FRESH Review Agent session (new chat / new Codex session):
@@ -196,17 +196,17 @@ Read:
 - AGENTS.md
 - prompts/agents/review_agent_instruction.md
 - docs/shared_infra/index.md
-- [relevant shared_infra docs for this slice, or omit line if none]
-- [path to work item file]
-- [path to linked PRD]
-- [ADR paths used in this slice]
+- <RELEVANT_SHARED_INFRA_DOCS>
+- <ASSIGNED_WORK_ITEM>
+- <LINKED_PRD>
+- <LINKED_ADRS>
 
 Review target:
-- PR #[PR number]
-- branch: [branch name]
+- PR #<PR_NUMBER>
+- branch: <BRANCH_NAME>
 
 Context:
-[One sentence: what this PR implements and any concerns the review agent should know]
+<CONTEXT — what the PR implements, any known concerns>
 
 Review against:
 1. scope fidelity to the linked work item
@@ -229,7 +229,7 @@ Return:
 6. required changes before merge
 ```
 
-Replace every `[bracketed value]` with the actual value before printing.
+Replace every `<…>` placeholder (and the `PR #` / `branch:` tokens) with concrete values before printing. If no extra shared-infra doc applies beyond `docs/shared_infra/index.md`, replace `<RELEVANT_SHARED_INFRA_DOCS>` with the best-matching path or follow `review_agent_instruction.md`.
 
 ### If CI is failing
 

--- a/prompts/agents/invocation_templates/review_invocation.md
+++ b/prompts/agents/invocation_templates/review_invocation.md
@@ -30,7 +30,7 @@ Review against:
 7. Gemini and Copilot review comments if present
 
 Work-item lifecycle (PASS only):
-- If your verdict is **PASS** and you **APPROVE** the PR, you must move the linked work item from `work_items/in_progress/` to `work_items/done/` **on the PR branch**, commit, and **push to the PR** so the merge includes that lifecycle update. Follow `prompts/agents/review_agent_instruction.md` → "GitHub actions required during review" → step 4. Skip if not PASS or if the WI is already in `done/`.
+- If your verdict is **PASS** and you **APPROVE** the PR, you must move the linked work item from `work_items/in_progress/` or `work_items/ready/` to `work_items/done/` **on the PR branch**, commit, and **push to the PR** so the merge includes that lifecycle update. Follow `prompts/agents/review_agent_instruction.md` → "GitHub actions required during review" → step 4. Skip if not PASS or if the WI is already in `done/`.
 
 Return:
 1. pass or fail recommendation

--- a/work_items/blocked/WI-4.1.2-data-controller-walker-delegate-slice.md
+++ b/work_items/blocked/WI-4.1.2-data-controller-walker-delegate-slice.md
@@ -1,0 +1,98 @@
+# WI-4.1.2
+
+## Status
+
+**BLOCKED** — gated on acceptance of WI-4.1.1 (implementation PRD on `main`).
+
+## Blocker
+
+- `docs/prds/phase-2/PRD-4.1-data-controller-walker-v1.md` (or the actual merged filename from WI-4.1.1) must be merged and treated as stable implementation contract.
+
+**Owner:** PRD / Spec Author completes WI-4.1.1 → human merge → PM moves this WI to `ready/`.
+
+## Linked PRD
+
+- **WI-4.1.1 deliverable:** `docs/prds/phase-2/PRD-4.1-data-controller-walker-v1.md` (path finalized when WI-4.1.1 lands)
+- PRD-2.1 (`docs/prds/phase-2/PRD-2.1-controls-production-integrity-assessment-service.md`) — service semantics unchanged
+
+## Linked ADRs
+
+- ADR-002
+- ADR-003
+
+## Linked shared infra
+
+- `docs/shared_infra/index.md`
+- `docs/shared_infra/adoption_matrix.md`
+
+## Purpose
+
+First **coding** slice for Data Controller Walker: a **thin** implementation under `src/walkers/data_controller/` that delegates **only** to the public `controls_integrity` service API (`get_integrity_assessment`), returning the same typed `IntegrityAssessment | ServiceError` union, with unit tests proving **parity** versus calling the service directly under identical fixture/index inputs.
+
+## Scope
+
+- Add `src/walkers/data_controller/` package (module layout consistent with repo patterns) exposing a single clear entry point (name per WI-4.1.1 PRD — e.g. a function or small façade) that:
+  - Calls **only** the public API `get_integrity_assessment` from `controls_integrity` (or package export path defined in PRD-4.1 v1).
+  - Does **not** duplicate trust aggregation, check ordering, reason-code logic, or evidence validation (all remain in `src/modules/controls_integrity`).
+  - Passes through fixture indices / parameters exactly as the service expects (no hidden defaults beyond what the service documents).
+- Unit tests that assert **byte-for-byte or model-equal** parity: for a representative matrix of inputs (success + representative `ServiceError` paths), walker output equals direct `get_integrity_assessment` output.
+- Package `__init__` / exports as appropriate for a walker root per existing `src/walkers/README.md` intent.
+
+## Out of scope
+
+- Changing PRD-2.1 or service behavior
+- Trust logic in the walker (any interpretation beyond pass-through)
+- `TrustAssessment`, `supporting_findings`, `recommended_next_step`, or other exemplar-only constructs not mandated by WI-4.1.1 PRD
+- Orchestrators, UI, telemetry wiring
+- Replay harness changes unless PRD-4.1 v1 explicitly requires (default: no)
+
+## Dependencies
+
+- **WI-4.1.1** — implementation PRD merged (blocking)
+- WI-2.1.3 — merged
+- WI-2.1.6 — merged
+- PRD-2.1, ADR-002, ADR-003
+
+## Target area
+
+- `src/walkers/data_controller/` (new)
+- `tests/unit/walkers/data_controller/` (or repo-standard test path for walkers)
+
+## Acceptance criteria
+
+- Walker entry point returns **`IntegrityAssessment | ServiceError`** only (same types as `get_integrity_assessment`); no parallel error or “wrapper” trust type.
+- No imports of private service internals (only public module API as defined in WI-4.1.1 PRD).
+- Unit tests demonstrate parity vs direct service calls for all cases exercised in the test matrix (minimum: at least one full success assessment, and one case each for `MISSING_SNAPSHOT`, `MISSING_NODE`, `MISSING_CONTROL_CONTEXT` if reachable with existing fixtures, or the maximal subset the PRD allows without inventing fixtures).
+- Lint/typecheck clean; no new non-deterministic behavior.
+
+## Test intent
+
+- Parametrized or table-driven tests: same args → walker vs service → equal results (`==` on models or structured dict equivalence per existing test patterns).
+
+## Review focus
+
+- Boundary discipline: walker is a façade, not a second trust engine
+- Import hygiene: public API only
+- Test sufficiency for parity claim
+
+## Suggested agent
+
+Coding Agent (after unblock)
+
+## READY_CRITERIA (checklist — work_items/READY_CRITERIA.md)
+
+*Blocked until WI-4.1.1 completes; when unblocked, all must hold:*
+
+1. **Linked contract** — WI-4.1.1 PRD exists on `main` and is linked at top of this file (update path if filename differs).
+2. **Scope clarity** — Pass-through + parity tests only.
+3. **Dependency clarity** — WI-4.1.1 merged; service and contracts stable.
+4. **Target location** — `src/walkers/data_controller/`, tests alongside walker unit tests.
+5. **Acceptance clarity** — Parity and typed union criteria above.
+6. **Test clarity** — Unit tests, parity matrix explicit in PRD/WI.
+7. **Evidence / replay** — No change to replay artifacts unless PRD requires; walker adds no new snapshot semantics.
+8. **Decision closure** — Walker behavior fully specified by WI-4.1.1 PRD + PRD-2.1.
+9. **Shared infra** — None required for this slice unless PRD mandates telemetry row in adoption matrix (default: no matrix update).
+
+## Residual notes for PM / downstream
+
+After WI-4.1.2 merges, consider telemetry/adoption matrix row for `src/walkers/` when a separate WI introduces walker telemetry.

--- a/work_items/blocked/WI-4.1.2-data-controller-walker-delegate-slice.md
+++ b/work_items/blocked/WI-4.1.2-data-controller-walker-delegate-slice.md
@@ -12,8 +12,9 @@
 
 ## Linked PRD
 
-- **WI-4.1.1 deliverable:** PRD-4.1-data-controller-walker-v1.md under docs/prds/phase-2/ (exact filename finalized when WI-4.1.1 lands)
-- PRD-2.1 (`docs/prds/phase-2/PRD-2.1-controls-production-integrity-assessment-service.md`) — service semantics unchanged
+docs/prds/phase-2/PRD-4.1-data-controller-walker-v1.md
+
+Planned implementation PRD path (file appears after WI-4.1.1-data-controller-walker-v1-implementation-prd completes; plain text only — no backticks on this path until the file exists). Service semantics: [PRD-2.1](docs/prds/phase-2/PRD-2.1-controls-production-integrity-assessment-service.md).
 
 ## Linked ADRs
 
@@ -48,10 +49,20 @@ First **coding** slice for Data Controller Walker: a **thin** implementation in 
 
 ## Dependencies
 
-- **WI-4.1.1** — implementation PRD merged (blocking)
-- WI-2.1.3 — merged
-- WI-2.1.6 — merged
-- PRD-2.1, ADR-002, ADR-003
+Blocking (not in done/ until WI-4.1.1 merges):
+
+- WI-4.1.1-data-controller-walker-v1-implementation-prd
+
+Merged prerequisites:
+
+- WI-2.1.3-integrity-assessment-service
+- WI-2.1.6-shared-evidence-ref-extraction
+
+Canon (not WI-gated by runtime):
+
+- PRD-2.1
+- ADR-002
+- ADR-003
 
 ## Target area
 

--- a/work_items/blocked/WI-4.1.2-data-controller-walker-delegate-slice.md
+++ b/work_items/blocked/WI-4.1.2-data-controller-walker-delegate-slice.md
@@ -6,13 +6,13 @@
 
 ## Blocker
 
-- `docs/prds/phase-2/PRD-4.1-data-controller-walker-v1.md` (or the actual merged filename from WI-4.1.1) must be merged and treated as stable implementation contract.
+- The WI-4.1.1 deliverable PRD file under docs/prds/phase-2/ (expected name PRD-4.1-data-controller-walker-v1.md unless WI-4.1.1 chooses another filename) must be merged and treated as stable implementation contract.
 
 **Owner:** PRD / Spec Author completes WI-4.1.1 → human merge → PM moves this WI to `ready/`.
 
 ## Linked PRD
 
-- **WI-4.1.1 deliverable:** `docs/prds/phase-2/PRD-4.1-data-controller-walker-v1.md` (path finalized when WI-4.1.1 lands)
+- **WI-4.1.1 deliverable:** PRD-4.1-data-controller-walker-v1.md under docs/prds/phase-2/ (exact filename finalized when WI-4.1.1 lands)
 - PRD-2.1 (`docs/prds/phase-2/PRD-2.1-controls-production-integrity-assessment-service.md`) — service semantics unchanged
 
 ## Linked ADRs
@@ -27,11 +27,11 @@
 
 ## Purpose
 
-First **coding** slice for Data Controller Walker: a **thin** implementation under `src/walkers/data_controller/` that delegates **only** to the public `controls_integrity` service API (`get_integrity_assessment`), returning the same typed `IntegrityAssessment | ServiceError` union, with unit tests proving **parity** versus calling the service directly under identical fixture/index inputs.
+First **coding** slice for Data Controller Walker: a **thin** implementation in a new **data_controller** package under `src/walkers/` (package path is created by this WI; do not cite the full path in backticks until it exists) that delegates **only** to the public `controls_integrity` service API (`get_integrity_assessment`), returning the same typed `IntegrityAssessment | ServiceError` union, with unit tests proving **parity** versus calling the service directly under identical fixture/index inputs.
 
 ## Scope
 
-- Add `src/walkers/data_controller/` package (module layout consistent with repo patterns) exposing a single clear entry point (name per WI-4.1.1 PRD — e.g. a function or small façade) that:
+- Add the **data_controller** package under `src/walkers/` (module layout consistent with repo patterns) exposing a single clear entry point (name per WI-4.1.1 PRD — e.g. a function or small façade) that:
   - Calls **only** the public API `get_integrity_assessment` from `controls_integrity` (or package export path defined in PRD-4.1 v1).
   - Does **not** duplicate trust aggregation, check ordering, reason-code logic, or evidence validation (all remain in `src/modules/controls_integrity`).
   - Passes through fixture indices / parameters exactly as the service expects (no hidden defaults beyond what the service documents).
@@ -55,8 +55,8 @@ First **coding** slice for Data Controller Walker: a **thin** implementation und
 
 ## Target area
 
-- `src/walkers/data_controller/` (new)
-- `tests/unit/walkers/data_controller/` (or repo-standard test path for walkers)
+- New package **data_controller** under `src/walkers/`
+- Matching unit tests under tests/unit/walkers/ (e.g. a data_controller test package created alongside implementation; exact layout per repo convention)
 
 ## Acceptance criteria
 
@@ -86,7 +86,7 @@ Coding Agent (after unblock)
 1. **Linked contract** — WI-4.1.1 PRD exists on `main` and is linked at top of this file (update path if filename differs).
 2. **Scope clarity** — Pass-through + parity tests only.
 3. **Dependency clarity** — WI-4.1.1 merged; service and contracts stable.
-4. **Target location** — `src/walkers/data_controller/`, tests alongside walker unit tests.
+4. **Target location** — data_controller package under `src/walkers/`, tests under tests/unit/walkers/ per convention.
 5. **Acceptance clarity** — Parity and typed union criteria above.
 6. **Test clarity** — Unit tests, parity matrix explicit in PRD/WI.
 7. **Evidence / replay** — No change to replay artifacts unless PRD requires; walker adds no new snapshot semantics.

--- a/work_items/ready/WI-4.1.1-data-controller-walker-v1-implementation-prd.md
+++ b/work_items/ready/WI-4.1.1-data-controller-walker-v1-implementation-prd.md
@@ -2,7 +2,7 @@
 
 ## Linked PRD (deliverable)
 
-**Primary artifact (to be authored by this work item):** `docs/prds/phase-2/PRD-4.1-data-controller-walker-v1.md`
+**Primary artifact (to be authored by this work item):** PRD-4.1-data-controller-walker-v1.md under docs/prds/phase-2/ (path does not exist until this WI lands; avoid backtick path literals in work items so drift reference_integrity stays green).
 
 **Upstream contracts (read-only, must not change semantics):**
 
@@ -28,7 +28,7 @@ Lock **Data Controller Walker v1** to a **typed pass-through** of `get_integrity
 
 ## Scope
 
-- Add a new **implementation PRD** under `docs/prds/phase-2/` (filename per repo convention, e.g. `PRD-4.1-data-controller-walker-v1.md`) that:
+- Add a new **implementation PRD** under `docs/prds/phase-2/` (filename per repo convention, e.g. PRD-4.1-data-controller-walker-v1.md) that:
   - Defines walker v1 responsibility as **delegation only** to the public `controls_integrity` API (`get_integrity_assessment` and its documented contracts).
   - States that the walker’s governed output type(s) are **the same** typed union as the service surface: success is `IntegrityAssessment`; failure paths use the existing typed `ServiceError` envelope (no parallel “walker trust” model).
   - Explicitly **rejects** normative use of exemplar-only concepts: no `TrustAssessment` aggregate as canonical output, no required `supporting_findings` or `recommended_next_step` fields for v1 unless PRD-2.1 / module contracts already provide them (they do not for the service — do not invent).

--- a/work_items/ready/WI-4.1.1-data-controller-walker-v1-implementation-prd.md
+++ b/work_items/ready/WI-4.1.1-data-controller-walker-v1-implementation-prd.md
@@ -1,0 +1,94 @@
+# WI-4.1.1
+
+## Linked PRD (deliverable)
+
+**Primary artifact (to be authored by this work item):** `docs/prds/phase-2/PRD-4.1-data-controller-walker-v1.md`
+
+**Upstream contracts (read-only, must not change semantics):**
+
+- PRD-2.1 (`docs/prds/phase-2/PRD-2.1-controls-production-integrity-assessment-service.md`)
+
+## Linked ADRs
+
+- ADR-002 (replay and snapshot model)
+- ADR-003 (evidence and trace model)
+
+## Linked shared infra
+
+- `docs/shared_infra/index.md`
+- `docs/shared_infra/adoption_matrix.md`
+
+## Non-binding background
+
+- `docs/prd_exemplars/PRD-4.1-data-controller-walker.md` (exemplar only; v1 PRD must **not** adopt `TrustAssessment`, `supporting_findings`, or `recommended_next_step` as normative walker output)
+
+## Purpose
+
+Lock **Data Controller Walker v1** to a **typed pass-through** of `get_integrity_assessment` results: `IntegrityAssessment | ServiceError`, with explicit boundaries so coding agents do not invent trust semantics or exemplar-only fields.
+
+## Scope
+
+- Add a new **implementation PRD** under `docs/prds/phase-2/` (filename per repo convention, e.g. `PRD-4.1-data-controller-walker-v1.md`) that:
+  - Defines walker v1 responsibility as **delegation only** to the public `controls_integrity` API (`get_integrity_assessment` and its documented contracts).
+  - States that the walker’s governed output type(s) are **the same** typed union as the service surface: success is `IntegrityAssessment`; failure paths use the existing typed `ServiceError` envelope (no parallel “walker trust” model).
+  - Explicitly **rejects** normative use of exemplar-only concepts: no `TrustAssessment` aggregate as canonical output, no required `supporting_findings` or `recommended_next_step` fields for v1 unless PRD-2.1 / module contracts already provide them (they do not for the service — do not invent).
+  - Cross-references PRD-2.1 for all trust-state, check, evidence, and degraded semantics; **no change** to PRD-2.1 wording or service semantics.
+  - States replay/evidence expectations consistent with ADR-002 and ADR-003 (propagation of snapshot/version context as already required by the service output).
+- Optionally add a one-line pointer in `docs/catalog/walkers.md` or a “Related PRD” note only if the repo’s doc style requires it for discoverability (keep diff minimal).
+
+## Out of scope
+
+- Any edit that changes PRD-2.1 trust or integrity semantics
+- Implementation under `src/walkers/` or `src/modules/` (coding is WI-4.1.2+)
+- Orchestrators, UI, telemetry adoption work
+- FRTB / PLA or new check types
+- Normative adoption of exemplar `TrustAssessment` / handoff narrative fields for v1
+
+## Dependencies
+
+- WI-2.1.3 (integrity assessment service) — merged
+- WI-2.1.6 (shared `EvidenceRef`; module re-export) — merged
+- PRD-2.1 stable on `main`
+
+## Target area
+
+- `docs/prds/phase-2/` (new PRD file)
+- Optional: `docs/catalog/walkers.md` (discovery only, minimal)
+
+## Acceptance criteria
+
+- New PRD exists, is numbered/titled consistently with Phase 2 PRDs, and is implementation-ready (typed outputs, error union, no ambiguity that would force coding to invent semantics).
+- Walker v1 is defined as **pass-through** of `IntegrityAssessment | ServiceError` from the public service API only.
+- Exemplar-only fields (`TrustAssessment`, `supporting_findings`, `recommended_next_step`) are explicitly out of scope for v1 or deferred with **no** implied contract for the first coding slice.
+- PRD-2.1 is cited as the sole source of trust/integrity semantics; no conflicting parallel definitions.
+- Open Questions lists any future v2+ topics (e.g. richer walker narrative) without blocking v1 implementation.
+
+## Test intent
+
+- Documentation-only: review agent verifies contract alignment with PRD-2.1, ADR-002/003, and WI-4.1.2 readiness (no missing typed pass-through definition).
+
+## Review focus
+
+- No accidental widening into exemplar semantics
+- No PRD-2.1 drift
+- Clear handoff to WI-4.1.2 (walker code = thin delegate + tests)
+
+## Suggested agent
+
+PRD / Spec Author
+
+## READY_CRITERIA (checklist — work_items/READY_CRITERIA.md)
+
+1. **Linked contract** — Delivers new PRD file under `docs/prds/phase-2/`; links PRD-2.1 as upstream service canon without altering it.
+2. **Scope clarity** — Pass-through only; explicit exclusion of exemplar-only output shapes.
+3. **Dependency clarity** — Service and shared evidence work complete (WI-2.1.3, WI-2.1.6); PRD-2.1 stable.
+4. **Target location** — `docs/prds/phase-2/` (+ optional catalog pointer).
+5. **Acceptance clarity** — Criteria above are reviewable without guesswork.
+6. **Test clarity** — Doc review + PRD/spec agent self-check; no code tests in this WI.
+7. **Evidence / replay** — PRD states walker defers to service outputs that already carry replay/evidence metadata per ADR-002/003.
+8. **Decision closure** — No new ADR required unless spec author discovers a cross-cutting gap (escalate to PM/human).
+9. **Shared infra** — Declare if walker PRD references shared evidence types only via PRD-2.1 / `controls_integrity` exports (no new shared-infra behavior).
+
+## Residual notes for PM / downstream
+
+- **WI-4.1.2 remains blocked** until this PRD is accepted on `main`. After merge, promote WI-4.1.2 from `blocked/` to `ready/` (or equivalent relay step).

--- a/work_items/ready/WI-4.1.1-data-controller-walker-v1-implementation-prd.md
+++ b/work_items/ready/WI-4.1.1-data-controller-walker-v1-implementation-prd.md
@@ -1,12 +1,10 @@
 # WI-4.1.1
 
-## Linked PRD (deliverable)
+## Linked PRD
 
-**Primary artifact (to be authored by this work item):** PRD-4.1-data-controller-walker-v1.md under docs/prds/phase-2/ (path does not exist until this WI lands; avoid backtick path literals in work items so drift reference_integrity stays green).
+PRD-4.1-data-controller-walker-v1 (primary deliverable: author the implementation PRD under docs/prds/phase-2/; do not use backtick-wrapped paths to not-yet-created files — reference_integrity flags them).
 
-**Upstream contracts (read-only, must not change semantics):**
-
-- PRD-2.1 (`docs/prds/phase-2/PRD-2.1-controls-production-integrity-assessment-service.md`)
+Upstream service contract (read-only; must not change semantics): [`docs/prds/phase-2/PRD-2.1-controls-production-integrity-assessment-service.md`](docs/prds/phase-2/PRD-2.1-controls-production-integrity-assessment-service.md) (PRD-2.1).
 
 ## Linked ADRs
 
@@ -46,9 +44,12 @@ Lock **Data Controller Walker v1** to a **typed pass-through** of `get_integrity
 
 ## Dependencies
 
-- WI-2.1.3 (integrity assessment service) — merged
-- WI-2.1.6 (shared `EvidenceRef`; module re-export) — merged
-- PRD-2.1 stable on `main`
+Merged prerequisite work items:
+
+- WI-2.1.3-integrity-assessment-service
+- WI-2.1.6-shared-evidence-ref-extraction
+
+PRD-2.1 is stable on main (not a WI dependency for runtime gating).
 
 ## Target area
 


### PR DESCRIPTION
## Summary

- **Coding agent instruction:** When handing off to Review (PR open, CI passing), the printed block must match `prompts/agents/invocation_templates/review_invocation.md` in full, including the **Work-item lifecycle** section. Adds shared-infra reads to the example and explicit PASS instructions to move the work item `in_progress` → `done` on the PR branch per `review_agent_instruction.md`.
- **Work items:** Adds WI-4.1.1 (Data Controller Walker v1 implementation PRD, `ready/`) and WI-4.1.2 (thin delegate slice, `blocked/` until 4.1.1 merges).

## Review focus

- Prompt wording matches `review_invocation.md` and does not contradict PM/review agent instructions.
- WI dependency and scope text align with PRD-2.1 pass-through (`IntegrityAssessment | ServiceError`) and exemplar non-binding note.

Made with [Cursor](https://cursor.com)