### PR TITLE
WI-4.1.4: Data Controller walker telemetry adoption

### DIFF
--- a/docs/shared_infra/adoption_matrix.md
+++ b/docs/shared_infra/adoption_matrix.md
@@ -16,7 +16,7 @@ Track shared-infrastructure usage, owners, and rollout state by layer.
 | --- | --- | --- | --- |
 | `src/modules/controls_integrity/` | shared evidence contract (`EvidenceRef` in `src/shared/evidence.py`) | adopted | Module imports canonical type from `src.shared`; re-exported via `controls_integrity.contracts` for stable public API (WI-2.1.6) |
 | `src/modules/risk_analytics/` | telemetry contract | planned | No module-local telemetry helper exists under `src/` today; adoption pending tracked implementation work items against `docs/shared_infra/telemetry.md` |
-| `src/walkers/` | telemetry contract | planned | Enforce once first walker telemetry WI lands |
+| `src/walkers/` | telemetry contract | adopted | `data_controller` walker emits via `src.shared.telemetry.emit_operation` (WI-4.1.4) |
 | `src/orchestrators/` | telemetry contract | planned | Keep orchestration concerns separate from deterministic services |
 | `agent_runtime/` | telemetry framework | adopted | Canonical runtime implementation; design reference only for `src/` |
 

--- a/src/walkers/data_controller/walker.py
+++ b/src/walkers/data_controller/walker.py
@@ -12,6 +12,7 @@ from src.modules.controls_integrity import (
 from src.modules.risk_analytics.contracts import MeasureType, NodeRef
 from src.modules.risk_analytics.fixtures import FixtureIndex
 from src.shared import ServiceError
+from src.shared.telemetry import emit_operation, node_ref_log_dict, timer_start
 
 
 def assess_integrity(
@@ -24,7 +25,8 @@ def assess_integrity(
     controls_fixture_index: ControlsIntegrityFixtureIndex | None = None,
 ) -> IntegrityAssessment | ServiceError:
     """Delegate to get_integrity_assessment; return its result unchanged."""
-    return get_integrity_assessment(
+    start_time = timer_start()
+    outcome = get_integrity_assessment(
         node_ref,
         measure_type,
         as_of_date,
@@ -32,3 +34,20 @@ def assess_integrity(
         risk_fixture_index=risk_fixture_index,
         controls_fixture_index=controls_fixture_index,
     )
+    status: str
+    if isinstance(outcome, ServiceError):
+        status = outcome.status_code
+    else:
+        status = outcome.assessment_status.value
+
+    emit_operation(
+        "assess_integrity",
+        status=status,
+        start_time=start_time,
+        include_trace_context=False,
+        node_ref=node_ref_log_dict(node_ref),
+        measure_type=measure_type,
+        as_of_date=as_of_date,
+        snapshot_id=snapshot_id,
+    )
+    return outcome

--- a/tests/unit/walkers/data_controller/conftest.py
+++ b/tests/unit/walkers/data_controller/conftest.py
@@ -1,0 +1,15 @@
+"""Shared fixtures for data_controller walker unit tests."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.shared.telemetry import reset_operation_logging_to_defaults
+
+
+@pytest.fixture(autouse=True)
+def _reset_shared_operation_logging() -> None:
+    """Avoid cross-test leakage when tests configure module-level operation logging."""
+    reset_operation_logging_to_defaults()
+    yield
+    reset_operation_logging_to_defaults()

--- a/tests/unit/walkers/data_controller/test_assess_integrity_telemetry.py
+++ b/tests/unit/walkers/data_controller/test_assess_integrity_telemetry.py
@@ -1,0 +1,83 @@
+"""Operation logging for Data Controller walker (WI-4.1.4)."""
+
+from __future__ import annotations
+
+import logging
+from datetime import date
+
+import pytest
+
+from src.modules.controls_integrity.fixtures import build_controls_integrity_fixture_index
+from src.modules.risk_analytics.contracts import HierarchyScope, MeasureType, NodeLevel, NodeRef
+from src.modules.risk_analytics.fixtures import build_fixture_index
+from src.shared.telemetry import LOGGER_NAME, StdlibLoggerAdapter, configure_operation_logging
+from src.walkers.data_controller import assess_integrity
+
+D_02 = date(2026, 1, 2)
+
+
+def _walker_structured_payload(caplog: pytest.LogCaptureFixture) -> dict[str, object]:
+    """Return the structured_event dict for the walker layer (``assess_integrity``)."""
+    for rec in caplog.records:
+        payload = getattr(rec, "structured_event", None)
+        if isinstance(payload, dict) and payload.get("operation") == "assess_integrity":
+            return payload
+    raise AssertionError("expected one operation log for assess_integrity")
+
+
+def _firm_grp() -> NodeRef:
+    return NodeRef(
+        hierarchy_scope=HierarchyScope.TOP_OF_HOUSE,
+        legal_entity_id=None,
+        node_level=NodeLevel.FIRM,
+        node_id="FIRM_GRP",
+        node_name="Firm Group",
+    )
+
+
+def test_walker_emit_status_matches_integrity_assessment(caplog: pytest.LogCaptureFixture) -> None:
+    risk_index = build_fixture_index()
+    controls_index = build_controls_integrity_fixture_index()
+    configure_operation_logging(enabled=True, logger=StdlibLoggerAdapter(LOGGER_NAME))
+    caplog.set_level(logging.INFO, logger=LOGGER_NAME)
+
+    outcome = assess_integrity(
+        node_ref=_firm_grp(),
+        measure_type=MeasureType.VAR_1D_99,
+        as_of_date=D_02,
+        risk_fixture_index=risk_index,
+        controls_fixture_index=controls_index,
+    )
+    payload = _walker_structured_payload(caplog)
+
+    assert payload["status"] == outcome.assessment_status.value
+    assert "trace_id" not in payload
+    assert "span_id" not in payload
+    nr = payload["node_ref"]
+    assert isinstance(nr, dict)
+    assert nr["node_id"] == "FIRM_GRP"
+    assert payload["measure_type"] == MeasureType.VAR_1D_99
+    assert payload["snapshot_id"] is None
+    assert isinstance(payload["duration_ms"], int)
+
+
+def test_walker_emit_status_matches_service_error(caplog: pytest.LogCaptureFixture) -> None:
+    risk_index = build_fixture_index()
+    controls_index = build_controls_integrity_fixture_index()
+    configure_operation_logging(enabled=True, logger=StdlibLoggerAdapter(LOGGER_NAME))
+    caplog.set_level(logging.INFO, logger=LOGGER_NAME)
+
+    outcome = assess_integrity(
+        node_ref=_firm_grp(),
+        measure_type=MeasureType.VAR_1D_99,
+        as_of_date=D_02,
+        snapshot_id="SNAP-NOT-THERE",
+        risk_fixture_index=risk_index,
+        controls_fixture_index=controls_index,
+    )
+    payload = _walker_structured_payload(caplog)
+
+    assert payload["status"] == outcome.status_code
+    assert outcome.status_code == "MISSING_SNAPSHOT"
+    assert "trace_id" not in payload
+    assert "span_id" not in payload


### PR DESCRIPTION
## Summary
Implements WI-4.1.4: one `emit_operation` on the return path of `assess_integrity` with `include_trace_context=False`, status from `ServiceError.status_code` or `IntegrityAssessment.assessment_status.value`.

## Changes
- `src/walkers/data_controller/walker.py`: delegate then emit with `node_ref_log_dict`, `measure_type`, `as_of_date`, `snapshot_id`
- `docs/shared_infra/adoption_matrix.md`: `src/walkers/` row → **adopted** (walkers row only)
- `tests/unit/walkers/data_controller/`: caplog tests for IntegrityAssessment and ServiceError paths; autouse telemetry reset

## Out of scope (per WI)
No changes to `get_integrity_assessment` signature, delegation, or return type.

## Tests
`pytest tests/unit/walkers/data_controller/`


Made with [Cursor](https://cursor.com)