### PR TITLE
WI-4.1.3: adoption matrix — risk_analytics telemetry adopted

### DIFF
--- a/docs/shared_infra/adoption_matrix.md
+++ b/docs/shared_infra/adoption_matrix.md
@@ -15,7 +15,7 @@ Track shared-infrastructure usage, owners, and rollout state by layer.
 | Area | Shared infra item | Status | Notes |
 | --- | --- | --- | --- |
 | `src/modules/controls_integrity/` | shared evidence contract (`EvidenceRef` in `src/shared/evidence.py`) | adopted | Module imports canonical type from `src.shared`; re-exported via `controls_integrity.contracts` for stable public API (WI-2.1.6) |
-| `src/modules/risk_analytics/` | telemetry contract | planned | No module-local telemetry helper exists under `src/` today; adoption pending tracked implementation work items against `docs/shared_infra/telemetry.md` |
+| `src/modules/risk_analytics/` | telemetry contract | adopted | Uses `src.shared.telemetry.emit_operation` (and shared helpers) for PRD minimum operation logs per WI-1.1.11; no module-local duplicate status mapping |
 | `src/walkers/` | telemetry contract | adopted | `data_controller` walker emits via `src.shared.telemetry.emit_operation` (WI-4.1.4) |
 | `src/orchestrators/` | telemetry contract | planned | Keep orchestration concerns separate from deterministic services |
 | `agent_runtime/` | telemetry framework | adopted | Canonical runtime implementation; design reference only for `src/` |

--- a/work_items/done/WI-4.1.3-adoption-matrix-risk-analytics-telemetry.md
+++ b/work_items/done/WI-4.1.3-adoption-matrix-risk-analytics-telemetry.md
@@ -35,7 +35,7 @@ Remove documented drift: `docs/shared_infra/adoption_matrix.md` lists `src/modul
 
 ## Dependencies
 
-- WI-1.1.11 (done) — establishes `risk_analytics` → `src.shared.telemetry` adoption
+- WI-1.1.11-risk-service-structured-logging
 
 ## Target area
 

--- a/work_items/done/WI-4.1.3-adoption-matrix-risk-analytics-telemetry.md
+++ b/work_items/done/WI-4.1.3-adoption-matrix-risk-analytics-telemetry.md
@@ -1,0 +1,66 @@
+# WI-4.1.3
+
+## Linked PRD
+
+PRD-4.1-data-controller-walker-v1 (context only; this slice is shared-infra documentation alignment)
+
+## Linked canon
+
+- `docs/shared_infra/adoption_matrix.md` — target file to update
+- `docs/shared_infra/telemetry.md`
+- `docs/shared_infra/index.md`
+
+## Linked ADRs (informational)
+
+- ADR-002-replay-and-snapshot-model.md (no change)
+- ADR-003-evidence-and-trace-model.md (no change)
+
+## Purpose
+
+Remove documented drift: `docs/shared_infra/adoption_matrix.md` lists `src/modules/risk_analytics/` telemetry as `planned`, but `src/modules/risk_analytics/service.py` already emits structured operation events via `src.shared.telemetry.emit_operation` per completed **WI-1.1.11**. Reconcile the matrix row only—no code changes.
+
+## Scope
+
+- Update the **`src/modules/risk_analytics/`** row in **`docs/shared_infra/adoption_matrix.md`**:
+  - Set **Status** to **`adopted`** (direct use of shared telemetry contract / `emit_operation`).
+  - Replace **Notes** with a short factual reference: telemetry uses `src/shared/telemetry` and the risk analytics operation-log slice is WI-1.1.11 (no module-local duplicate status mapping).
+- Do not edit `src/`, `tests/`, or other docs for this WI.
+
+## Out of scope
+
+- Any change to `src/shared/telemetry/` behavior or APIs
+- Any change to `src/modules/risk_analytics/service.py` or tests
+- Updating the `src/walkers/` or `src/orchestrators/` rows (covered by WI-4.1.4 and WI-4.1.5 respectively)
+- PRD-4.1 text edits (optional follow-up; not required for matrix reconciliation)
+
+## Dependencies
+
+- WI-1.1.11 (done) — establishes `risk_analytics` → `src.shared.telemetry` adoption
+
+## Target area
+
+- `docs/shared_infra/adoption_matrix.md` only
+
+## Acceptance criteria
+
+- `risk_analytics` telemetry row reflects **`adopted`** with notes consistent with existing code (`emit_operation` via shared telemetry, WI-1.1.11).
+- No other matrix rows are changed in this WI.
+- Review can verify against `src/modules/risk_analytics/service.py` imports and `emit_operation` usage.
+
+## Test intent
+
+- Documentation-only slice: manual review against `READY_CRITERIA.md` and grep/spot-check of `emit_operation` in `service.py`.
+
+## Suggested agent
+
+Human operator or Coding Agent (single-file doc edit only—no application code).
+
+## Review focus
+
+- Matrix status matches in-repo usage (`adopted` not `planned`).
+- Notes do not claim helpers that do not exist; do not reintroduce superseded “shared outcome emission helper” wording.
+
+## Stop conditions
+
+- Stop if review finds `risk_analytics` telemetry is not actually wired to `src.shared.telemetry` on current `main` (escalate to PM / drift monitor).
+- Stop if a broader doc refactor is requested—this WI is a single-row fix only.


### PR DESCRIPTION
## Summary

Documentation-only slice: reconcile `docs/shared_infra/adoption_matrix.md` with current code.

## Changes

- Set `src/modules/risk_analytics/` telemetry row status from `planned` to `adopted`.
- Notes reference `src.shared.telemetry.emit_operation`, shared helpers, and WI-1.1.11 (operation logs; no module-local duplicate status mapping).

## Verification

- `src/modules/risk_analytics/service.py` imports and calls `emit_operation` from `src.shared.telemetry` (see `_emit_risk_operation`).

## Linked work item

- WI-4.1.3

## Out of scope (per WI)

- No `src/` or `tests/` changes.

Made with [Cursor](https://cursor.com)