### PR TITLE
docs(work_items): add Quant Walker WI-4.2 decomposition artifacts

### DIFF
--- a/work_items/done/WI-4.2.1-quant-walker-v1-implementation-prd.md
+++ b/work_items/done/WI-4.2.1-quant-walker-v1-implementation-prd.md
@@ -1,0 +1,83 @@
+# WI-4.2.1
+
+## Linked PRD
+
+PRD-4.2-quant-walker-v1 (primary deliverable: author the implementation PRD under docs/prds/phase-2/; do not use backtick-wrapped paths to not-yet-created files — reference_integrity flags them).
+
+Upstream service contract (read-only; must not change semantics): [`docs/prds/phase-1/PRD-1.1-risk-summary-service-v2.md`](docs/prds/phase-1/PRD-1.1-risk-summary-service-v2.md) (PRD-1.1-v2).
+
+## Linked ADRs
+
+- ADR-001 (schema and typing)
+- ADR-002 (replay and snapshot model)
+- ADR-003 (evidence and trace model)
+
+## Linked shared infra
+
+- `docs/shared_infra/index.md`
+- `docs/shared_infra/adoption_matrix.md`
+
+## Purpose
+
+Lock **Quant Walker v1** to a **typed pass-through** of `get_risk_change_profile` results: `RiskChangeProfile | ServiceError`, with explicit boundaries so coding agents do not invent quant interpretation semantics, wrapper outputs, or telemetry scope in v1.
+
+## Scope
+
+- Add a new **implementation PRD** under `docs/prds/phase-2/` (filename per repo convention, PRD-4.2-quant-walker-v1.md) that:
+  - Defines walker v1 responsibility as **delegation only** to the public `risk_analytics` API (`get_risk_change_profile` and its documented contracts).
+  - States that the walker's governed output type(s) are **the same** typed union as the service surface: success is `RiskChangeProfile`; failure paths use the existing typed `ServiceError` envelope (no parallel walker model).
+  - Cross-references PRD-1.1-v2 for service semantics and keeps those semantics unchanged.
+  - States replay/evidence expectations consistent with ADR-001, ADR-002, and ADR-003.
+  - States explicit v1 deferrals for telemetry, multi-delegate expansion, narrative behavior, and orchestrator routing.
+
+## Out of scope
+
+- Any edit that changes PRD-1.1-v2 service semantics
+- Implementation under `src/walkers/` or `tests/` (coding is WI-4.2.2)
+- Orchestrators, UI, telemetry adoption work
+- New types, new error envelope, or new status vocabulary
+
+## Dependencies
+
+PRD-1.1-v2 is stable on main (not a WI dependency for runtime gating).
+
+## Target area
+
+- `docs/prds/phase-2/` (new PRD file)
+
+## Acceptance criteria
+
+- New PRD exists, is numbered/titled consistently with Phase 2 PRDs, and is implementation-ready (typed outputs, error union, no ambiguity that would force coding to invent semantics).
+- Walker v1 is defined as **pass-through** of `RiskChangeProfile | ServiceError` from the public service API only.
+- Telemetry, multi-delegate expansion, narrative behavior, and orchestrator routing are explicitly out of scope for v1.
+- PRD-1.1-v2 is cited as the source of quant/risk service semantics; no conflicting parallel definitions.
+
+## Test intent
+
+- Documentation-only: review agent verifies contract alignment with PRD-1.1-v2, ADR-001/002/003, and WI-4.2.2 readiness.
+
+## Review focus
+
+- No accidental widening beyond delegation-only v1 scope
+- No PRD-1.1-v2 drift
+- Clear handoff to WI-4.2.2 (walker code = thin delegate + parity tests)
+
+## Suggested agent
+
+PRD / Spec Author
+
+## READY_CRITERIA (checklist — work_items/READY_CRITERIA.md)
+
+1. **Linked contract** — Delivers PRD-4.2 file under `docs/prds/phase-2/`; links PRD-1.1-v2 as upstream service canon without altering it.
+2. **Scope clarity** — Pass-through only; explicit exclusion of telemetry/narrative/multi-delegate/orchestrator v1 scope.
+3. **Dependency clarity** — Upstream service contract stable on `main`.
+4. **Target location** — `docs/prds/phase-2/`.
+5. **Acceptance clarity** — Criteria above are reviewable without guesswork.
+6. **Test clarity** — Doc review only; no code tests in this WI.
+7. **Evidence / replay** — PRD states walker defers to service outputs for replay/evidence context.
+8. **Decision closure** — No new ADR required for v1.
+9. **Shared infra** — Shared infra canon linked; quant-walker telemetry adoption deferred from v1 by contract.
+
+## Residual notes for PM / downstream
+
+- PRD-4.2 is merged on `main`; WI-4.2.2 is unblocked and tracked in `work_items/ready/`.

--- a/work_items/ready/WI-4.2.2-quant-walker-delegate-slice.md
+++ b/work_items/ready/WI-4.2.2-quant-walker-delegate-slice.md
@@ -1,0 +1,142 @@
+# WI-4.2.2
+
+## Status
+
+**READY** — WI-4.2.1 (implementation PRD) is merged on `main`; PRD-4.2 is stable implementation contract.
+
+## Blocker
+
+- None. PM can assign this slice to Coding Agent.
+
+## Linked PRD
+
+docs/prds/phase-2/PRD-4.2-quant-walker-v1.md
+
+Planned walker package path for this WI is src/walkers/quant/ (plain text only until created on main). Upstream service semantics: [PRD-1.1-v2](docs/prds/phase-1/PRD-1.1-risk-summary-service-v2.md).
+
+## Linked ADRs
+
+- ADR-001
+- ADR-002
+- ADR-003
+
+## Linked shared infra
+
+- `docs/shared_infra/index.md`
+- `docs/shared_infra/adoption_matrix.md`
+
+## Purpose
+
+First **coding** slice for Quant Walker: a **thin** implementation in a new **quant** package under `src/walkers/` (package path is created by this WI; do not cite the full path in backticks until it exists) that delegates **only** to the public `risk_analytics` service API (`get_risk_change_profile`), returning the same typed `RiskChangeProfile | ServiceError` union, with unit tests proving **parity** versus calling the service directly under identical inputs.
+
+## Scope
+
+- Add the **quant** package under `src/walkers/` (module layout consistent with repo patterns) exposing one entry point `summarize_change` that:
+  - Calls **only** the public API `get_risk_change_profile` from `risk_analytics`.
+  - Passes through request inputs unchanged: `node_ref`, `measure_type`, `as_of_date`, `compare_to_date`, `lookback_window`, `require_complete`, `snapshot_id`, `fixture_index`.
+  - Returns pass-through `RiskChangeProfile | ServiceError` with no wrapper types, no field transformation, and no additional fields.
+- Package `__init__` / exports as appropriate for walker roots per existing `src/walkers/README.md` intent.
+- Unit tests that assert parity matrix coverage from PRD-4.2 Test intent: walker output equals direct `get_risk_change_profile` output, including `ValueError` propagation parity.
+
+## Out of scope
+
+- Any walker-owned interpretive logic (hierarchy localization, significance, narrative, recommended next step, caveat synthesis)
+- Multi-function delegation (`get_risk_summary`, `get_risk_delta`, `get_risk_history`) in v1
+- Telemetry for Quant Walker package/component in v1
+- Orchestrator coupling or routing changes (including PRD-5.1 integration)
+- New fixtures or fixture-index extensions for v1
+- New types, wrapper outputs, error envelopes, status vocabulary, or ADR-level semantics
+
+## Dependencies
+
+Merged prerequisite:
+
+- WI-4.2.1-quant-walker-v1-implementation-prd
+
+Canon (not WI-gated by runtime):
+
+- PRD-4.2
+- PRD-1.1-v2
+- ADR-001
+- ADR-002
+- ADR-003
+
+## Target area
+
+- New package quant under `src/walkers/` (single walker module + `__init__.py` re-export)
+- Matching unit tests under tests/unit/walkers/ (exact layout per repo convention)
+
+## Acceptance criteria
+
+### Functional
+
+- Walker entry point `summarize_change` exists and is importable as `from src.walkers.quant import summarize_change`
+- For any valid combination of inputs, `summarize_change(args)` returns an object equal (`==` on the pydantic model or its structural equivalent for `ServiceError`) to `get_risk_change_profile(args)` called with the same arguments
+- For each documented `ServiceError` path (`UNSUPPORTED_MEASURE`, `MISSING_SNAPSHOT`, `MISSING_NODE`), walker output equals direct service output
+- For each documented `ValueError` validation path (invalid `lookback_window`, blank `snapshot_id`, `compare_to_date > as_of_date`), the walker raises the same `ValueError` (same message) that the service raises
+
+### Contract
+
+- Walker return type annotation is exactly `RiskChangeProfile | ServiceError` — no wrapper, no `Optional`, no additional fields
+- No imports of private service internals (only public module API and the established `contracts` / `fixtures` submodule type imports)
+- No new types defined in the walker package for v1 (the package contains the entry point and its module file only; nothing else)
+- Defaults on the walker signature match `get_risk_change_profile` defaults exactly
+
+### Architecture
+
+- Quant logic remains in `src/modules/risk_analytics/`; the walker is a facade only
+- Walker package location is src/walkers/quant/ per `src/walkers/README.md`
+- Package layout mirrors `src/walkers/data_controller/` (single `walker.py` module exporting one entry point via `__init__.py`)
+- No coupling to PRD-5.1 orchestrator code, no coupling to any other walker, no coupling to `agent_runtime`
+
+### Test
+
+- Parametrized or table-driven unit tests demonstrate parity: same inputs produce equal outputs (or equal raised exceptions) when invoked via walker vs. direct service call
+- Test matrix covers at minimum: one successful `RiskChangeProfile` case, plus one case each for `UNSUPPORTED_MEASURE`, `MISSING_SNAPSHOT`, `MISSING_NODE`, plus at least one `ValueError` propagation case
+- Tests use existing `risk_analytics` fixture infrastructure (`build_fixture_index` / passed-in `fixture_index`); no new fixture files or fixture-index extensions are required for v1
+- If existing fixtures do not cover any required parity row, the coding agent must cover the maximal subset reachable with current fixtures and explicitly note any gap (deferred to a v2+ Open Question; do not invent new fixtures in v1)
+
+## Test intent
+
+Tests must prove that the walker is a faithful delegate with no semantic divergence from the service.
+
+**Pattern:** For each test case, call both `summarize_change` (walker) and `get_risk_change_profile` (service) with identical arguments and assert equality on the result. For `ValueError` cases, assert that both raise `ValueError` with the same message.
+
+**Minimum parity matrix:**
+
+| Case | Trigger | Expected outcome | Key assertion |
+| --- | --- | --- | --- |
+| Successful change profile | valid `node_ref`, supported `measure_type`, `as_of_date` with snapshot, prior business day available | `RiskChangeProfile` with in-object `status` per service rules | walker result `==` service result; both objects field-equal |
+| Unsupported measure | `measure_type` not in fixture pack's `supported_measures` | `ServiceError(status_code="UNSUPPORTED_MEASURE", operation="get_risk_change_profile")` | walker result `==` service result |
+| Missing snapshot | `snapshot_id` does not exist (or no snapshot for `as_of_date`) | `ServiceError(status_code="MISSING_SNAPSHOT", operation="get_risk_change_profile")` | walker result `==` service result |
+| Missing node | current snapshot exists but `node_ref` + `measure_type` not present in it | `ServiceError(status_code="MISSING_NODE", operation="get_risk_change_profile")` | walker result `==` service result |
+| Invalid `lookback_window` | `lookback_window` set to any value other than `60` | `ValueError` from request validation | walker raises same `ValueError` as service (same message) |
+| Blank `snapshot_id` | `snapshot_id=""` | `ValueError` from request validation | walker raises same `ValueError` as service (same message) |
+| `compare_to_date > as_of_date` | invalid compare-date input | `ValueError` from request validation | walker raises same `ValueError` as service (same message) |
+
+## Review focus
+
+- Boundary discipline: walker is a facade with no quant interpretation logic
+- Import hygiene: public module API plus approved typed contract imports only
+- Parity-test sufficiency against PRD-4.2 matrix and `ValueError` propagation
+
+## Suggested agent
+
+Coding Agent
+
+## READY_CRITERIA (checklist — work_items/READY_CRITERIA.md)
+
+1. **Linked contract** — PRD-4.2 exists on `main` and is linked at top of this file.
+2. **Scope clarity** — Delegation-only `summarize_change` + parity tests only.
+3. **Dependency clarity** — WI-4.2.1 merged; upstream service contract stable.
+4. **Target location** — quant package under `src/walkers/`, tests under tests/unit/walkers/ per convention.
+5. **Acceptance clarity** — Functional/Contract/Architecture/Test criteria are explicit and directly lifted from PRD-4.2.
+6. **Test clarity** — Unit tests with explicit parity matrix and error-propagation cases.
+7. **Evidence / replay** — Walker adds no replay/evidence semantics; service outputs remain source of truth.
+8. **Decision closure** — No unresolved architecture decision remains for v1; ADRs linked.
+9. **Shared infra** — Shared infra canon linked; Quant Walker telemetry explicitly out of scope for this v1 slice.
+
+## Residual notes for PM / downstream
+
+- This WI is already unblocked by merged PRD-4.2 and can be assigned directly to Coding Agent.
+- Keep telemetry, multi-delegate expansion, and orchestrator routing as future WI(s) only.


### PR DESCRIPTION
## Summary
- add `work_items/ready/WI-4.2.2-quant-walker-delegate-slice.md` as the delegation-only coding slice aligned to PRD-4.2 acceptance criteria and test-intent parity matrix
- add `work_items/done/WI-4.2.1-quant-walker-v1-implementation-prd.md` as the PRD-authoring done marker to mirror existing WI-4.1.1 lifecycle convention
- keep v1 scope constrained (no telemetry sub-WI, no extra decomposition, no src/tests/docs contract changes)

## Test plan
- [x] verify new WI files reference PRD-4.2, ADR-001/002/003, and shared-infra canon
- [x] verify WI-4.2.2 is in `work_items/ready/` and marked unblocked based on merged PRD-4.2
- [x] verify no unrelated files were included in the commit

Made with [Cursor](https://cursor.com)