### PR TITLE
feat(WI-5.1.3): adopt shared telemetry for daily run orchestrator

### DIFF
--- a/docs/shared_infra/adoption_matrix.md
+++ b/docs/shared_infra/adoption_matrix.md
@@ -17,7 +17,7 @@ Track shared-infrastructure usage, owners, and rollout state by layer.
 | `src/modules/controls_integrity/` | shared evidence contract (`EvidenceRef` in `src/shared/evidence.py`) | adopted | Module imports canonical type from `src.shared`; re-exported via `controls_integrity.contracts` for stable public API (WI-2.1.6) |
 | `src/modules/risk_analytics/` | telemetry contract | adopted | Uses `src.shared.telemetry.emit_operation` (and shared helpers) for PRD minimum operation logs per WI-1.1.11; no module-local duplicate status mapping |
 | `src/walkers/` | telemetry contract | adopted | `data_controller` walker emits via `src.shared.telemetry.emit_operation` (WI-4.1.4) |
-| `src/orchestrators/` | telemetry contract | planned | Keep orchestration concerns separate from deterministic services |
+| `src/orchestrators/` | telemetry contract | adopted | Telemetry uses `src.shared.telemetry.emit_operation`; daily-run operation-log slice is WI-5.1.3; no module-local duplicate status mapping |
 | `agent_runtime/` | telemetry framework | adopted | Canonical runtime implementation; design reference only for `src/` |
 
 ## Governance

--- a/src/orchestrators/daily_risk_investigation/orchestrator.py
+++ b/src/orchestrators/daily_risk_investigation/orchestrator.py
@@ -2,8 +2,8 @@
 
 Slice ownership:
 - WI-5.1.1: typed enums, typed models, entry-point signature, run_id derivation.
-- WI-5.1.2: end-to-end Stages 1–9 implementation in start_daily_run (this slice).
-- WI-5.1.3: telemetry adoption + adoption-matrix flip (deferred).
+- WI-5.1.2: end-to-end Stages 1–9 implementation in start_daily_run.
+- WI-5.1.3: telemetry adoption + adoption-matrix flip.
 - WI-5.1.4: replay determinism test set (deferred).
 """
 
@@ -11,7 +11,6 @@ from __future__ import annotations
 
 import hashlib
 import json
-import time as _time_module
 from datetime import date, datetime, time, timezone
 from enum import StrEnum
 from typing import Any
@@ -29,7 +28,12 @@ from src.modules.risk_analytics import get_risk_summary
 from src.modules.risk_analytics.contracts import MeasureType, NodeRef
 from src.modules.risk_analytics.fixtures import FixtureIndex
 from src.shared import ServiceError
-from src.shared.telemetry import node_ref_log_dict
+from src.shared.telemetry import (
+    canonical_terminal_run_status_status,
+    emit_operation,
+    node_ref_log_dict,
+    timer_start,
+)
 from src.walkers.data_controller import assess_integrity
 
 orchestrator_version: str = "1.0.0"
@@ -292,6 +296,23 @@ def _derive_generated_at(
     return datetime.combine(as_of_date, _GENERATED_AT_FALLBACK_TIME)
 
 
+def _emit_daily_run_operation(
+    operation: str,
+    *,
+    status: str,
+    start_time: float,
+    **context: Any,
+) -> None:
+    """Emit one orchestrator operation event via the shared telemetry contract."""
+    emit_operation(
+        operation,
+        status=status,
+        start_time=start_time,
+        include_trace_context=False,
+        **context,
+    )
+
+
 # ---------------------------------------------------------------------------
 # Entry point
 # ---------------------------------------------------------------------------
@@ -309,23 +330,28 @@ def start_daily_run(
     """Run one daily risk investigation end-to-end and return a typed DailyRunResult.
 
     Implements Stages 1–9 per PRD-5.1 §"Workflow stages".
-    No telemetry in this slice (deferred to WI-5.1.3).
     """
     # Stage 1 — intake
+    intake_start = timer_start()
     if snapshot_id is None or not snapshot_id.strip():
         raise ValueError("snapshot_id must be a non-empty string")
     if not candidate_targets:
         raise ValueError("candidate_targets must be a non-empty tuple")
 
     run_id = _derive_run_id(as_of_date, snapshot_id, measure_type, candidate_targets)
-    # Internal monotonic anchor for stage-internal bookkeeping; not part of the
-    # returned model. Telemetry adoption (WI-5.1.3) will consume this anchor for
-    # operation duration accounting; v1 exists deliberately to keep the surface
-    # symmetric with the planned telemetry slice.
-    _started_at_monotonic: float = _time_module.monotonic()
-    del _started_at_monotonic
+    _emit_daily_run_operation(
+        "daily_run.intake",
+        status="OK",
+        start_time=intake_start,
+        run_id=run_id,
+        as_of_date=as_of_date,
+        snapshot_id=snapshot_id,
+        measure_type=measure_type,
+        candidate_count=len(candidate_targets),
+    )
 
     # Stage 2 — readiness_gate (canary call against first candidate)
+    readiness_start = timer_start()
     canary_outcome = get_risk_summary(
         node_ref=candidate_targets[0],
         measure_type=measure_type,
@@ -346,12 +372,24 @@ def start_daily_run(
         readiness_state = ReadinessState.READY
         readiness_reason_codes = ()
 
+    readiness_status = "OK" if readiness_state is ReadinessState.READY else canary_outcome.status_code
+    _emit_daily_run_operation(
+        "daily_run.readiness_gate",
+        status=readiness_status,
+        start_time=readiness_start,
+        run_id=run_id,
+        as_of_date=as_of_date,
+        snapshot_id=snapshot_id,
+        readiness_state=readiness_state,
+        readiness_reason_codes=readiness_reason_codes,
+    )
+
     if readiness_state is ReadinessState.BLOCKED:
         # Stages 3–8 are skipped; Stage 9 still runs (terminal-state derivation).
         empty_target_results: tuple[TargetInvestigationResult, ...] = ()
         empty_handoff: tuple[TargetHandoffEntry, ...] = ()
         empty_selected: tuple[NodeRef, ...] = ()
-        return DailyRunResult(
+        blocked_result = DailyRunResult(
             run_id=run_id,
             as_of_date=as_of_date,
             snapshot_id=snapshot_id,
@@ -368,9 +406,27 @@ def start_daily_run(
             orchestrator_version=orchestrator_version,
             generated_at=_derive_generated_at(empty_target_results, as_of_date),
         )
+        complete_start = timer_start()
+        _emit_daily_run_operation(
+            "daily_run_complete",
+            status=canonical_terminal_run_status_status(blocked_result.terminal_status),
+            start_time=complete_start,
+            run_id=run_id,
+            as_of_date=as_of_date,
+            snapshot_id=snapshot_id,
+            terminal_status=blocked_result.terminal_status,
+            degraded=blocked_result.degraded,
+            partial=blocked_result.partial,
+            selected_count=0,
+            assessment_count=0,
+            service_error_count=0,
+        )
+        return blocked_result
 
     # Stage 3 — target_selection (pass-through with MISSING_NODE filter)
+    selection_start = timer_start()
     selected_list: list[NodeRef] = []
+    excluded_missing_node_count = 0
     for node_ref in candidate_targets:
         selection_outcome = get_risk_summary(
             node_ref=node_ref,
@@ -381,15 +437,27 @@ def start_daily_run(
         )
         if isinstance(selection_outcome, ServiceError):
             if selection_outcome.status_code == "MISSING_NODE":
+                excluded_missing_node_count += 1
                 continue
             raise RuntimeError("readiness invariant violated after gate passed")
         selected_list.append(node_ref)
     selected_targets = tuple(selected_list)
+    _emit_daily_run_operation(
+        "daily_run.target_selection",
+        status="OK",
+        start_time=selection_start,
+        run_id=run_id,
+        candidate_count=len(candidate_targets),
+        selected_count=len(selected_targets),
+        excluded_missing_node_count=excluded_missing_node_count,
+    )
 
     # Stage 4 — target_routing (constant: every selected target → data_controller)
-    # No telemetry in this slice; routing is implicit in the Stage 5 call shape.
+    # Routing is implicit in the Stage 5 call shape. PRD-5.1 intentionally
+    # forbids a standalone target_routing telemetry event in v1.
 
     # Stage 5 — investigation (one walker call per selected target, sequentially)
+    investigation_start = timer_start()
     raw_outcomes: list[IntegrityAssessment | ServiceError] = []
     for node_ref in selected_targets:
         # Per PRD-4.1: walker may raise ValueError for invalid inputs; that
@@ -403,6 +471,17 @@ def start_daily_run(
             controls_fixture_index=controls_fixture_index,
         )
         raw_outcomes.append(walker_outcome)
+    assessment_count = sum(1 for outcome in raw_outcomes if isinstance(outcome, IntegrityAssessment))
+    service_error_count = len(raw_outcomes) - assessment_count
+    _emit_daily_run_operation(
+        "daily_run.investigation",
+        status="OK",
+        start_time=investigation_start,
+        run_id=run_id,
+        selected_count=len(selected_targets),
+        assessment_count=assessment_count,
+        service_error_count=service_error_count,
+    )
 
     # Stage 6 — synthesis (structural collation; upstream object propagated by reference)
     target_results = tuple(
@@ -417,11 +496,39 @@ def start_daily_run(
     )
 
     # Stage 7 — challenge (per-target gate; reason codes propagated unchanged)
+    challenge_start = timer_start()
     handoff = tuple(_build_handoff_entry(r) for r in target_results)
+    ready_for_handoff_count = sum(1 for entry in handoff if entry.handoff_status is HandoffStatus.READY_FOR_HANDOFF)
+    proceed_with_caveat_count = sum(1 for entry in handoff if entry.handoff_status is HandoffStatus.PROCEED_WITH_CAVEAT)
+    hold_blocking_trust_count = sum(1 for entry in handoff if entry.handoff_status is HandoffStatus.HOLD_BLOCKING_TRUST)
+    hold_unresolved_trust_count = sum(1 for entry in handoff if entry.handoff_status is HandoffStatus.HOLD_UNRESOLVED_TRUST)
+    hold_investigation_failed_count = sum(
+        1 for entry in handoff if entry.handoff_status is HandoffStatus.HOLD_INVESTIGATION_FAILED
+    )
+    _emit_daily_run_operation(
+        "daily_run.challenge",
+        status="OK",
+        start_time=challenge_start,
+        run_id=run_id,
+        ready_for_handoff_count=ready_for_handoff_count,
+        proceed_with_caveat_count=proceed_with_caveat_count,
+        hold_blocking_trust_count=hold_blocking_trust_count,
+        hold_unresolved_trust_count=hold_unresolved_trust_count,
+        hold_investigation_failed_count=hold_investigation_failed_count,
+    )
 
     # Stage 8 — handoff (structural assembly only; no I/O)
+    handoff_start = timer_start()
+    _emit_daily_run_operation(
+        "daily_run.handoff",
+        status="OK",
+        start_time=handoff_start,
+        run_id=run_id,
+        handoff_count=len(handoff),
+    )
 
     # Stage 9 — persist
+    complete_start = timer_start()
     terminal_status = _derive_terminal_status(selected_targets, target_results, handoff)
     degraded = any(
         r.outcome_kind is OutcomeKind.ASSESSMENT and r.assessment is not None and r.assessment.assessment_status is AssessmentStatus.DEGRADED
@@ -432,7 +539,7 @@ def start_daily_run(
     partial = has_service_error and has_assessment
     generated_at = _derive_generated_at(target_results, as_of_date)
 
-    return DailyRunResult(
+    result = DailyRunResult(
         run_id=run_id,
         as_of_date=as_of_date,
         snapshot_id=snapshot_id,
@@ -449,3 +556,18 @@ def start_daily_run(
         orchestrator_version=orchestrator_version,
         generated_at=generated_at,
     )
+    _emit_daily_run_operation(
+        "daily_run_complete",
+        status=canonical_terminal_run_status_status(result.terminal_status),
+        start_time=complete_start,
+        run_id=run_id,
+        as_of_date=as_of_date,
+        snapshot_id=snapshot_id,
+        terminal_status=result.terminal_status,
+        degraded=result.degraded,
+        partial=result.partial,
+        selected_count=len(selected_targets),
+        assessment_count=assessment_count,
+        service_error_count=service_error_count,
+    )
+    return result

--- a/src/orchestrators/daily_risk_investigation/orchestrator.py
+++ b/src/orchestrators/daily_risk_investigation/orchestrator.py
@@ -363,16 +363,17 @@ def start_daily_run(
         if canary_outcome.status_code in _READINESS_BLOCKING_STATUS_CODES:
             readiness_state = ReadinessState.BLOCKED
             readiness_reason_codes: tuple[str, ...] = (canary_outcome.status_code,)
+            readiness_status = canary_outcome.status_code
         elif canary_outcome.status_code == "MISSING_NODE":
             readiness_state = ReadinessState.READY
             readiness_reason_codes = (_READINESS_CANARY_MISSING_NODE_REASON,)
+            readiness_status = "OK"
         else:
             raise RuntimeError(f"readiness gate received unexpected ServiceError status_code={canary_outcome.status_code!r}")
     else:
         readiness_state = ReadinessState.READY
         readiness_reason_codes = ()
-
-    readiness_status = "OK" if readiness_state is ReadinessState.READY else canary_outcome.status_code
+        readiness_status = "OK"
     _emit_daily_run_operation(
         "daily_run.readiness_gate",
         status=readiness_status,
@@ -502,9 +503,7 @@ def start_daily_run(
     proceed_with_caveat_count = sum(1 for entry in handoff if entry.handoff_status is HandoffStatus.PROCEED_WITH_CAVEAT)
     hold_blocking_trust_count = sum(1 for entry in handoff if entry.handoff_status is HandoffStatus.HOLD_BLOCKING_TRUST)
     hold_unresolved_trust_count = sum(1 for entry in handoff if entry.handoff_status is HandoffStatus.HOLD_UNRESOLVED_TRUST)
-    hold_investigation_failed_count = sum(
-        1 for entry in handoff if entry.handoff_status is HandoffStatus.HOLD_INVESTIGATION_FAILED
-    )
+    hold_investigation_failed_count = sum(1 for entry in handoff if entry.handoff_status is HandoffStatus.HOLD_INVESTIGATION_FAILED)
     _emit_daily_run_operation(
         "daily_run.challenge",
         status="OK",

--- a/src/orchestrators/daily_risk_investigation/orchestrator.py
+++ b/src/orchestrators/daily_risk_investigation/orchestrator.py
@@ -390,6 +390,7 @@ def start_daily_run(
         empty_target_results: tuple[TargetInvestigationResult, ...] = ()
         empty_handoff: tuple[TargetHandoffEntry, ...] = ()
         empty_selected: tuple[NodeRef, ...] = ()
+        complete_start = timer_start()
         blocked_result = DailyRunResult(
             run_id=run_id,
             as_of_date=as_of_date,
@@ -407,7 +408,6 @@ def start_daily_run(
             orchestrator_version=orchestrator_version,
             generated_at=_derive_generated_at(empty_target_results, as_of_date),
         )
-        complete_start = timer_start()
         _emit_daily_run_operation(
             "daily_run_complete",
             status=canonical_terminal_run_status_status(blocked_result.terminal_status),

--- a/src/shared/telemetry/__init__.py
+++ b/src/shared/telemetry/__init__.py
@@ -8,6 +8,7 @@ See ``docs/shared_infra/telemetry.md``.
 from __future__ import annotations
 
 from .operation_log import (
+    canonical_terminal_run_status_status,
     EVENT_NAME,
     LOGGER_NAME,
     StdlibLoggerAdapter,
@@ -23,6 +24,7 @@ from .operation_log import (
 )
 
 __all__ = [
+    "canonical_terminal_run_status_status",
     "EVENT_NAME",
     "LOGGER_NAME",
     "StdlibLoggerAdapter",

--- a/src/shared/telemetry/operation_log.py
+++ b/src/shared/telemetry/operation_log.py
@@ -109,7 +109,13 @@ def status_string(outcome: Any) -> str:
 
 
 def canonical_terminal_run_status_status(terminal_status: str | Enum) -> str:
-    """Map PRD terminal run statuses to shared canonical telemetry statuses."""
+    """Map PRD terminal run statuses to shared canonical telemetry statuses.
+
+    Degrades gracefully on unrecognised values: logs a warning and returns
+    ``"DEGRADED"`` so that a future TerminalRunStatus addition never crashes
+    an otherwise complete orchestrator run.  Contract coverage is verified by
+    the exhaustive test in ``tests/unit/shared/telemetry/test_operation_log.py``.
+    """
     terminal_status_value = terminal_status.value if isinstance(terminal_status, Enum) else terminal_status
     mapping = {
         "COMPLETED": "OK",
@@ -118,10 +124,17 @@ def canonical_terminal_run_status_status(terminal_status: str | Enum) -> str:
         "FAILED_ALL_TARGETS": "DEGRADED",
         "BLOCKED_READINESS": "DEGRADED",
     }
-    try:
-        return mapping[terminal_status_value]
-    except KeyError as exc:
-        raise RuntimeError(f"unhandled terminal_status for telemetry: {terminal_status_value!r}") from exc
+    result = mapping.get(terminal_status_value)
+    if result is None:
+        _log.warning(
+            EVENT_NAME,
+            operation="canonical_terminal_run_status_status",
+            status="DEGRADED",
+            duration_ms=0,
+            unrecognised_terminal_status=terminal_status_value,
+        )
+        return "DEGRADED"
+    return result
 
 
 def node_ref_log_dict(node_ref: Any) -> dict[str, str | None]:

--- a/src/shared/telemetry/operation_log.py
+++ b/src/shared/telemetry/operation_log.py
@@ -108,6 +108,22 @@ def status_string(outcome: Any) -> str:
     return cast(str, outcome.status.value)
 
 
+def canonical_terminal_run_status_status(terminal_status: str | Enum) -> str:
+    """Map PRD terminal run statuses to shared canonical telemetry statuses."""
+    terminal_status_value = terminal_status.value if isinstance(terminal_status, Enum) else terminal_status
+    mapping = {
+        "COMPLETED": "OK",
+        "COMPLETED_WITH_CAVEATS": "DEGRADED",
+        "COMPLETED_WITH_FAILURES": "PARTIAL",
+        "FAILED_ALL_TARGETS": "DEGRADED",
+        "BLOCKED_READINESS": "DEGRADED",
+    }
+    try:
+        return mapping[terminal_status_value]
+    except KeyError as exc:
+        raise RuntimeError(f"unhandled terminal_status for telemetry: {terminal_status_value!r}") from exc
+
+
 def node_ref_log_dict(node_ref: Any) -> dict[str, str | None]:
     """Serialize a scope-aware node reference for structured logs (risk analytics shape)."""
     return {

--- a/src/shared/telemetry/operation_log.py
+++ b/src/shared/telemetry/operation_log.py
@@ -126,13 +126,14 @@ def canonical_terminal_run_status_status(terminal_status: str | Enum) -> str:
     }
     result = mapping.get(terminal_status_value)
     if result is None:
-        _log.warning(
-            EVENT_NAME,
-            operation="canonical_terminal_run_status_status",
-            status="DEGRADED",
-            duration_ms=0,
-            unrecognised_terminal_status=terminal_status_value,
-        )
+        if _should_emit("DEGRADED"):
+            _log.warning(
+                EVENT_NAME,
+                operation="canonical_terminal_run_status_status",
+                status="DEGRADED",
+                duration_ms=0,
+                unrecognised_terminal_status=str(terminal_status_value),
+            )
         return "DEGRADED"
     return result
 

--- a/tests/unit/orchestrators/daily_risk_investigation/test_telemetry.py
+++ b/tests/unit/orchestrators/daily_risk_investigation/test_telemetry.py
@@ -1,0 +1,346 @@
+"""WI-5.1.3 — Orchestrator telemetry emission and payload discipline."""
+
+from __future__ import annotations
+
+import json
+import logging
+import subprocess
+import sys
+from datetime import date, datetime, timezone
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from src.modules.controls_integrity import (
+    AssessmentStatus,
+    CheckState,
+    CheckType,
+    ControlCheckResult,
+    IntegrityAssessment,
+    TrustState,
+)
+from src.modules.controls_integrity.contracts.enums import FalseSignalRisk
+from src.modules.risk_analytics.contracts import (
+    HierarchyScope,
+    MeasureType,
+    NodeLevel,
+    NodeRef,
+    RiskSummary,
+)
+from src.modules.risk_analytics.contracts.enums import SummaryStatus
+from src.orchestrators.daily_risk_investigation import start_daily_run
+from src.shared import ServiceError
+from src.shared.telemetry import (
+    LOGGER_NAME,
+    StdlibLoggerAdapter,
+    configure_operation_logging,
+    reset_operation_logging_to_defaults,
+)
+
+_AS_OF_DATE = date(2024, 1, 15)
+_GENERATED_AT = datetime(2024, 1, 15, 18, 0, 0, tzinfo=timezone.utc)
+_SNAPSHOT_ID = "snap-001"
+
+_RISK_PATCH = "src.orchestrators.daily_risk_investigation.orchestrator.get_risk_summary"
+_WALKER_PATCH = "src.orchestrators.daily_risk_investigation.orchestrator.assess_integrity"
+
+
+@pytest.fixture(autouse=True)
+def _reset_telemetry() -> None:
+    reset_operation_logging_to_defaults()
+    yield
+    reset_operation_logging_to_defaults()
+
+
+def _node(node_id: str) -> NodeRef:
+    return NodeRef(
+        hierarchy_scope=HierarchyScope.TOP_OF_HOUSE,
+        legal_entity_id=None,
+        node_level=NodeLevel.DESK,
+        node_id=node_id,
+    )
+
+
+def _risk_summary(node_ref: NodeRef) -> RiskSummary:
+    return RiskSummary(
+        node_ref=node_ref,
+        measure_type=MeasureType.VAR_1D_99,
+        as_of_date=_AS_OF_DATE,
+        current_value=1.0,
+        status=SummaryStatus.OK,
+        snapshot_id=_SNAPSHOT_ID,
+        data_version="dv-1",
+        service_version="sv-1",
+        generated_at=_GENERATED_AT,
+    )
+
+
+def _assessment(node_ref: NodeRef) -> IntegrityAssessment:
+    checks = tuple(
+        ControlCheckResult(
+            check_type=check_type,
+            check_state=CheckState.PASS,
+            reason_codes=(),
+            evidence_refs=(),
+        )
+        for check_type in (
+            CheckType.FRESHNESS,
+            CheckType.COMPLETENESS,
+            CheckType.LINEAGE,
+            CheckType.RECONCILIATION,
+            CheckType.PUBLICATION_READINESS,
+        )
+    )
+    return IntegrityAssessment(
+        node_ref=node_ref,
+        measure_type=MeasureType.VAR_1D_99,
+        as_of_date=_AS_OF_DATE,
+        trust_state=TrustState.TRUSTED,
+        false_signal_risk=FalseSignalRisk.LOW,
+        assessment_status=AssessmentStatus.OK,
+        blocking_reason_codes=(),
+        cautionary_reason_codes=(),
+        check_results=checks,
+        snapshot_id=_SNAPSHOT_ID,
+        data_version="dv-1",
+        service_version="sv-1",
+        generated_at=_GENERATED_AT,
+    )
+
+
+def _payloads(caplog: pytest.LogCaptureFixture) -> list[dict[str, object]]:
+    payloads: list[dict[str, object]] = []
+    for record in caplog.records:
+        payload = getattr(record, "structured_event", None)
+        if isinstance(payload, dict) and str(payload.get("operation", "")).startswith("daily_run"):
+            payloads.append(payload)
+    return payloads
+
+
+def _assert_exact_keys(payload: dict[str, object], *context_keys: str) -> None:
+    expected = {"operation", "status", "duration_ms", *context_keys}
+    assert set(payload) == expected
+    assert isinstance(payload["duration_ms"], int)
+    assert "trace_id" not in payload
+    assert "span_id" not in payload
+
+
+def _assert_no_forbidden_payload_values(value: object) -> None:
+    if isinstance(value, dict):
+        for nested in value.values():
+            _assert_no_forbidden_payload_values(nested)
+        return
+    if isinstance(value, list):
+        for nested in value:
+            _assert_no_forbidden_payload_values(nested)
+        return
+    assert not isinstance(value, (IntegrityAssessment, ServiceError))
+    if isinstance(value, str):
+        assert "IntegrityAssessment" not in value
+        assert "ServiceError" not in value
+
+
+def test_daily_run_emits_required_events_once_with_low_cardinality_payloads(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    configure_operation_logging(enabled=True, logger=StdlibLoggerAdapter(LOGGER_NAME))
+    caplog.set_level(logging.INFO, logger=LOGGER_NAME)
+
+    candidates = (_node("D-1"), _node("D-2"), _node("D-3"))
+
+    def risk_side_effect(*, node_ref: NodeRef, **_: object) -> RiskSummary | ServiceError:
+        if node_ref.node_id == "D-2":
+            return ServiceError(operation="get_risk_summary", status_code="MISSING_NODE")
+        return _risk_summary(node_ref)
+
+    def walker_side_effect(node_ref: NodeRef, *_args: object, **_kwargs: object) -> IntegrityAssessment | ServiceError:
+        if node_ref.node_id == "D-3":
+            return ServiceError(operation="assess_integrity", status_code="MISSING_CONTROL_CONTEXT")
+        return _assessment(node_ref)
+
+    with (
+        patch(_RISK_PATCH, side_effect=risk_side_effect),
+        patch(_WALKER_PATCH, side_effect=walker_side_effect),
+    ):
+        result = start_daily_run(
+            as_of_date=_AS_OF_DATE,
+            snapshot_id=_SNAPSHOT_ID,
+            candidate_targets=candidates,
+            measure_type=MeasureType.VAR_1D_99,
+        )
+
+    payloads = _payloads(caplog)
+    assert [payload["operation"] for payload in payloads] == [
+        "daily_run.intake",
+        "daily_run.readiness_gate",
+        "daily_run.target_selection",
+        "daily_run.investigation",
+        "daily_run.challenge",
+        "daily_run.handoff",
+        "daily_run_complete",
+    ]
+    assert len(payloads) == 7
+
+    intake, readiness, selection, investigation, challenge, handoff, complete = payloads
+
+    _assert_exact_keys(intake, "run_id", "as_of_date", "snapshot_id", "measure_type", "candidate_count")
+    assert intake["status"] == "OK"
+    assert intake["run_id"] == result.run_id
+    assert intake["as_of_date"] == "2024-01-15"
+    assert intake["snapshot_id"] == _SNAPSHOT_ID
+    assert intake["measure_type"] == "VAR_1D_99"
+    assert intake["candidate_count"] == 3
+
+    _assert_exact_keys(readiness, "run_id", "as_of_date", "snapshot_id", "readiness_state", "readiness_reason_codes")
+    assert readiness["status"] == "OK"
+    assert readiness["run_id"] == result.run_id
+    assert readiness["readiness_state"] == "READY"
+    assert readiness["readiness_reason_codes"] == []
+
+    _assert_exact_keys(selection, "run_id", "candidate_count", "selected_count", "excluded_missing_node_count")
+    assert selection["status"] == "OK"
+    assert selection["run_id"] == result.run_id
+    assert selection["candidate_count"] == 3
+    assert selection["selected_count"] == 2
+    assert selection["excluded_missing_node_count"] == 1
+
+    _assert_exact_keys(investigation, "run_id", "selected_count", "assessment_count", "service_error_count")
+    assert investigation["status"] == "OK"
+    assert investigation["run_id"] == result.run_id
+    assert investigation["selected_count"] == 2
+    assert investigation["assessment_count"] == 1
+    assert investigation["service_error_count"] == 1
+
+    _assert_exact_keys(
+        challenge,
+        "run_id",
+        "ready_for_handoff_count",
+        "proceed_with_caveat_count",
+        "hold_blocking_trust_count",
+        "hold_unresolved_trust_count",
+        "hold_investigation_failed_count",
+    )
+    assert challenge["status"] == "OK"
+    assert challenge["run_id"] == result.run_id
+    assert challenge["ready_for_handoff_count"] == 1
+    assert challenge["proceed_with_caveat_count"] == 0
+    assert challenge["hold_blocking_trust_count"] == 0
+    assert challenge["hold_unresolved_trust_count"] == 0
+    assert challenge["hold_investigation_failed_count"] == 1
+
+    _assert_exact_keys(handoff, "run_id", "handoff_count")
+    assert handoff["status"] == "OK"
+    assert handoff["run_id"] == result.run_id
+    assert handoff["handoff_count"] == 2
+
+    _assert_exact_keys(
+        complete,
+        "run_id",
+        "as_of_date",
+        "snapshot_id",
+        "terminal_status",
+        "degraded",
+        "partial",
+        "selected_count",
+        "assessment_count",
+        "service_error_count",
+    )
+    assert complete["status"] == "PARTIAL"
+    assert complete["run_id"] == result.run_id
+    assert complete["as_of_date"] == "2024-01-15"
+    assert complete["snapshot_id"] == _SNAPSHOT_ID
+    assert complete["terminal_status"] == "COMPLETED_WITH_FAILURES"
+    assert complete["degraded"] is False
+    assert complete["partial"] is True
+    assert complete["selected_count"] == 2
+    assert complete["assessment_count"] == 1
+    assert complete["service_error_count"] == 1
+
+    for payload in payloads:
+        _assert_no_forbidden_payload_values(payload)
+
+
+@pytest.mark.parametrize("blocking_status", ["MISSING_SNAPSHOT", "UNSUPPORTED_MEASURE"])
+def test_blocked_readiness_emits_only_intake_gate_and_complete(
+    caplog: pytest.LogCaptureFixture,
+    blocking_status: str,
+) -> None:
+    configure_operation_logging(enabled=True, logger=StdlibLoggerAdapter(LOGGER_NAME))
+    caplog.set_level(logging.INFO, logger=LOGGER_NAME)
+
+    candidates = (_node("D-1"), _node("D-2"))
+
+    with (
+        patch(_RISK_PATCH, return_value=ServiceError(operation="get_risk_summary", status_code=blocking_status)),
+        patch(_WALKER_PATCH) as walker_spy,
+    ):
+        result = start_daily_run(
+            as_of_date=_AS_OF_DATE,
+            snapshot_id=_SNAPSHOT_ID,
+            candidate_targets=candidates,
+            measure_type=MeasureType.VAR_1D_99,
+        )
+
+    walker_spy.assert_not_called()
+    payloads = _payloads(caplog)
+    assert [payload["operation"] for payload in payloads] == [
+        "daily_run.intake",
+        "daily_run.readiness_gate",
+        "daily_run_complete",
+    ]
+    assert len(payloads) == 3
+
+    intake, readiness, complete = payloads
+    _assert_exact_keys(intake, "run_id", "as_of_date", "snapshot_id", "measure_type", "candidate_count")
+    assert intake["status"] == "OK"
+
+    _assert_exact_keys(readiness, "run_id", "as_of_date", "snapshot_id", "readiness_state", "readiness_reason_codes")
+    assert readiness["status"] == blocking_status
+    assert readiness["readiness_state"] == "BLOCKED"
+    assert readiness["readiness_reason_codes"] == [blocking_status]
+
+    _assert_exact_keys(
+        complete,
+        "run_id",
+        "as_of_date",
+        "snapshot_id",
+        "terminal_status",
+        "degraded",
+        "partial",
+        "selected_count",
+        "assessment_count",
+        "service_error_count",
+    )
+    assert complete["status"] == "DEGRADED"
+    assert complete["run_id"] == result.run_id
+    assert complete["terminal_status"] == "BLOCKED_READINESS"
+    assert complete["degraded"] is False
+    assert complete["partial"] is False
+    assert complete["selected_count"] == 0
+    assert complete["assessment_count"] == 0
+    assert complete["service_error_count"] == 0
+
+
+def test_orchestrator_package_does_not_import_agent_runtime() -> None:
+    repo_root = Path(__file__).resolve().parents[4]
+    script = """
+import json
+import sys
+
+before = set(sys.modules)
+import src.orchestrators.daily_risk_investigation  # noqa: F401
+after = set(sys.modules)
+loaded = sorted(
+    name for name in (after - before) if name == "agent_runtime" or name.startswith("agent_runtime.")
+)
+print(json.dumps(loaded))
+"""
+    completed = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=repo_root,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert json.loads(completed.stdout.strip()) == []

--- a/tests/unit/shared/telemetry/test_operation_log.py
+++ b/tests/unit/shared/telemetry/test_operation_log.py
@@ -181,9 +181,7 @@ def test_canonical_terminal_run_status_covers_all_known_values() -> None:
     """
     for member in _TerminalRunStatus:
         result = canonical_terminal_run_status_status(member)
-        assert result == _EXPECTED_TERMINAL_STATUS_MAPPING[member.value], (
-            f"unexpected telemetry status for {member!r}: got {result!r}"
-        )
+        assert result == _EXPECTED_TERMINAL_STATUS_MAPPING[member.value], f"unexpected telemetry status for {member!r}: got {result!r}"
 
 
 def test_canonical_terminal_run_status_accepts_plain_string() -> None:

--- a/tests/unit/shared/telemetry/test_operation_log.py
+++ b/tests/unit/shared/telemetry/test_operation_log.py
@@ -4,12 +4,16 @@ from __future__ import annotations
 
 import logging
 from datetime import date
-from enum import Enum
+from enum import Enum, StrEnum
 
 import pytest
 
 from src.shared.telemetry import operation_log as tel
-from src.shared.telemetry.operation_log import emit_operation, reset_operation_logging_to_defaults
+from src.shared.telemetry.operation_log import (
+    canonical_terminal_run_status_status,
+    emit_operation,
+    reset_operation_logging_to_defaults,
+)
 
 
 class _SampleEnum(Enum):
@@ -147,6 +151,58 @@ def test_emit_context_normalization_and_unserializable_fallback(caplog: pytest.L
     assert payload["sample_enum"] == "alpha"
     assert payload["nested"] == {"k": 1}
     assert payload["bad_obj"] == "<unserializable:object>"
+
+
+class _TerminalRunStatus(StrEnum):
+    """Replica of TerminalRunStatus used to verify exhaustive mapping without an orchestrator import."""
+
+    COMPLETED = "COMPLETED"
+    COMPLETED_WITH_CAVEATS = "COMPLETED_WITH_CAVEATS"
+    COMPLETED_WITH_FAILURES = "COMPLETED_WITH_FAILURES"
+    FAILED_ALL_TARGETS = "FAILED_ALL_TARGETS"
+    BLOCKED_READINESS = "BLOCKED_READINESS"
+
+
+_EXPECTED_TERMINAL_STATUS_MAPPING = {
+    "COMPLETED": "OK",
+    "COMPLETED_WITH_CAVEATS": "DEGRADED",
+    "COMPLETED_WITH_FAILURES": "PARTIAL",
+    "FAILED_ALL_TARGETS": "DEGRADED",
+    "BLOCKED_READINESS": "DEGRADED",
+}
+
+
+def test_canonical_terminal_run_status_covers_all_known_values() -> None:
+    """Every TerminalRunStatus value must map to a canonical shared-telemetry status.
+
+    This test pins the exhaustive mapping so that adding a new TerminalRunStatus
+    member surfaces here rather than falling through to the graceful-degradation path
+    at runtime.
+    """
+    for member in _TerminalRunStatus:
+        result = canonical_terminal_run_status_status(member)
+        assert result == _EXPECTED_TERMINAL_STATUS_MAPPING[member.value], (
+            f"unexpected telemetry status for {member!r}: got {result!r}"
+        )
+
+
+def test_canonical_terminal_run_status_accepts_plain_string() -> None:
+    assert canonical_terminal_run_status_status("COMPLETED") == "OK"
+    assert canonical_terminal_run_status_status("COMPLETED_WITH_FAILURES") == "PARTIAL"
+
+
+def test_canonical_terminal_run_status_degrades_gracefully_on_unknown(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    tel.configure_operation_logging(enabled=True, logger=tel.StdlibLoggerAdapter(tel.LOGGER_NAME))
+    caplog.set_level(logging.WARNING, logger=tel.LOGGER_NAME)
+
+    result = canonical_terminal_run_status_status("UNKNOWN_FUTURE_STATUS")
+
+    assert result == "DEGRADED"
+    assert len(caplog.records) == 1
+    payload = getattr(caplog.records[0], "structured_event")
+    assert payload.get("unrecognised_terminal_status") == "UNKNOWN_FUTURE_STATUS"
 
 
 def test_stdlib_logger_adapter_bind_merges_context(caplog: pytest.LogCaptureFixture) -> None:

--- a/work_items/done/WI-5.1.3-telemetry-adoption-and-adoption-matrix-flip.md
+++ b/work_items/done/WI-5.1.3-telemetry-adoption-and-adoption-matrix-flip.md
@@ -1,0 +1,141 @@
+# WI-5.1.3
+
+## Status
+
+**BLOCKED** — gated on WI-5.1.2 (stage execution end-to-end) merging on `main`.
+
+## Blocker
+
+- WI-5.1.2-stage-execution-end-to-end must be merged and the full orchestrator stage implementation must be stable on `main` before telemetry calls are added.
+
+**Owner:** Coding Agent completes WI-5.1.2 → human merge → PM moves this WI to `in_progress`.
+
+## Linked PRD
+
+docs/prds/phase-2/PRD-5.1-daily-risk-investigation-orchestrator-v1.md
+
+Telemetry contract: [docs/shared_infra/telemetry.md](docs/shared_infra/telemetry.md). Adoption matrix: [docs/shared_infra/adoption_matrix.md](docs/shared_infra/adoption_matrix.md).
+
+## Linked ADRs
+
+- ADR-001
+- ADR-003
+
+## Linked shared infra
+
+- `docs/shared_infra/index.md`
+- `docs/shared_infra/telemetry.md`
+- `docs/shared_infra/adoption_matrix.md`
+
+## Purpose
+
+Third coding slice for the Daily Risk Investigation Orchestrator: add `emit_operation` calls for every required telemetry event per the PRD-5.1 telemetry table, assert payload discipline (no `IntegrityAssessment` payloads in logs, no `agent_runtime` import), add telemetry tests using the shared-infra test pattern established in `src/walkers/data_controller/`, and flip `src/orchestrators/` in `docs/shared_infra/adoption_matrix.md` from `planned` to `adopted`.
+
+## Scope
+
+- Add `src.shared.telemetry.emit_operation` calls at the correct stage boundaries per PRD-5.1 "Required events (v1)":
+  - `daily_run.intake` — after Stage 1 completes; status: `OK`; context: `run_id`, `as_of_date`, `snapshot_id`, `measure_type`, `candidate_count`
+  - `daily_run.readiness_gate` — after Stage 2 completes; status: `OK` when `readiness_state == READY`, else the `ServiceError.status_code` from the canary call (`MISSING_SNAPSHOT` or `UNSUPPORTED_MEASURE`); context: `run_id`, `as_of_date`, `snapshot_id`, `readiness_state`, `readiness_reason_codes`
+  - `daily_run.target_selection` — after Stage 3 completes; status: `OK`; context: `run_id`, `candidate_count`, `selected_count`, `excluded_missing_node_count`
+  - `daily_run.investigation` — after Stage 5 completes; status: `OK`; context: `run_id`, `selected_count`, `assessment_count`, `service_error_count`
+  - `daily_run.challenge` — after Stage 7 completes; status: `OK`; context: `run_id`, `ready_for_handoff_count`, `proceed_with_caveat_count`, `hold_blocking_trust_count`, `hold_unresolved_trust_count`, `hold_investigation_failed_count`
+  - `daily_run.handoff` — after Stage 8 completes; status: `OK`; context: `run_id`, `handoff_count`
+  - `daily_run_complete` — at end of Stage 9; status: mapped canonical status per normative mapping (`COMPLETED` → `OK`; `COMPLETED_WITH_CAVEATS` → `DEGRADED`; `COMPLETED_WITH_FAILURES` → `PARTIAL`; `FAILED_ALL_TARGETS` → `DEGRADED`; `BLOCKED_READINESS` → `DEGRADED`); context: `run_id`, `as_of_date`, `snapshot_id`, `terminal_status`, `degraded`, `partial`, `selected_count`, `assessment_count`, `service_error_count`
+- `BLOCKED_READINESS` path: emit only `daily_run.intake`, `daily_run.readiness_gate`, and `daily_run_complete`; no Stage 3–8 events
+- Telemetry tests (caplog-style, following the pattern from `src/walkers/data_controller/` and `src/modules/controls_integrity/`):
+  - Each required event is emitted exactly once per happy-path run with the documented context fields
+  - No `IntegrityAssessment` or `ServiceError` objects appear in log payloads (low-cardinality identifiers and counts only)
+  - `agent_runtime` is not imported transitively from the orchestrator package
+  - `BLOCKED_READINESS` path emits exactly three events: `daily_run.intake`, `daily_run.readiness_gate`, `daily_run_complete`
+- Update `docs/shared_infra/adoption_matrix.md`: flip `src/orchestrators/` row from `planned` to `adopted`; set Notes to: "Telemetry uses `src.shared.telemetry.emit_operation`; daily-run operation-log slice is WI-5.1.3; no module-local duplicate status mapping"
+
+## Out of scope
+
+- Any new telemetry status strings beyond those already in `_INFO_STATUSES` or `_WARNING_STATUSES` in `src.shared.telemetry.operation_log`
+- Module-local status mapping in the orchestrator (status-to-level mapping is owned entirely by shared telemetry)
+- Separate telemetry events for `target_routing`, `synthesis`, or `persist` stages (forbidden without a PRD update)
+- `include_trace_context=True` (deferred to a future WI per PRD-5.1 open questions)
+- Replay determinism tests — WI-5.1.4
+- Any orchestrator stage logic changes (locked in WI-5.1.1 and WI-5.1.2)
+- Any new typed contracts, status values, or evidence shapes
+
+## Dependencies
+
+Blocking:
+
+- WI-5.1.2-stage-execution-end-to-end
+
+Canon (not WI-gated):
+
+- PRD-5.1
+- ADR-001
+- ADR-003
+- `docs/shared_infra/telemetry.md`
+
+## Target area
+
+- `src/orchestrators/daily_risk_investigation/` (add `emit_operation` calls to existing implementation from WI-5.1.2)
+- `docs/shared_infra/adoption_matrix.md` (flip `src/orchestrators/` row to `adopted`)
+- `tests/unit/orchestrators/daily_risk_investigation/` (telemetry tests)
+
+## Acceptance criteria
+
+### Telemetry
+
+- All seven events from the PRD-5.1 telemetry table are emitted exactly once per complete run (happy path)
+- Each event includes exactly the context fields listed in PRD-5.1; no `IntegrityAssessment` or `ServiceError` objects appear in log payloads; only low-cardinality identifiers, counts, and canonical statuses
+- `daily_run_complete` `status` field is the mapped canonical status (e.g. `OK` for `COMPLETED`), not the raw `terminal_status` enum value; `terminal_status` appears only as a context field
+- `daily_run.readiness_gate` `status` is `OK` when `readiness_state == READY`; otherwise the `ServiceError.status_code` from the canary call (`MISSING_SNAPSHOT` or `UNSUPPORTED_MEASURE`)
+- `BLOCKED_READINESS` path: exactly three events emitted (`daily_run.intake`, `daily_run.readiness_gate`, `daily_run_complete`); no Stage 3–8 events
+- All `status` values passed to `emit_operation` are members of the canonical sets already in shared telemetry; no new status strings introduced in the orchestrator
+- No `agent_runtime` import in the orchestrator package (transitively)
+
+### Adoption matrix
+
+- `src/orchestrators/` row in `docs/shared_infra/adoption_matrix.md` reflects `adopted`
+- Notes field states: telemetry uses `src.shared.telemetry.emit_operation`; daily-run operation-log slice is WI-5.1.3; no module-local duplicate status mapping
+
+### Test
+
+- caplog assertion that each event is emitted exactly once per happy-path run with correct `operation` and context fields
+- Assertion that no `IntegrityAssessment` or `ServiceError` payload appears in any log record across a run
+- Import-hygiene assertion: `agent_runtime` is not importable transitively from `src.orchestrators.daily_risk_investigation`
+- `BLOCKED_READINESS` path test: assert exactly three events emitted with correct `operation` names
+
+## Test intent
+
+Mirror the test pattern from `src/walkers/data_controller/` telemetry tests:
+
+- Capture log records via pytest `caplog` or equivalent
+- Assert `operation` and `status` fields on each captured record match the normative table
+- Assert context fields match the documented minimums per event
+- Assert no forbidden payload fields (no full typed objects)
+- Assert event count per run is exactly the expected count (7 for complete run; 3 for `BLOCKED_READINESS`)
+
+## Review focus
+
+- Telemetry payload discipline: no full typed objects in log records; low-cardinality identifiers and counts only
+- Status mapping correctness: the raw `terminal_status` enum value must not be the canonical `status` field on `daily_run_complete`; it must appear only as a context field
+- `BLOCKED_READINESS` path emits exactly the three required events and no others
+- `daily_run.readiness_gate` status reflects the canary `ServiceError.status_code` correctly in the blocked case
+- Adoption matrix row correctly flipped to `adopted` with accurate notes
+- No new status strings introduced in the orchestrator
+- No stage logic changes introduced in this WI
+
+## Suggested agent
+
+Coding Agent (after WI-5.1.2 unblocks)
+
+## READY_CRITERIA (checklist — work_items/READY_CRITERIA.md)
+
+*Blocked until WI-5.1.2 completes; when unblocked, all must hold:*
+
+1. **Linked contract** — PRD-5.1 and shared-infra telemetry canon are merged on `main` and linked above.
+2. **Scope clarity** — `emit_operation` calls + telemetry tests + adoption matrix flip only; no stage-behavior changes.
+3. **Dependency clarity** — WI-5.1.2 merged; shared telemetry contract stable on `main`.
+4. **Target location** — `src/orchestrators/daily_risk_investigation/`, `docs/shared_infra/adoption_matrix.md`, `tests/unit/orchestrators/daily_risk_investigation/`.
+5. **Acceptance clarity** — All telemetry event table rows are explicit; payload discipline requirements are explicit; adoption matrix update is explicit and normative in PRD-5.1.
+6. **Test clarity** — caplog-style tests per established pattern; specific assertions named above.
+7. **Evidence / replay** — No new evidence shape. Telemetry payloads must not include raw typed evidence objects per ADR-003 payload discipline.
+8. **Decision closure** — Status mapping is normative in PRD-5.1 "Required events (v1)"; no unresolved telemetry design decisions.
+9. **Shared infra** — This WI is the telemetry adoption slice; `docs/shared_infra/telemetry.md` and `docs/shared_infra/adoption_matrix.md` are both linked and explicitly modified by this WI.


### PR DESCRIPTION
## Summary
- add the PRD-required `daily_run.*` operation logs to the daily-risk orchestrator, including the blocked-readiness emission path
- add focused caplog telemetry tests for event counts, required context fields, payload discipline, and `agent_runtime` import hygiene
- flip the shared-infra adoption matrix for `src/orchestrators/` and move the terminal-run status mapping into shared telemetry so the orchestrator does not keep a duplicate local mapping

## Test plan
- [x] `pytest tests/unit/orchestrators/daily_risk_investigation/test_telemetry.py -q`
- [x] `pytest tests/unit/orchestrators/daily_risk_investigation -q`

Made with [Cursor](https://cursor.com)