### PR TITLE
fix(telemetry): wire dispatch audit events and clarify docs

### DIFF
--- a/agent_runtime/orchestrator/graph.py
+++ b/agent_runtime/orchestrator/graph.py
@@ -58,7 +58,7 @@ def _dispatch_with_timeout(execution: RunnerExecution, defaults: RuntimeDefaults
     # shutdown(wait=False) and return immediately without blocking until the thread
     # finishes — which could be minutes for a long-running agent.
     executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
-    future = executor.submit(dispatch_runner_execution, execution)
+    future = executor.submit(dispatch_runner_execution, execution, state_db_path=defaults.state_db_path)
     try:
         result = future.result(timeout=timeout_seconds)
         executor.shutdown(wait=False)
@@ -569,7 +569,7 @@ def main() -> int:
 
                         _empty = _RS(work_items=(), pull_requests=(), workflow_runs=(), warnings=())
                         _exec = _bre(_empty, governance_decision)
-                        _result = dispatch_runner_execution(_exec) if _exec is not None else None
+                        _result = dispatch_runner_execution(_exec, state_db_path=defaults.state_db_path) if _exec is not None else None
                         payload: dict[str, object] = {
                             "action": governance_decision.action.value,
                             "reason": governance_decision.reason,
@@ -670,7 +670,11 @@ def main() -> int:
 
             empty_snapshot = _RS(work_items=(), pull_requests=(), workflow_runs=(), warnings=())
             execution = build_runner_execution(empty_snapshot, governance_decision)
-            runner_result = dispatch_runner_execution(execution) if args.dispatch and execution is not None else None
+            runner_result = (
+                dispatch_runner_execution(execution, state_db_path=defaults.state_db_path)
+                if args.dispatch and execution is not None
+                else None
+            )
             governance_payload: dict[str, object] = {
                 "action": governance_decision.action.value,
                 "reason": governance_decision.reason,

--- a/agent_runtime/orchestrator/graph.py
+++ b/agent_runtime/orchestrator/graph.py
@@ -671,9 +671,7 @@ def main() -> int:
             empty_snapshot = _RS(work_items=(), pull_requests=(), workflow_runs=(), warnings=())
             execution = build_runner_execution(empty_snapshot, governance_decision)
             runner_result = (
-                dispatch_runner_execution(execution, state_db_path=defaults.state_db_path)
-                if args.dispatch and execution is not None
-                else None
+                dispatch_runner_execution(execution, state_db_path=defaults.state_db_path) if args.dispatch and execution is not None else None
             )
             governance_payload: dict[str, object] = {
                 "action": governance_decision.action.value,

--- a/agent_runtime/orchestrator/langgraph_graph.py
+++ b/agent_runtime/orchestrator/langgraph_graph.py
@@ -167,7 +167,7 @@ def _dispatch_node(decision_payload: dict[str, object], *, defaults: RuntimeDefa
     decision = TransitionDecision(action=action, work_item_id=work_item_id, reason=reason)
     snapshot = build_runtime_snapshot(defaults.repo_root, defaults.state_db_path)
     execution = build_runner_execution(snapshot, decision)
-    runner_result = dispatch_runner_execution(execution) if execution is not None else None
+    runner_result = dispatch_runner_execution(execution, state_db_path=defaults.state_db_path) if execution is not None else None
 
     result_dict = (
         {

--- a/agent_runtime/runners/dispatch.py
+++ b/agent_runtime/runners/dispatch.py
@@ -19,53 +19,70 @@ from .spec_runner import dispatch_spec_execution
 def dispatch_runner_execution(execution: RunnerExecution, *, state_db_path: Path | None = None) -> RunnerResult:
     runner_name = execution.runner_name.value
     run_id = execution.metadata.get("run_id")
-    start = time.monotonic()
     component = "agent_runtime.runners.dispatch"
 
-    if state_db_path is not None:
-        emit_audit_event(
-            state_db_path,
-            event_type="runner.dispatch.started",
-            component=component,
-            payload={"runner_name": runner_name},
-            run_id=run_id,
-            work_item_id=execution.work_item_id,
-        )
-
     with runner_span(runner_name, execution.work_item_id, run_id=run_id) as span:
-        if execution.runner_name is RunnerName.PM:
-            result = dispatch_pm_execution(execution)
-        elif execution.runner_name is RunnerName.SPEC:
-            result = dispatch_spec_execution(execution)
-        elif execution.runner_name is RunnerName.ISSUE_PLANNER:
-            result = dispatch_issue_planner_execution(execution)
-        elif execution.runner_name is RunnerName.CODING:
-            result = dispatch_coding_execution(execution)
-        elif execution.runner_name is RunnerName.REVIEW:
-            result = dispatch_review_execution(execution)
-        elif execution.runner_name is RunnerName.DRIFT_MONITOR:
-            result = dispatch_drift_monitor_execution(execution)
-        else:
-            raise RuntimeError(f"unsupported runner dispatch target: {execution.runner_name}")
+        if state_db_path is not None:
+            emit_audit_event(
+                state_db_path,
+                event_type="runner.dispatch.started",
+                component=component,
+                payload={"runner_name": runner_name},
+                run_id=run_id,
+                work_item_id=execution.work_item_id,
+            )
+        start = time.monotonic()
+
+        try:
+            if execution.runner_name is RunnerName.PM:
+                result = dispatch_pm_execution(execution)
+            elif execution.runner_name is RunnerName.SPEC:
+                result = dispatch_spec_execution(execution)
+            elif execution.runner_name is RunnerName.ISSUE_PLANNER:
+                result = dispatch_issue_planner_execution(execution)
+            elif execution.runner_name is RunnerName.CODING:
+                result = dispatch_coding_execution(execution)
+            elif execution.runner_name is RunnerName.REVIEW:
+                result = dispatch_review_execution(execution)
+            elif execution.runner_name is RunnerName.DRIFT_MONITOR:
+                result = dispatch_drift_monitor_execution(execution)
+            else:
+                raise RuntimeError(f"unsupported runner dispatch target: {execution.runner_name}")
+        except Exception as exc:
+            duration = time.monotonic() - start
+            if state_db_path is not None:
+                emit_audit_event(
+                    state_db_path,
+                    event_type="runner.dispatch.failed",
+                    component=component,
+                    payload={
+                        "runner_name": runner_name,
+                        "exception_type": type(exc).__name__,
+                        "duration_seconds": duration,
+                    },
+                    run_id=run_id,
+                    work_item_id=execution.work_item_id,
+                    level="ERROR",
+                )
+            raise
 
         outcome = result.outcome_status or result.status.value
         if span is not None:
             span.set_attribute("runner.outcome_status", outcome)
-
-    duration = time.monotonic() - start
-    if state_db_path is not None:
-        emit_audit_event(
-            state_db_path,
-            event_type="runner.dispatch.completed",
-            component=component,
-            payload={
-                "runner_name": runner_name,
-                "status": result.status.value,
-                "outcome_status": result.outcome_status,
-                "duration_seconds": duration,
-            },
-            run_id=run_id,
-            work_item_id=execution.work_item_id,
-        )
+        duration = time.monotonic() - start
+        if state_db_path is not None:
+            emit_audit_event(
+                state_db_path,
+                event_type="runner.dispatch.completed",
+                component=component,
+                payload={
+                    "runner_name": runner_name,
+                    "status": result.status.value,
+                    "outcome_status": result.outcome_status,
+                    "duration_seconds": duration,
+                },
+                run_id=run_id,
+                work_item_id=execution.work_item_id,
+            )
     record_runner_dispatch(runner_name, outcome, duration)
     return result

--- a/agent_runtime/runners/dispatch.py
+++ b/agent_runtime/runners/dispatch.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 import time
+from pathlib import Path
 
-from agent_runtime.telemetry import record_runner_dispatch, runner_span
+from agent_runtime.telemetry import emit_audit_event, record_runner_dispatch, runner_span
 
 from .coding_runner import dispatch_coding_execution
 from .contracts import RunnerExecution, RunnerName, RunnerResult
@@ -15,10 +16,21 @@ from .review_runner import dispatch_review_execution
 from .spec_runner import dispatch_spec_execution
 
 
-def dispatch_runner_execution(execution: RunnerExecution) -> RunnerResult:
+def dispatch_runner_execution(execution: RunnerExecution, *, state_db_path: Path | None = None) -> RunnerResult:
     runner_name = execution.runner_name.value
     run_id = execution.metadata.get("run_id")
     start = time.monotonic()
+    component = "agent_runtime.runners.dispatch"
+
+    if state_db_path is not None:
+        emit_audit_event(
+            state_db_path,
+            event_type="runner.dispatch.started",
+            component=component,
+            payload={"runner_name": runner_name},
+            run_id=run_id,
+            work_item_id=execution.work_item_id,
+        )
 
     with runner_span(runner_name, execution.work_item_id, run_id=run_id) as span:
         if execution.runner_name is RunnerName.PM:
@@ -41,5 +53,19 @@ def dispatch_runner_execution(execution: RunnerExecution) -> RunnerResult:
             span.set_attribute("runner.outcome_status", outcome)
 
     duration = time.monotonic() - start
+    if state_db_path is not None:
+        emit_audit_event(
+            state_db_path,
+            event_type="runner.dispatch.completed",
+            component=component,
+            payload={
+                "runner_name": runner_name,
+                "status": result.status.value,
+                "outcome_status": result.outcome_status,
+                "duration_seconds": duration,
+            },
+            run_id=run_id,
+            work_item_id=execution.work_item_id,
+        )
     record_runner_dispatch(runner_name, outcome, duration)
     return result

--- a/agent_runtime/tests/test_autonomous_loop.py
+++ b/agent_runtime/tests/test_autonomous_loop.py
@@ -143,9 +143,10 @@ def test_dispatch_with_timeout_returns_timed_out_on_timeout() -> None:
     )
     defaults = _defaults(runner_timeout_seconds_default=1)
 
-    def slow_dispatch(_exec: RunnerExecution) -> RunnerResult:
+    def slow_dispatch(_exec: RunnerExecution, *, state_db_path: Path | None = None) -> RunnerResult:
         # Sleep longer than the 1s timeout but short enough that the background
         # thread clears before the test suite exits (shutdown(wait=False) abandons it).
+        assert state_db_path is not None
         time.sleep(3)
         raise AssertionError("should not reach here")
 

--- a/agent_runtime/tests/test_transitions.py
+++ b/agent_runtime/tests/test_transitions.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
 import os
 from pathlib import Path
 import sqlite3
@@ -33,6 +34,7 @@ from agent_runtime.storage.sqlite import (
     EXPECTED_WORKTREE_LEASE_COLUMNS,
     WorkflowRunRecord,
     initialize_database,
+    load_telemetry_events,
     load_workflow_run_by_run_id,
     load_workflow_run,
     load_workflow_runs,
@@ -786,6 +788,74 @@ def test_dispatch_runner_execution_returns_prepared_result() -> None:
     assert "Prepared PM readiness handoff" in result.summary
     assert result.details["target_path"].endswith("WI-1.1.4-risk-summary-core-service.md")
     assert result.outcome_status is None
+
+
+def test_dispatch_runner_execution_writes_audit_events() -> None:
+    snapshot = RuntimeSnapshot(
+        work_items=(
+            WorkItemSnapshot(
+                id="WI-1.1.4-risk-summary-core-service",
+                title="WI-1.1.4",
+                path=Path("work_items/ready/WI-1.1.4-risk-summary-core-service.md"),
+                stage=WorkItemStage.READY,
+            ),
+        )
+    )
+
+    decision = decide_next_action(snapshot)
+    execution = build_runner_execution(snapshot, decision)
+
+    assert execution is not None
+    execution = replace(execution, metadata={**execution.metadata, "run_id": "pm-wi-1-1-4-test-run"})
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        db_path = Path(temp_dir) / "runtime" / "state.db"
+        with patch.dict(os.environ, {"AGENT_RUNTIME_PM_BACKEND": "prepared"}, clear=False):
+            result = dispatch_runner_execution(execution, state_db_path=db_path)
+
+        events = load_telemetry_events(db_path, run_id="pm-wi-1-1-4-test-run", limit=10)
+
+    assert result.runner_name is RunnerName.PM
+    assert [event.event_type for event in events] == ["runner.dispatch.completed", "runner.dispatch.started"]
+    assert all(event.component == "agent_runtime.runners.dispatch" for event in events)
+    assert all(event.work_item_id == execution.work_item_id for event in events)
+
+    completed_event = events[0]
+    started_event = events[1]
+    assert completed_event.payload["runner_name"] == "pm"
+    assert completed_event.payload["status"] == RunnerDispatchStatus.PREPARED.value
+    assert completed_event.payload["outcome_status"] is None
+    assert isinstance(completed_event.payload["duration_seconds"], float)
+    assert started_event.payload == {"runner_name": "pm"}
+
+
+def test_dispatch_runner_execution_audits_without_run_id() -> None:
+    snapshot = RuntimeSnapshot(
+        work_items=(
+            WorkItemSnapshot(
+                id="WI-1.1.4-risk-summary-core-service",
+                title="WI-1.1.4",
+                path=Path("work_items/ready/WI-1.1.4-risk-summary-core-service.md"),
+                stage=WorkItemStage.READY,
+            ),
+        )
+    )
+
+    decision = decide_next_action(snapshot)
+    execution = build_runner_execution(snapshot, decision)
+
+    assert execution is not None
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        db_path = Path(temp_dir) / "runtime" / "state.db"
+        with patch.dict(os.environ, {"AGENT_RUNTIME_PM_BACKEND": "prepared"}, clear=False):
+            dispatch_runner_execution(execution, state_db_path=db_path)
+
+        events = load_telemetry_events(db_path, event_type="runner.dispatch.completed", limit=5)
+
+    assert len(events) == 1
+    assert events[0].run_id is None
+    assert events[0].work_item_id == execution.work_item_id
 
 
 def test_completed_review_changes_requested_routes_to_coding_when_pr_is_unchanged() -> None:

--- a/agent_runtime/tests/test_transitions.py
+++ b/agent_runtime/tests/test_transitions.py
@@ -10,6 +10,8 @@ import tempfile
 from typing import Any
 from unittest.mock import patch
 
+import pytest
+
 from agent_runtime.orchestrator.github_sync import (
     _extract_pull_request_page,
     build_pull_request_snapshots,
@@ -856,6 +858,39 @@ def test_dispatch_runner_execution_audits_without_run_id() -> None:
     assert len(events) == 1
     assert events[0].run_id is None
     assert events[0].work_item_id == execution.work_item_id
+
+
+def test_dispatch_runner_execution_writes_failed_audit_event_on_exception() -> None:
+    snapshot = RuntimeSnapshot(
+        work_items=(
+            WorkItemSnapshot(
+                id="WI-1.1.4-risk-summary-core-service",
+                title="WI-1.1.4",
+                path=Path("work_items/ready/WI-1.1.4-risk-summary-core-service.md"),
+                stage=WorkItemStage.READY,
+            ),
+        )
+    )
+
+    decision = decide_next_action(snapshot)
+    execution = build_runner_execution(snapshot, decision)
+
+    assert execution is not None
+    execution = replace(execution, metadata={**execution.metadata, "run_id": "pm-wi-1-1-4-test-run"})
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        db_path = Path(temp_dir) / "runtime" / "state.db"
+        with patch("agent_runtime.runners.dispatch.dispatch_pm_execution", side_effect=RuntimeError("boom")):
+            with pytest.raises(RuntimeError, match="boom"):
+                dispatch_runner_execution(execution, state_db_path=db_path)
+
+        events = load_telemetry_events(db_path, run_id="pm-wi-1-1-4-test-run", limit=10)
+
+    assert [event.event_type for event in events] == ["runner.dispatch.failed", "runner.dispatch.started"]
+    assert events[0].level == "ERROR"
+    assert events[0].payload["runner_name"] == "pm"
+    assert events[0].payload["exception_type"] == "RuntimeError"
+    assert isinstance(events[0].payload["duration_seconds"], float)
 
 
 def test_completed_review_changes_requested_routes_to_coding_when_pr_is_unchanged() -> None:

--- a/docs/06_prd_authoring_standard.md
+++ b/docs/06_prd_authoring_standard.md
@@ -1,5 +1,7 @@
 # PRD Authoring Standard
 
+> Note on numbering: the PRD ID prefix, the roadmap phase number, and the containing folder name are different tracking schemes. `PRD-1.1` does not mean "Phase 1.1," and a file living under a phase-numbered folder does not redefine its roadmap phase.
+
 ## Purpose
 
 This standard explains how PRDs in this repo should be written so they remain specific to the AI-supported risk manager and do not drift into generic software boilerplate.

--- a/docs/guides/telemetry_guide.md
+++ b/docs/guides/telemetry_guide.md
@@ -118,8 +118,9 @@ OTLP HTTP export      SQLite telemetry_events
 ## Audit events reference
 
 Current audit-table coverage is intentionally narrow: the runtime persists
-runner dispatch start/completion events, and additional event families should be
-documented only after they are wired in code.
+runner dispatch start/completion events plus a failure event when dispatch
+raises, and additional event families should be documented only after they are
+wired in code.
 
 Audit events are written to:
 
@@ -132,6 +133,7 @@ Audit events are written to:
 |------------|-----------|------|
 | `runner.dispatch.started` | `agent_runtime.runners.dispatch` | Immediately before each runner execution |
 | `runner.dispatch.completed` | `agent_runtime.runners.dispatch` | After each runner execution, with `runner_name`, `status`, `outcome_status`, `duration_seconds` |
+| `runner.dispatch.failed` | `agent_runtime.runners.dispatch` | When runner dispatch raises, with `runner_name`, `exception_type`, `duration_seconds` |
 
 ### Querying audit events
 

--- a/docs/guides/telemetry_guide.md
+++ b/docs/guides/telemetry_guide.md
@@ -14,7 +14,7 @@ stack, and how to extend the system with new instrumentation.
 |--------|-------|---------|
 | **Distributed traces** (spans) | OTel → Jaeger | Reconstruct the exact sequence of operations for a workflow run — supervisor tick, runner dispatch, drift scan |
 | **Metrics** (counters + histograms) | OTel → Prometheus | Track aggregate health: step rate, runner latency, risk call outcomes, supervisor liveness |
-| **Structured audit log** | SQLite `telemetry_events` + structlog | Append-only, queryable record of every significant event; correlated with active OTel trace/span |
+| **Structured audit log** | SQLite `telemetry_events` + structlog | Append-only, queryable record of instrumented runtime events such as runner dispatches; correlated with active OTel trace/span |
 
 All three signals are optional. The runtime degrades gracefully when the
 `telemetry` extras are not installed — all wrappers become no-ops and stdlib
@@ -117,6 +117,10 @@ OTLP HTTP export      SQLite telemetry_events
 
 ## Audit events reference
 
+Current audit-table coverage is intentionally narrow: the runtime persists
+runner dispatch start/completion events, and additional event families should be
+documented only after they are wired in code.
+
 Audit events are written to:
 
 1. **`telemetry_events` table** in `state.db` — queryable with DuckDB or any SQLite client;
@@ -126,8 +130,8 @@ Audit events are written to:
 
 | Event type | Component | When |
 |------------|-----------|------|
-| `runner.dispatch.started` | `agent_runtime.orchestrator` | Before each runner execution |
-| `runner.dispatch.completed` | `agent_runtime.orchestrator` | After each runner execution, with `runner_name`, `status`, `outcome_status`, `duration_seconds` |
+| `runner.dispatch.started` | `agent_runtime.runners.dispatch` | Immediately before each runner execution |
+| `runner.dispatch.completed` | `agent_runtime.runners.dispatch` | After each runner execution, with `runner_name`, `status`, `outcome_status`, `duration_seconds` |
 
 ### Querying audit events
 

--- a/docs/roadmap/phased_implementation_roadmap.md
+++ b/docs/roadmap/phased_implementation_roadmap.md
@@ -1,5 +1,7 @@
 # Phased Implementation Roadmap
 
+> Note on numbering: the PRD ID prefix, the roadmap phase number, and the containing folder name are different tracking schemes. `PRD-1.1` does not mean "Phase 1.1," and a file living under a phase-numbered folder does not redefine its roadmap phase.
+
 ## Delivery principles
 
 - implement in vertical slices


### PR DESCRIPTION
## Summary
- wire `emit_audit_event` into the runner dispatch path and thread `state_db_path` through poll-loop and LangGraph dispatch call sites
- add end-to-end tests that verify dispatch audit rows persist in `telemetry_events`, including the case where `run_id` is absent
- tighten telemetry documentation to match the implemented dispatch audit scope and add the phase-numbering clarification notes requested in the roadmap and PRD authoring docs

## Test plan
- [x] `pytest -q agent_runtime/tests/test_transitions.py`
- [x] `ruff check agent_runtime/runners/dispatch.py agent_runtime/orchestrator/graph.py agent_runtime/orchestrator/langgraph_graph.py agent_runtime/tests/test_transitions.py`
- [x] `mypy agent_runtime/runners/dispatch.py agent_runtime/orchestrator/graph.py agent_runtime/orchestrator/langgraph_graph.py agent_runtime/tests/test_transitions.py`

Made with [Cursor](https://cursor.com)