### PR TITLE
chore: clean sync-conflict artifacts and align repo metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,9 @@ secrets/
 # Marp stitched deck (run presentation/build-deck.sh)
 presentation/deck.md
 
+# Sync-conflict markdown duplicates (e.g. "file 2.md")
+.claude/commands/* [0-9].md
+.cursor/skills/**/* [0-9].md
+.github/skills/**/* [0-9].md
+work_items/**/* [0-9].md
+

--- a/.gitignore
+++ b/.gitignore
@@ -58,7 +58,7 @@ secrets/
 presentation/deck.md
 
 # Sync-conflict markdown duplicates (e.g. "file 2.md")
-.claude/commands/* [0-9].md
+.claude/commands/**/* [0-9].md
 .cursor/skills/**/* [0-9].md
 .github/skills/**/* [0-9].md
 work_items/**/* [0-9].md

--- a/docs/registry/current_state_registry.yaml
+++ b/docs/registry/current_state_registry.yaml
@@ -1,5 +1,5 @@
 version: 1
-last_updated: 2026-04-08
+last_updated: 2026-04-18
 
 components:
   modules:
@@ -21,8 +21,8 @@ components:
           path: src/modules/risk_analytics/service.py
           status: implemented
         - name: risk_summary_core_service
-          path: null
-          status: not-started
+          path: src/modules/risk_analytics/service.py
+          status: implemented
     - id: MOD-CONTROLS-INTEGRITY
       name: Controls Integrity
       status: in-progress

--- a/src/modules/README.md
+++ b/src/modules/README.md
@@ -2,11 +2,16 @@
 
 Each module owns deterministic truth for a bounded domain.
 
-Planned module roots:
+Current module roots:
 - risk_analytics/
+- controls_integrity/
+
+The `controls_integrity/` package is the current implementation root for the
+Controls & Production Integrity slice.
+
+Planned additional module roots:
 - frtb_pla_controls/
 - limits_approvals/
-- controls_production_integrity/
 - governance_reporting/
 - capital_desk_status/
 - model_inventory_usage_registry/

--- a/src/modules/README.md
+++ b/src/modules/README.md
@@ -7,7 +7,7 @@ Current module roots:
 - controls_integrity/
 
 The `controls_integrity/` package is the current implementation root for the
-Controls & Production Integrity slice.
+Controls Integrity module tracked in the registry.
 
 Planned additional module roots:
 - frtb_pla_controls/

--- a/tests/README.md
+++ b/tests/README.md
@@ -2,8 +2,11 @@
 
 Current visible test tree:
 - `tests/unit/` for deterministic service and small wrapper tests
+- `tests/replay/` for fixture-backed replay coverage of implemented services
 
-Future slices may add integration, replay, and golden-case test directories when those test types are introduced. They are not part of the current visible test tree and should be created in-slice rather than assumed to already exist.
+Future slices may add integration and golden-case test directories when those
+test types are introduced. They should be created in-slice rather than assumed
+to already exist.
 
 Repo-level `pytest` configuration already exists in `pyproject.toml`, so `pytest` is the default test entrypoint.
 


### PR DESCRIPTION
## Summary
- ignore common sync-conflict markdown duplicates so `* 2.md` artifacts do not keep reappearing in tracked areas
- update the component registry to reflect the implemented `risk_summary_core_service`
- refresh `src/modules/README.md` and `tests/README.md` so the repo's self-description matches the current module and test layout

## Test plan
- [x] `pytest -q tests/unit/agent_runtime/test_registry_alignment.py`
- [x] manual diff review of `.gitignore`, `docs/registry/current_state_registry.yaml`, `src/modules/README.md`, and `tests/README.md`

Made with [Cursor](https://cursor.com)