### PR TITLE
[codex] add module dashboard governance and drift checks

### DIFF
--- a/agent_runtime/drift/__init__.py
+++ b/agent_runtime/drift/__init__.py
@@ -10,6 +10,7 @@ from .drift_suite import (
     render_drift_suite_markdown_summary,
 )
 from .instruction_surfaces import InstructionSurfaceReport, build_instruction_surface_report
+from .module_dashboard_freshness import ModuleDashboardFreshnessReport, build_module_dashboard_freshness_report
 from .reference_integrity import ReferenceScanReport, build_reference_scan_report
 from .registry_alignment import RegistryAlignmentReport, build_registry_alignment_report
 from .surface_liveness import SurfaceLivenessReport, build_surface_liveness_report
@@ -20,6 +21,7 @@ __all__ = [
     "DependencyHygieneReport",
     "DriftSuiteReport",
     "InstructionSurfaceReport",
+    "ModuleDashboardFreshnessReport",
     "ReferenceScanReport",
     "RegistryAlignmentReport",
     "SurfaceLivenessReport",
@@ -28,6 +30,7 @@ __all__ = [
     "build_dependency_hygiene_report",
     "build_drift_suite_report",
     "build_instruction_surface_report",
+    "build_module_dashboard_freshness_report",
     "build_reference_scan_report",
     "build_registry_alignment_report",
     "build_surface_liveness_report",

--- a/agent_runtime/drift/dependency_hygiene.py
+++ b/agent_runtime/drift/dependency_hygiene.py
@@ -26,6 +26,9 @@ UNDECLARED_IMPORT_SEVERITY = "critical"
 WORKFLOW_TOOL_SEVERITY = "major"
 STALE_GUIDANCE_SEVERITY = "major"
 STDLIB_MODULES = set(sys.stdlib_module_names)
+IMPORT_NAME_ALIASES = {
+    "yaml": "pyyaml",
+}
 
 
 @dataclass(frozen=True, slots=True)
@@ -171,7 +174,8 @@ def _maybe_add_third_party_import(imports: set[str], module_path: str) -> None:
     top_level = module_path.partition(".")[0]
     if top_level in STDLIB_MODULES or top_level in LOCAL_IMPORT_ROOTS or top_level == "__future__":
         return
-    imports.add(_canonicalize_dependency_name(top_level))
+    normalized = IMPORT_NAME_ALIASES.get(top_level, top_level)
+    imports.add(_canonicalize_dependency_name(normalized))
 
 
 def _append_runtime_import_findings(

--- a/agent_runtime/drift/drift_suite.py
+++ b/agent_runtime/drift/drift_suite.py
@@ -12,6 +12,7 @@ from .architecture_boundaries import ArchitectureBoundaryReport, build_architect
 from .canon_lineage import CanonLineageReport, build_canon_lineage_report
 from .dependency_hygiene import DependencyHygieneReport, build_dependency_hygiene_report
 from .instruction_surfaces import InstructionSurfaceReport, build_instruction_surface_report
+from .module_dashboard_freshness import ModuleDashboardFreshnessReport, build_module_dashboard_freshness_report
 from .reference_integrity import ReferenceScanReport, build_reference_scan_report
 from .registry_alignment import RegistryAlignmentReport, build_registry_alignment_report
 from .surface_liveness import SurfaceLivenessReport, build_surface_liveness_report
@@ -27,6 +28,7 @@ _ReportT = (
     | CanonLineageReport
     | DependencyHygieneReport
     | InstructionSurfaceReport
+    | ModuleDashboardFreshnessReport
     | ReferenceScanReport
     | RegistryAlignmentReport
     | SurfaceLivenessReport
@@ -210,6 +212,12 @@ _SCANNERS: tuple[_ScannerSpec, ...] = (
         build_report=build_instruction_surface_report,
     ),
     _ScannerSpec(
+        scan_name="module_dashboard_freshness",
+        title="Module Dashboard Freshness",
+        artifact_name="module_dashboard_freshness.json",
+        build_report=build_module_dashboard_freshness_report,
+    ),
+    _ScannerSpec(
         scan_name="reference_integrity",
         title="Reference Integrity",
         artifact_name="reference_integrity.json",
@@ -234,6 +242,7 @@ _SIGNATURE_FIELDS: dict[str, tuple[str, ...]] = {
     "canon_lineage": ("kind", "source_path", "related_paths"),
     "dependency_hygiene": ("kind", "dependency_name", "source_path"),
     "instruction_surfaces": ("kind", "source_path", "related_paths"),
+    "module_dashboard_freshness": ("kind", "module_id", "dashboard_path", "registry_path"),
     "reference_integrity": ("kind", "source_file", "source_line", "reference"),
     "registry_alignment": ("kind", "component_id", "implementation_path", "registry_path"),
     "surface_liveness": ("kind", "source_path", "source_line", "related_path"),

--- a/agent_runtime/drift/module_dashboard_freshness.py
+++ b/agent_runtime/drift/module_dashboard_freshness.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+
+from scripts.render_module_dashboard import DEFAULT_REGISTRY_PATH, load_registry, render_module_dashboard
+
+
+@dataclass(frozen=True, slots=True)
+class ModuleDashboardFreshnessFinding:
+    kind: str
+    severity: str
+    drift_class: str
+    owner: str
+    module_id: str
+    dashboard_path: str
+    registry_path: str
+    message: str
+
+
+@dataclass(frozen=True, slots=True)
+class ModuleDashboardFreshnessStats:
+    dashboards_declared: int
+    dashboards_checked: int
+    missing_dashboards: int
+    stale_dashboards: int
+    findings_count: int
+
+
+@dataclass(frozen=True, slots=True)
+class ModuleDashboardFreshnessReport:
+    scan_name: str
+    root: str
+    generated_at: str
+    findings: tuple[ModuleDashboardFreshnessFinding, ...]
+    stats: ModuleDashboardFreshnessStats
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "scan_name": self.scan_name,
+            "root": self.root,
+            "generated_at": self.generated_at,
+            "findings": [asdict(finding) for finding in self.findings],
+            "stats": asdict(self.stats),
+        }
+
+
+def build_module_dashboard_freshness_report(root: Path) -> ModuleDashboardFreshnessReport:
+    repo_root = root.resolve()
+    registry_path = repo_root / DEFAULT_REGISTRY_PATH
+    payload = load_registry(registry_path)
+    raw_dashboards = payload.get("module_dashboards")
+    if raw_dashboards is None:
+        raw_dashboards = []
+    if not isinstance(raw_dashboards, list):
+        raise ValueError("registry `module_dashboards` must be a list")
+
+    findings: list[ModuleDashboardFreshnessFinding] = []
+    dashboards_checked = 0
+    missing_dashboards = 0
+    stale_dashboards = 0
+
+    for entry in raw_dashboards:
+        if not isinstance(entry, dict):
+            raise ValueError("registry `module_dashboards` entries must be mappings")
+        module_id = str(entry.get("id") or "UNKNOWN")
+        dashboard_path = entry.get("dashboard_path")
+        if not isinstance(dashboard_path, str) or not dashboard_path:
+            raise ValueError("module dashboard entries must declare a non-empty `dashboard_path`")
+
+        dashboards_checked += 1
+        output_path = repo_root / dashboard_path
+        expected = render_module_dashboard(payload, module_id=module_id)
+
+        if not output_path.is_file():
+            missing_dashboards += 1
+            findings.append(
+                ModuleDashboardFreshnessFinding(
+                    kind="missing_generated_dashboard",
+                    severity="critical",
+                    drift_class="maturity or status drift",
+                    owner="PM",
+                    module_id=module_id,
+                    dashboard_path=dashboard_path,
+                    registry_path=DEFAULT_REGISTRY_PATH.as_posix(),
+                    message=(
+                        f"Generated module dashboard `{dashboard_path}` for `{module_id}` is missing. "
+                        f"Rerun `python scripts/render_module_dashboard.py --module-id {module_id}` after updating the registry."
+                    ),
+                )
+            )
+            continue
+
+        actual = output_path.read_text(encoding="utf-8")
+        if actual != expected:
+            stale_dashboards += 1
+            findings.append(
+                ModuleDashboardFreshnessFinding(
+                    kind="stale_generated_dashboard",
+                    severity="critical",
+                    drift_class="maturity or status drift",
+                    owner="PM",
+                    module_id=module_id,
+                    dashboard_path=dashboard_path,
+                    registry_path=DEFAULT_REGISTRY_PATH.as_posix(),
+                    message=(
+                        f"Generated module dashboard `{dashboard_path}` is out of sync with "
+                        f"`{DEFAULT_REGISTRY_PATH.as_posix()}` for `{module_id}`. "
+                        f"Rerun `python scripts/render_module_dashboard.py --module-id {module_id}`."
+                    ),
+                )
+            )
+
+    findings.sort(key=lambda finding: (finding.dashboard_path, finding.kind, finding.module_id))
+    return ModuleDashboardFreshnessReport(
+        scan_name="module_dashboard_freshness",
+        root=".",
+        generated_at=datetime.now(UTC).isoformat(),
+        findings=tuple(findings),
+        stats=ModuleDashboardFreshnessStats(
+            dashboards_declared=len(raw_dashboards),
+            dashboards_checked=dashboards_checked,
+            missing_dashboards=missing_dashboards,
+            stale_dashboards=stale_dashboards,
+            findings_count=len(findings),
+        ),
+    )

--- a/artifacts/drift/README.md
+++ b/artifacts/drift/README.md
@@ -9,6 +9,7 @@ Recommended local output paths:
 - `artifacts/drift/instruction_surfaces.json`
 - `artifacts/drift/issue_body.md`
 - `artifacts/drift/latest_report.json`
+- `artifacts/drift/module_dashboard_freshness.json`
 - `artifacts/drift/reference_integrity.json`
 - `artifacts/drift/registry_alignment.json`
 - `artifacts/drift/surface_liveness.json`

--- a/docs/delivery/01_pm_operating_model.md
+++ b/docs/delivery/01_pm_operating_model.md
@@ -20,6 +20,7 @@ The PM agent is responsible for deciding whether work is truly ready, whether it
 - overnight sequencing and morning handoff summaries
 - escalation when canon is incomplete
 - triage of drift-monitor findings into the correct owner queue
+- freshness of registry-backed module dashboard state when capability maturity, PRD lineage, or MVP blockers change
 
 ## What the PM agent does not own
 
@@ -74,3 +75,4 @@ Every PM readiness pass should produce:
 6. explicit out-of-scope reminders
 7. implementation brief
 8. stop conditions for the coding agent
+9. any required updates to `docs/registry/current_state_registry.yaml` and generated module dashboard pages under `docs/roadmap/`

--- a/docs/delivery/05_repo_drift_monitoring.md
+++ b/docs/delivery/05_repo_drift_monitoring.md
@@ -137,6 +137,20 @@ Checks:
 
 Does not check prompt quality, global minimality, or whether semantically aligned overlap should be deduplicated.
 
+### Module dashboard freshness
+
+**Implementation:** `agent_runtime/drift/module_dashboard_freshness.py`
+**CLI:** `scripts/drift/check_module_dashboard_freshness.py`
+**Drift class:** maturity or status drift
+**Typical owner:** PM
+
+Checks:
+- Missing generated module dashboard pages declared in `docs/registry/current_state_registry.yaml`
+- Generated module dashboard pages that no longer match the current registry-backed render output
+- Registry changes that were not followed by rerendering the governed dashboard page
+
+Does not check whether the registry status itself is correct; it only checks whether the generated dashboard page is present and fresh relative to the registry.
+
 ### Reference integrity
 
 **Implementation:** `agent_runtime/drift/reference_integrity.py`
@@ -190,6 +204,7 @@ Per-scanner JSON:
 - `artifacts/drift/canon_lineage.json`
 - `artifacts/drift/dependency_hygiene.json`
 - `artifacts/drift/instruction_surfaces.json`
+- `artifacts/drift/module_dashboard_freshness.json`
 - `artifacts/drift/reference_integrity.json`
 - `artifacts/drift/registry_alignment.json`
 - `artifacts/drift/surface_liveness.json`
@@ -276,7 +291,7 @@ Whether duplication is sanctioned (labeled summary, index, exemplar, or local ad
 Whether prompt instructions match governed delivery canon, work-item standards match PM and review expectations, role boundaries remain explicit, and the agent relay is preserved.
 
 ### Registry and catalog coherence
-Whether catalogs, registries, README files, and status markers still reflect actual state well enough to guide future work safely.
+Whether catalogs, registries, generated module dashboard pages under `docs/roadmap/`, README files, and status markers still reflect actual state well enough to guide future work safely.
 
 ### Tooling and operational hygiene
 Whether packaging, dependency declarations, lint/format/type-check/test controls, and CI checks match real implementation state.

--- a/docs/prds/phase-8/PRD-8.1-module-dashboard-and-registry-governance-v1.md
+++ b/docs/prds/phase-8/PRD-8.1-module-dashboard-and-registry-governance-v1.md
@@ -1,0 +1,262 @@
+# PRD-8.1: Module Dashboard And Registry Governance v1
+
+## Header
+
+- **PRD ID:** PRD-8.1
+- **Title:** Module Dashboard And Registry Governance v1
+- **Phase:** Phase 8
+- **Status:** Ready for implementation
+- **Layer:** Delivery governance / shared status surfaces
+- **Type:** Registry-backed documentation and workflow governance
+- **Primary owner:** PM / Coordination Agent
+- **Supporting owners:** Review Agent, Drift Monitor Agent, Repository Maintenance
+- **Related canon:** `docs/roadmap/phased_implementation_roadmap.md`, `docs/registry/current_state_registry.yaml`, `docs/delivery/01_pm_operating_model.md`, `docs/delivery/05_repo_drift_monitoring.md`
+- **Related implementation surfaces:** `scripts/render_module_dashboard.py`, `docs/roadmap/`
+
+## Purpose
+
+Provide a governed, human-readable module dashboard that shows where a module stands at any point in delivery, what is implemented, what is missing for MVP, which PRDs are missing, and which existing PRDs require a new version.
+
+v1 establishes the pattern for Module 1 only, using the registry as the canonical source of truth and a generated Markdown page under `docs/roadmap/` as the operator-facing surface.
+
+## Why this exists
+
+The repository already has:
+
+- a phase roadmap
+- a current-state registry
+- work-item state
+- PRD lineage spread across multiple directories
+
+Those surfaces are useful but not sufficient to answer one operator question cleanly:
+
+> For this module, what is implemented now, what is missing for MVP, and what contracts are still needed?
+
+Without a governed dashboard, the answer lives across PRDs, work items, catalogs, registry entries, and implementation state. That raises PM routing risk and makes drift harder to detect.
+
+## Supported process context
+
+This PRD supports:
+
+- PM readiness and sequencing
+- post-merge status updates
+- review of capability-maturity changes
+- drift monitoring of roadmap/registry/implementation alignment
+
+It does not support:
+
+- product planning outside the repository
+- UI productization of dashboards
+- automated merge decisions
+
+## Human owner and decision boundary
+
+- **Primary human-facing owner:** PM / Coordination Agent
+- **Accountable human boundary:** repository operator / maintainer decides whether dashboard state is accurate enough to treat as current governance truth
+
+Agents may update registry-backed status surfaces only when the implementation or canon change materially affects module maturity, MVP blockers, or PRD lineage.
+
+## In scope
+
+- one registry-backed module dashboard for Module 1
+- canonical status data stored in `docs/registry/current_state_registry.yaml`
+- one generated Markdown page under `docs/roadmap/`
+- a render script that converts registry dashboard entries into Markdown
+- explicit Module 1 fields for:
+  - mission
+  - MVP definition
+  - current overall status
+  - capability status
+  - MVP blockers
+  - PRD lineage
+  - next recommended slices
+  - post-MVP enhancements
+- workflow hooks requiring PM, review, and drift-monitor surfaces to keep the dashboard current
+
+## Out of scope
+
+- dashboards for modules other than Module 1
+- a web UI, terminal UI, or external dashboard application
+- automatic status inference from code alone
+- replacing PRDs, work items, or the current-state registry with the dashboard
+- a full schema validator for every registry field in v1
+- GitHub Project / Notion / Airtable synchronization
+
+## Core principles
+
+- registry is canonical, dashboard is derived
+- generated Markdown is human-facing, reviewable, and linkable
+- MVP status must be explicit per module
+- missing PRDs and PRD-version gaps must be called out directly
+- PM owns status truth, but review and drift-monitor surfaces enforce freshness
+- the dashboard must reduce planning ambiguity, not add another disconnected planning layer
+
+## Canonical surfaces
+
+### Source of truth
+
+`docs/registry/current_state_registry.yaml`
+
+The registry remains the authoritative structured source for:
+
+- module dashboard state
+- capability-level maturity
+- missing-for-MVP items
+- PRD lineage
+- version-gap tracking
+
+### Generated human-facing surface
+
+`docs/roadmap/module_1_var_dashboard.md`
+
+This file is generated from registry state and should not be hand-edited.
+
+### Generator
+
+`scripts/render_module_dashboard.py`
+
+The renderer reads the registry and writes the generated dashboard page.
+
+## Required dashboard sections (v1)
+
+The generated page must contain:
+
+- mission
+- MVP definition
+- current overall status
+- journey/status stages
+- capability status table
+- MVP gap summary
+- PRD lineage table
+- in-progress items
+- next recommended slices
+- post-MVP enhancements
+- open questions
+- change log
+
+## Required registry fields (v1)
+
+The registry must support a `module_dashboards` section with fields sufficient to render the required dashboard sections.
+
+At minimum the v1 dashboard entry must support:
+
+- `id`
+- `name`
+- `owner_role`
+- `dashboard_path`
+- `overall_state`
+- `delivery_phase`
+- `mission`
+- `mvp_definition`
+- `summary`
+- `current_mvp_blockers`
+- `not_required_for_mvp`
+- `journey_stages`
+- `capabilities`
+- `prd_lineage`
+- `in_progress_items`
+- `next_recommended_slices`
+- `post_mvp_enhancements`
+- `open_questions`
+- `change_log`
+
+Capability entries must support, at minimum:
+
+- `component_ref` or `name`
+- `layer`
+- `current_state`
+- `implemented_now`
+- `missing_for_mvp`
+- `missing_prds`
+- `needs_new_prd_version`
+- `next_version_reason`
+- `next_slice`
+
+## Workflow responsibilities
+
+### PM
+
+PM must update the registry and regenerate the affected dashboard when:
+
+- a capability maturity state changes
+- an MVP blocker is removed or newly discovered
+- PRD lineage changes
+- a new PRD or PRD v2 becomes required
+
+### Review
+
+Review must check status-surface freshness when a PR changes capability maturity, MVP blockers, or PRD lineage.
+
+### Drift monitor
+
+Drift monitor must treat generated dashboard pages as governed status surfaces and flag mismatches between:
+
+- registry state
+- generated dashboard content
+- implemented repository reality
+- PRD/work-item status claims
+
+## Degraded and drift states
+
+The dashboard system is degraded when:
+
+- the registry exists but the dashboard has not been regenerated after a material state change
+- the generated dashboard page contradicts implementation or PRD reality
+- a capability is marked mature but the required PRD or implementation is missing
+
+These are governance failures, not UI issues. They must be routed primarily to PM, and to PRD/spec when lineage is wrong or incomplete.
+
+## Acceptance criteria
+
+### Functional
+
+- Module 1 dashboard page exists under `docs/roadmap/`
+- dashboard content is generated from the registry, not hand-maintained prose
+- Module 1 dashboard clearly states:
+  - what is implemented
+  - what is missing for MVP
+  - which PRDs are missing
+  - which PRDs need a new version
+
+### Workflow
+
+- PM instruction surfaces explicitly reference registry-backed module dashboard maintenance
+- Review instruction surfaces explicitly check status-surface freshness
+- Drift-monitor instruction surfaces explicitly treat module dashboards as governed status surfaces
+
+### Test
+
+- unit tests cover rendering of the dashboard from a registry fixture
+- unit tests verify the renderer CLI writes the expected page
+- existing registry-alignment and instruction-surface checks continue to pass
+
+## Test intent
+
+- render a minimal registry fixture and assert required dashboard sections are present
+- assert known capability and PRD-lineage values appear in the generated output
+- assert the CLI writes the configured dashboard path
+- run instruction-surface and registry-alignment tests to confirm the new governance surfaces do not break existing drift controls
+
+## Suggested implementation decomposition
+
+v1 is intentionally one bounded slice:
+
+1. extend the registry schema in place
+2. add the renderer
+3. seed the Module 1 dashboard entry
+4. generate the dashboard page
+5. update PM / review / drift-monitor workflow hooks
+6. add renderer tests
+
+Future slices, if needed, should be separate:
+
+- dashboard schema validation
+- additional module dashboards
+- CI enforcement for dashboard regeneration
+- richer drift scanning for dashboard/registry mismatches
+
+## Open questions
+
+- should generated module dashboards eventually be re-rendered in CI and checked for clean diff?
+- should a dedicated deterministic drift scanner compare dashboard contents to registry contents, or is registry plus review discipline sufficient in v1?
+- when the second module dashboard is added, should there be an index page under `docs/roadmap/`?

--- a/docs/registry/current_state_registry.yaml
+++ b/docs/registry/current_state_registry.yaml
@@ -1,12 +1,257 @@
-version: 1
-last_updated: 2026-04-18
+version: 2
+last_updated: 2026-04-19
+
+module_dashboards:
+  - id: MODULE-1-VAR
+    name: "Module 1 Dashboard: End-to-End VaR Workflow"
+    owner_role: PM / Coordination Agent
+    dashboard_path: docs/roadmap/module_1_var_dashboard.md
+    overall_state: MVP_PARTIAL
+    delivery_phase: Phase 5
+    mission: >-
+      Deliver a replayable, deterministic, explainable daily VaR investigation
+      workflow for Module 1 using governed deterministic services, specialist
+      walkers, and bounded orchestration.
+    mvp_definition:
+      - deterministic VaR retrieval and change-profile analysis
+      - trust / readiness assessment
+      - quantitative interpretation
+      - time-series interpretation
+      - orchestrated investigation flow
+      - governance-ready handoff output
+    summary: >-
+      Deterministic risk analytics and controls-integrity foundations are
+      implemented. The bounded daily orchestrator exists. Multi-walker
+      analytical interpretation and governance-ready output are still missing.
+    current_mvp_blockers:
+      - Quant Walker v2 contract is not yet defined.
+      - Time Series Walker v1 PRD is missing.
+      - Daily Risk Investigation Orchestrator v2 multi-walker routing is missing.
+      - Governance / Reporting Walker v1 PRD is missing.
+    not_required_for_mvp:
+      - Market Context Walker
+      - Critic / Challenge Walker
+      - Human workflow / UX layer
+      - Advanced production scheduling
+    journey_stages:
+      - id: deterministic_foundation
+        label: Deterministic foundation
+        goal: canonical deterministic VaR analytics
+        status: done
+        notes: Risk Analytics and Controls Integrity deterministic services are implemented.
+      - id: trust_gate
+        label: Trust / controls gate
+        goal: determine whether data is safe to interpret
+        status: done
+        notes: Data Controller Walker and bounded trust-gate orchestration exist.
+      - id: analytical_interpretation
+        label: Analytical interpretation
+        goal: explain quantitative movement and historical context
+        status: partial
+        notes: Quant Walker exists as a delegate only; Time Series Walker is missing.
+      - id: workflow_orchestration
+        label: Workflow orchestration
+        goal: route, synthesize, challenge, and hand off the investigation
+        status: partial
+        notes: Daily orchestrator exists but is single-walker only.
+      - id: governance_handoff
+        label: Governance-ready handoff
+        goal: produce management-ready conclusions and actions
+        status: not_started
+        notes: Governance / Reporting Walker is not implemented.
+      - id: production_operation
+        label: Production operation
+        goal: durable, repeatable, live execution
+        status: not_started
+        notes: Durable persistence and live execution contracts are not yet implemented.
+    capabilities:
+      - component_ref: MOD-RISK-ANALYTICS
+        layer: module
+        current_state: implemented
+        implemented_now:
+          - get_risk_summary
+          - get_risk_delta
+          - get_risk_history
+          - get_risk_change_profile
+          - fixture loader and business-day resolver
+        missing_for_mvp:
+          - Decide whether production data integration is inside MVP scope.
+        missing_prds: []
+        needs_new_prd_version: false
+        next_version_reason: ""
+        next_slice: Decide whether a production adapter PRD is required for MVP.
+      - component_ref: MOD-CONTROLS-INTEGRITY
+        layer: module
+        current_state: implemented
+        implemented_now:
+          - IntegrityAssessment service
+          - shared evidence refs
+          - replay and validation coverage
+        missing_for_mvp:
+          - none
+        missing_prds: []
+        needs_new_prd_version: false
+        next_version_reason: ""
+        next_slice: No immediate MVP gap; extend only if new control families are required.
+      - component_ref: WALKER-DATA-CONTROLLER
+        layer: walker
+        current_state: implemented
+        implemented_now:
+          - assess_integrity delegate
+          - walker telemetry
+        missing_for_mvp:
+          - none
+        missing_prds: []
+        needs_new_prd_version: false
+        next_version_reason: ""
+        next_slice: Keep stable unless downstream consumers require richer walker-owned output.
+      - component_ref: WALKER-QUANT
+        layer: walker
+        current_state: delegate_only
+        implemented_now:
+          - summarize_change delegate over get_risk_change_profile
+        missing_for_mvp:
+          - interpretive quantitative walker output
+        missing_prds: []
+        needs_new_prd_version: true
+        next_version_reason: >-
+          Current PRD covers delegation-only v1. Module 1 MVP needs actual
+          walker inference over deterministic risk change output.
+        next_slice: Author PRD-4.2-v2 for interpretive Quant Walker output.
+      - component_ref: WALKER-TIME-SERIES
+        layer: walker
+        current_state: not_started
+        implemented_now: []
+        missing_for_mvp:
+          - full time-series interpretation capability
+        missing_prds:
+          - PRD-TBD-Time-Series-Walker-v1
+        needs_new_prd_version: true
+        next_version_reason: Capability has no v1 implementation PRD yet.
+        next_slice: Author Time Series Walker v1 PRD.
+      - component_ref: ORCH-DAILY-RISK-INVESTIGATION
+        layer: orchestrator
+        current_state: partial
+        implemented_now:
+          - bounded single-walker daily run
+          - target selection
+          - challenge gate
+          - typed handoff
+          - shared telemetry
+        missing_for_mvp:
+          - multi-walker routing
+          - multi-walker synthesis
+          - governance-ready downstream path
+        missing_prds: []
+        needs_new_prd_version: true
+        next_version_reason: >-
+          PRD-5.1 intentionally excludes quant/time-series routing and richer
+          orchestration behavior required for Module 1 MVP.
+        next_slice: Author PRD-5.1-v2 for multi-walker orchestration.
+      - component_ref: WALKER-GOVERNANCE-REPORTING
+        layer: walker
+        current_state: not_started
+        implemented_now: []
+        missing_for_mvp:
+          - governance-ready output
+        missing_prds:
+          - PRD-TBD-Governance-Reporting-Walker-v1
+        needs_new_prd_version: true
+        next_version_reason: Capability has no v1 implementation PRD yet.
+        next_slice: Author Governance / Reporting Walker v1 PRD.
+      - name: Production integration
+        layer: cross-cutting
+        current_state: not_started
+        implemented_now: []
+        missing_for_mvp:
+          - explicit live execution / persistence decision
+        missing_prds:
+          - PRD-TBD-Module-1-Production-Integration
+        needs_new_prd_version: true
+        next_version_reason: >-
+          Module 1 does not yet define whether MVP is fixture-backed only or
+          requires live execution semantics.
+        next_slice: Decide whether production integration is inside or after MVP, then author the required PRD.
+    prd_lineage:
+      - capability: Risk Analytics
+        active_prd: PRD-1.1-v2
+        status: active
+        supersedes: PRD-1.1-v1
+        next_needed_prd: ""
+        why: Current deterministic bounded scope is stable.
+      - capability: Controls Integrity
+        active_prd: PRD-2.1
+        status: active
+        supersedes: ""
+        next_needed_prd: ""
+        why: Current bounded trust-assessment scope is stable.
+      - capability: Data Controller Walker
+        active_prd: PRD-4.1
+        status: active
+        supersedes: ""
+        next_needed_prd: ""
+        why: v1 delegate is sufficient for the current trust-gate role.
+      - capability: Quant Walker
+        active_prd: PRD-4.2
+        status: active
+        supersedes: ""
+        next_needed_prd: PRD-4.2-v2
+        why: v1 is delegation-only; Module 1 MVP needs interpretive walker output.
+      - capability: Time Series Walker
+        active_prd: ""
+        status: missing
+        supersedes: ""
+        next_needed_prd: PRD-TBD-Time-Series-Walker-v1
+        why: Capability required for MVP but no implementation PRD exists.
+      - capability: Daily Risk Investigation Orchestrator
+        active_prd: PRD-5.1
+        status: active
+        supersedes: ""
+        next_needed_prd: PRD-5.1-v2
+        why: Current orchestrator is bounded to a single-walker flow.
+      - capability: Governance / Reporting Walker
+        active_prd: ""
+        status: missing
+        supersedes: ""
+        next_needed_prd: PRD-TBD-Governance-Reporting-Walker-v1
+        why: Capability required for MVP but no implementation PRD exists.
+    in_progress_items: []
+    next_recommended_slices:
+      - Author PRD-4.2-v2 for interpretive Quant Walker output.
+      - Author Time Series Walker v1 PRD.
+      - Author PRD-5.1-v2 for multi-walker orchestration.
+      - Author Governance / Reporting Walker v1 PRD.
+    post_mvp_enhancements:
+      - Market Context Walker
+      - Critic / Challenge Walker
+      - Human workflow and UX layer
+      - richer production operations
+    open_questions:
+      - Is live-data integration inside Module 1 MVP or immediately post-MVP?
+      - Is Governance / Reporting Walker required for MVP or can typed handoff suffice?
+    change_log:
+      - "2026-04-19: Initial Module 1 dashboard seed added to the registry."
 
 components:
   modules:
     - id: MOD-RISK-ANALYTICS
       name: Risk Analytics
-      status: in-progress
+      status: implemented
       contract_status: implemented
+      active_prds:
+        - PRD-1.1-v2
+      superseded_prds:
+        - PRD-1.1-v1
+      missing_prds: []
+      needs_new_prd_version: false
+      next_version_reason: ""
+      delivery_stage: foundation_implemented
+      mvp_relevance:
+        - MODULE-1-VAR
+      missing_for_mvp:
+        - Decide whether production integration belongs in MVP scope.
+      next_recommended_slices:
+        - Decide whether a production adapter PRD is required for MVP.
       sub_components:
         - name: contracts
           path: src/modules/risk_analytics/contracts/
@@ -25,8 +270,20 @@ components:
           status: implemented
     - id: MOD-CONTROLS-INTEGRITY
       name: Controls Integrity
-      status: in-progress
+      status: implemented
       contract_status: implemented
+      active_prds:
+        - PRD-2.1
+      superseded_prds: []
+      missing_prds: []
+      needs_new_prd_version: false
+      next_version_reason: ""
+      delivery_stage: foundation_implemented
+      mvp_relevance:
+        - MODULE-1-VAR
+      missing_for_mvp: []
+      next_recommended_slices:
+        - No immediate MVP gap; extend only if new control families are required.
       sub_components:
         - name: contracts
           path: src/modules/controls_integrity/contracts/
@@ -59,16 +316,56 @@ components:
   walkers:
     - id: WALKER-QUANT
       name: Quant Walker
-      status: in-progress
-      contract_status: draft
+      status: implemented
+      contract_status: implemented
+      active_prds:
+        - PRD-4.2
+      superseded_prds: []
+      missing_prds: []
+      needs_new_prd_version: true
+      next_version_reason: >-
+        Current PRD is delegation-only; richer interpretive output is needed
+        for Module 1 MVP.
+      delivery_stage: delegate_implemented
+      mvp_relevance:
+        - MODULE-1-VAR
+      missing_for_mvp:
+        - interpretive quantitative output
+      next_recommended_slices:
+        - Author PRD-4.2-v2.
     - id: WALKER-TIME-SERIES
       name: Time Series Walker
       status: proposed
       contract_status: draft
+      active_prds: []
+      superseded_prds: []
+      missing_prds:
+        - PRD-TBD-Time-Series-Walker-v1
+      needs_new_prd_version: true
+      next_version_reason: Capability does not yet have a v1 implementation PRD.
+      delivery_stage: not_started
+      mvp_relevance:
+        - MODULE-1-VAR
+      missing_for_mvp:
+        - full time-series interpretation capability
+      next_recommended_slices:
+        - Author Time Series Walker v1 PRD.
     - id: WALKER-DATA-CONTROLLER
       name: Data Controller Walker
-      status: in-progress
-      contract_status: draft
+      status: implemented
+      contract_status: implemented
+      active_prds:
+        - PRD-4.1
+      superseded_prds: []
+      missing_prds: []
+      needs_new_prd_version: false
+      next_version_reason: ""
+      delivery_stage: delegate_implemented
+      mvp_relevance:
+        - MODULE-1-VAR
+      missing_for_mvp: []
+      next_recommended_slices:
+        - Keep stable unless downstream consumers require richer output.
     - id: WALKER-CONTROLS-CHANGE
       name: Controls / Change Walker
       status: proposed
@@ -81,6 +378,19 @@ components:
       name: Governance / Reporting Walker
       status: proposed
       contract_status: draft
+      active_prds: []
+      superseded_prds: []
+      missing_prds:
+        - PRD-TBD-Governance-Reporting-Walker-v1
+      needs_new_prd_version: true
+      next_version_reason: Capability does not yet have a v1 implementation PRD.
+      delivery_stage: not_started
+      mvp_relevance:
+        - MODULE-1-VAR
+      missing_for_mvp:
+        - governance-ready output
+      next_recommended_slices:
+        - Author Governance / Reporting Walker v1 PRD.
     - id: WALKER-CRITIC-CHALLENGE
       name: Critic / Challenge Walker
       status: proposed
@@ -97,8 +407,25 @@ components:
   orchestrators:
     - id: ORCH-DAILY-RISK-INVESTIGATION
       name: Daily Risk Investigation
-      status: in-progress
-      contract_status: draft
+      status: implemented
+      contract_status: implemented
+      active_prds:
+        - PRD-5.1
+      superseded_prds: []
+      missing_prds: []
+      needs_new_prd_version: true
+      next_version_reason: >-
+        Current orchestrator is bounded to a single-walker v1 flow; Module 1
+        MVP requires multi-walker routing and synthesis.
+      delivery_stage: workflow_partial
+      mvp_relevance:
+        - MODULE-1-VAR
+      missing_for_mvp:
+        - multi-walker routing
+        - multi-walker synthesis
+        - governance-ready downstream path
+      next_recommended_slices:
+        - Author PRD-5.1-v2.
     - id: ORCH-LIMIT-BREACH
       name: Limit Breach
       status: proposed

--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -1,0 +1,25 @@
+# Roadmap Surfaces
+
+## Purpose
+
+This folder holds operator-facing roadmap views for repository delivery state.
+
+Use these surfaces together:
+
+- [Phased Implementation Roadmap](/Users/thomas/Documents/Projects/risk-manager/docs/roadmap/phased_implementation_roadmap.md:1)
+  High-level phase sequencing and delivery principles for the repository as a whole.
+- [Module 1 Dashboard: End-to-End VaR Workflow](/Users/thomas/Documents/Projects/risk-manager/docs/roadmap/module_1_var_dashboard.md:1)
+  Registry-backed status view for Module 1 showing what is implemented, what is missing for MVP, which PRDs are missing, and which capabilities need a new PRD version.
+
+## Source Of Truth
+
+- Phase-level sequencing remains governed by [phased_implementation_roadmap.md](/Users/thomas/Documents/Projects/risk-manager/docs/roadmap/phased_implementation_roadmap.md:1).
+- Module dashboard content is generated from [current_state_registry.yaml](/Users/thomas/Documents/Projects/risk-manager/docs/registry/current_state_registry.yaml:1) via [render_module_dashboard.py](/Users/thomas/Documents/Projects/risk-manager/scripts/render_module_dashboard.py:1).
+
+Do not hand-edit generated dashboard pages. Update the registry and re-render instead.
+
+## Ownership
+
+- PM / Coordination Agent owns freshness of module dashboard state.
+- Review Agent checks status-surface freshness when capability maturity or PRD lineage changes.
+- Drift Monitor Agent audits roadmap / registry / implementation alignment.

--- a/docs/roadmap/module_1_var_dashboard.md
+++ b/docs/roadmap/module_1_var_dashboard.md
@@ -1,0 +1,110 @@
+<!-- GENERATED FILE: edit docs/registry/current_state_registry.yaml and rerun scripts/render_module_dashboard.py -->
+
+# Module 1 Dashboard: End-to-End VaR Workflow
+
+_Last updated: 2026-04-19_  
+_Source of truth: `docs/registry/current_state_registry.yaml`_  
+_Owner: PM / Coordination Agent_
+
+## Mission
+
+Deliver a replayable, deterministic, explainable daily VaR investigation workflow for Module 1 using governed deterministic services, specialist walkers, and bounded orchestration.
+
+## MVP Definition
+
+- deterministic VaR retrieval and change-profile analysis
+- trust / readiness assessment
+- quantitative interpretation
+- time-series interpretation
+- orchestrated investigation flow
+- governance-ready handoff output
+
+## Current Overall Status
+
+- Overall state: `MVP_PARTIAL`
+- Delivery phase: `Phase 5`
+- Summary: Deterministic risk analytics and controls-integrity foundations are implemented. The bounded daily orchestrator exists. Multi-walker analytical interpretation and governance-ready output are still missing.
+- Current MVP blockers:
+  - Quant Walker v2 contract is not yet defined.
+  - Time Series Walker v1 PRD is missing.
+  - Daily Risk Investigation Orchestrator v2 multi-walker routing is missing.
+  - Governance / Reporting Walker v1 PRD is missing.
+
+## Journey Status
+
+| Stage | Goal | Status | Notes |
+| --- | --- | --- | --- |
+| Deterministic foundation | canonical deterministic VaR analytics | `done` | Risk Analytics and Controls Integrity deterministic services are implemented. |
+| Trust / controls gate | determine whether data is safe to interpret | `done` | Data Controller Walker and bounded trust-gate orchestration exist. |
+| Analytical interpretation | explain quantitative movement and historical context | `partial` | Quant Walker exists as a delegate only; Time Series Walker is missing. |
+| Workflow orchestration | route, synthesize, challenge, and hand off the investigation | `partial` | Daily orchestrator exists but is single-walker only. |
+| Governance-ready handoff | produce management-ready conclusions and actions | `not_started` | Governance / Reporting Walker is not implemented. |
+| Production operation | durable, repeatable, live execution | `not_started` | Durable persistence and live execution contracts are not yet implemented. |
+
+## Capability Status
+
+| Capability | Layer | Current State | Implemented Now | Missing For MVP | Missing PRD | Needs New PRD Version? | Reason | Next Slice |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| Risk Analytics | module | `implemented` | get_risk_summary<br>get_risk_delta<br>get_risk_history<br>get_risk_change_profile<br>fixture loader and business-day resolver | Decide whether production data integration is inside MVP scope. | none | `no` | none | Decide whether a production adapter PRD is required for MVP. |
+| Controls Integrity | module | `implemented` | IntegrityAssessment service<br>shared evidence refs<br>replay and validation coverage | none | none | `no` | none | No immediate MVP gap; extend only if new control families are required. |
+| Data Controller Walker | walker | `implemented` | assess_integrity delegate<br>walker telemetry | none | none | `no` | none | Keep stable unless downstream consumers require richer walker-owned output. |
+| Quant Walker | walker | `delegate_only` | summarize_change delegate over get_risk_change_profile | interpretive quantitative walker output | none | `yes` | Current PRD covers delegation-only v1. Module 1 MVP needs actual walker inference over deterministic risk change output. | Author PRD-4.2-v2 for interpretive Quant Walker output. |
+| Time Series Walker | walker | `not_started` | none | full time-series interpretation capability | PRD-TBD-Time-Series-Walker-v1 | `yes` | Capability has no v1 implementation PRD yet. | Author Time Series Walker v1 PRD. |
+| Daily Risk Investigation | orchestrator | `partial` | bounded single-walker daily run<br>target selection<br>challenge gate<br>typed handoff<br>shared telemetry | multi-walker routing<br>multi-walker synthesis<br>governance-ready downstream path | none | `yes` | PRD-5.1 intentionally excludes quant/time-series routing and richer orchestration behavior required for Module 1 MVP. | Author PRD-5.1-v2 for multi-walker orchestration. |
+| Governance / Reporting Walker | walker | `not_started` | none | governance-ready output | PRD-TBD-Governance-Reporting-Walker-v1 | `yes` | Capability has no v1 implementation PRD yet. | Author Governance / Reporting Walker v1 PRD. |
+| Production integration | cross-cutting | `not_started` | none | explicit live execution / persistence decision | PRD-TBD-Module-1-Production-Integration | `yes` | Module 1 does not yet define whether MVP is fixture-backed only or requires live execution semantics. | Decide whether production integration is inside or after MVP, then author the required PRD. |
+
+## MVP Gap Summary
+
+The following items are still required to declare Module 1 MVP complete:
+
+- Quant Walker v2 contract is not yet defined.
+- Time Series Walker v1 PRD is missing.
+- Daily Risk Investigation Orchestrator v2 multi-walker routing is missing.
+- Governance / Reporting Walker v1 PRD is missing.
+
+The following items are explicitly not required for Module 1 MVP:
+
+- Market Context Walker
+- Critic / Challenge Walker
+- Human workflow / UX layer
+- Advanced production scheduling
+
+## PRD Lineage
+
+| Capability | Active PRD | Status | Supersedes | Next Needed PRD | Why |
+| --- | --- | --- | --- | --- | --- |
+| Risk Analytics | PRD-1.1-v2 | `active` | PRD-1.1-v1 | none | Current deterministic bounded scope is stable. |
+| Controls Integrity | PRD-2.1 | `active` | none | none | Current bounded trust-assessment scope is stable. |
+| Data Controller Walker | PRD-4.1 | `active` | none | none | v1 delegate is sufficient for the current trust-gate role. |
+| Quant Walker | PRD-4.2 | `active` | none | PRD-4.2-v2 | v1 is delegation-only; Module 1 MVP needs interpretive walker output. |
+| Time Series Walker | none | `missing` | none | PRD-TBD-Time-Series-Walker-v1 | Capability required for MVP but no implementation PRD exists. |
+| Daily Risk Investigation Orchestrator | PRD-5.1 | `active` | none | PRD-5.1-v2 | Current orchestrator is bounded to a single-walker flow. |
+| Governance / Reporting Walker | none | `missing` | none | PRD-TBD-Governance-Reporting-Walker-v1 | Capability required for MVP but no implementation PRD exists. |
+
+## In Progress
+
+None recorded.
+
+## Next Recommended Slices
+
+1. Author PRD-4.2-v2 for interpretive Quant Walker output.
+2. Author Time Series Walker v1 PRD.
+3. Author PRD-5.1-v2 for multi-walker orchestration.
+4. Author Governance / Reporting Walker v1 PRD.
+
+## Post-MVP Enhancements
+
+- Market Context Walker
+- Critic / Challenge Walker
+- Human workflow and UX layer
+- richer production operations
+
+## Open Questions
+
+- Is live-data integration inside Module 1 MVP or immediately post-MVP?
+- Is Governance / Reporting Walker required for MVP or can typed handoff suffice?
+
+## Change Log
+
+- 2026-04-19: Initial Module 1 dashboard seed added to the registry.

--- a/prompts/agents/drift_monitor_agent_instruction.md
+++ b/prompts/agents/drift_monitor_agent_instruction.md
@@ -14,8 +14,9 @@ The drift monitor is a repo-health auditor, not a coding agent, not a PR reviewe
 4. `docs/delivery/05_repo_drift_monitoring.md`
 5. `docs/guides/repo_health_audit_checklist.md`
 6. `docs/registry/current_state_registry.yaml`
-7. deterministic precheck output if present under `artifacts/drift/`
-8. relevant README, PRD, ADR, or prompt artifacts in the repo areas being audited
+7. relevant generated module dashboard pages under `docs/roadmap/`
+8. deterministic precheck output if present under `artifacts/drift/`
+9. relevant README, PRD, ADR, or prompt artifacts in the repo areas being audited
 
 ## Primary responsibilities
 
@@ -24,6 +25,7 @@ The drift monitor is a repo-health auditor, not a coding agent, not a PR reviewe
 - detect boundary erosion across modules, walkers, orchestrators, and UI
 - detect tooling and dependency drift such as missing packaging, mismatched CI controls, or declared dependencies far ahead of actual implementation use
 - detect maturity mismatches where registries, statuses, or roadmap signals no longer reflect implemented and tested reality
+- detect module dashboard drift where generated human-readable status pages no longer match registry truth or repository reality
 - detect document sprawl, repetitive prose, and focus loss where those problems weaken governance
 - detect operational-instruction sprawl across multiple agent or tool surfaces
 - route each material finding to the right owner
@@ -48,7 +50,7 @@ Is the implementation still respecting module, walker, orchestrator, and UI boun
 
 ### 5. Registry and structure integrity
 
-Do registry, catalogs, README files, and folder-level docs still reflect reality?
+Do registry entries, generated module dashboard pages, catalogs, README files, and folder-level docs still reflect reality?
 
 ### 6. Tooling and dependency integrity
 

--- a/prompts/agents/pm_agent_instruction.md
+++ b/prompts/agents/pm_agent_instruction.md
@@ -11,6 +11,7 @@ The PM agent owns readiness, dependency logic, work-item promotion, and overnigh
 - maintain dependency integrity
 - enforce `work_items/READY_CRITERIA.md`
 - apply the delivery canon in `docs/delivery/`
+- keep `docs/registry/current_state_registry.yaml` and generated module dashboard pages under `docs/roadmap/` aligned with real capability maturity
 - triage repo-wide drift findings into PM, spec, PRD, coding, review, repository maintenance, or human follow-up
 - route missing-contract work to PRD, ADR, or spec drafting
 - assign only bounded work items for coding
@@ -34,7 +35,7 @@ Before promoting or assigning work, read in this order:
 10. relevant work item
 11. linked PRD
 12. linked ADRs
-13. relevant roadmap or registry entries
+13. relevant roadmap, registry, and module dashboard entries
 
 ## Operating rules
 
@@ -72,6 +73,12 @@ If a slice touches cross-cutting infrastructure (for example telemetry), the
 implementation brief must link relevant `docs/shared_infra/` canon and state
 whether this is a shared-contract change or module-local adoption only.
 
+### Keep status surfaces fresh
+
+When capability maturity, MVP blockers, or PRD lineage change, update
+`docs/registry/current_state_registry.yaml` first and regenerate the affected
+module dashboard page under `docs/roadmap/` before handing work forward.
+
 ## Allowed outputs
 
 - backlog sequencing
@@ -93,7 +100,9 @@ implementation.
 
 When the PM agent is told a PR has been merged, the WI is already in `done/`.
 The PM agent's job at that point is only to assess the next ready work item and
-produce the next implementation brief or identify blockers.
+produce the next implementation brief or identify blockers. If the merged work
+changed capability maturity, MVP blockers, or PRD lineage, update the registry
+and regenerate the relevant module dashboard before the next readiness pass.
 
 ## Stop conditions
 

--- a/prompts/agents/review_agent_instruction.md
+++ b/prompts/agents/review_agent_instruction.md
@@ -13,8 +13,9 @@ The review agent is not a style enforcer first. Its main job is to detect wrong 
 3. linked PRD
 4. linked ADRs
 5. `docs/shared_infra/index.md` (when shared infra is touched)
-6. relevant changed files
-7. relevant tests
+6. relevant roadmap / registry / module dashboard entries when the PR changes capability maturity or PRD lineage
+7. relevant changed files
+8. relevant tests
 
 ## Review priorities
 
@@ -45,7 +46,13 @@ If the PR affects deterministic or governed outputs, are replay and evidence hoo
 
 Do tests cover positive, negative, edge, and degraded cases required by the PRD?
 
-### 7. Work-item lifecycle
+### 7. Status-surface freshness
+
+If the PR changes capability maturity, MVP blockers, or PRD lineage, were
+`docs/registry/current_state_registry.yaml` and any affected generated module
+dashboard pages under `docs/roadmap/` updated to reflect that new reality?
+
+### 8. Work-item lifecycle
 
 Not a review check — the review agent performs this action itself after
 issuing PASS (see "GitHub actions required during review", step 4).

--- a/scripts/drift/check_module_dashboard_freshness.py
+++ b/scripts/drift/check_module_dashboard_freshness.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import sys
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Scan generated module dashboard pages for stale or missing output relative to the registry.")
+    parser.add_argument("--root", help="Repository root to scan. Defaults to the repo root containing this script.")
+    parser.add_argument("--output", help="Optional JSON report path.")
+    parser.add_argument(
+        "--fail-on-findings",
+        action="store_true",
+        help="Exit non-zero when any findings are detected.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    repo_root = Path(__file__).resolve().parents[2]
+    if str(repo_root) not in sys.path:
+        sys.path.insert(0, str(repo_root))
+
+    from agent_runtime.drift.module_dashboard_freshness import build_module_dashboard_freshness_report
+
+    args = parse_args()
+    scan_root = repo_root if args.root is None else _resolve_scan_root(repo_root, args.root)
+    report = build_module_dashboard_freshness_report(scan_root)
+    payload = json.dumps(report.to_dict(), indent=2, sort_keys=True)
+    if args.output:
+        output_path = Path(args.output)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(payload + "\n", encoding="utf-8")
+    print(payload)
+    if args.fail_on_findings and report.findings:
+        return 1
+    return 0
+
+
+def _resolve_scan_root(repo_root: Path, raw_root: str) -> Path:
+    candidate = Path(raw_root)
+    resolved = candidate if candidate.is_absolute() else (repo_root / candidate)
+    resolved = resolved.resolve()
+    if not resolved.exists():
+        raise FileNotFoundError(f"Scan root `{resolved}` does not exist.")
+    if not resolved.is_dir():
+        raise NotADirectoryError(f"Scan root `{resolved}` is not a directory.")
+    return resolved
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/render_module_dashboard.py
+++ b/scripts/render_module_dashboard.py
@@ -99,7 +99,7 @@ def render_module_dashboard(payload: dict[str, Any], *, module_id: str) -> str:
     )
     for stage in _mapping_list(dashboard_entry.get("journey_stages")):
         lines.append(
-            f"| {stage.get('label', '')} | {_normalize_text(stage.get('goal'))} | "
+            f"| {_escape_markdown_table_text(stage.get('label'))} | {_normalize_text(stage.get('goal'))} | "
             f"`{stage.get('status', 'unknown')}` | {_normalize_text(stage.get('notes'))} |"
         )
 
@@ -117,7 +117,8 @@ def render_module_dashboard(payload: dict[str, Any], *, module_id: str) -> str:
         component = component_index.get(component_ref, {})
         capability_name = str(component.get("name") or capability.get("name") or component_ref)
         lines.append(
-            f"| {capability_name} | {capability.get('layer', '')} | `{capability.get('current_state', 'unknown')}` | "
+            f"| {_escape_markdown_table_text(capability_name)} | {_escape_markdown_table_text(capability.get('layer'))} | "
+            f"`{capability.get('current_state', 'unknown')}` | "
             f"{_render_table_list(_string_list(capability.get('implemented_now')))} | "
             f"{_render_table_list(_string_list(capability.get('missing_for_mvp')))} | "
             f"{_render_table_list(_string_list(capability.get('missing_prds')))} | "
@@ -155,7 +156,7 @@ def render_module_dashboard(payload: dict[str, Any], *, module_id: str) -> str:
     )
     for lineage in _mapping_list(dashboard_entry.get("prd_lineage")):
         lines.append(
-            f"| {lineage.get('capability', '')} | {_normalize_text(lineage.get('active_prd'))} | "
+            f"| {_escape_markdown_table_text(lineage.get('capability'))} | {_normalize_text(lineage.get('active_prd'))} | "
             f"`{lineage.get('status', 'unknown')}` | {_normalize_text(lineage.get('supersedes'))} | "
             f"{_normalize_text(lineage.get('next_needed_prd'))} | {_normalize_text(lineage.get('why'))} |"
         )
@@ -171,8 +172,8 @@ def render_module_dashboard(payload: dict[str, Any], *, module_id: str) -> str:
         )
         for item in in_progress_items:
             lines.append(
-                f"| {item.get('id', '')} | `{item.get('type', '')}` | `{item.get('status', '')}` | "
-                f"{item.get('owner', '')} | `{'yes' if item.get('blocking') else 'no'}` | {_normalize_text(item.get('notes'))} |"
+                f"| {_escape_markdown_table_text(item.get('id'))} | `{item.get('type', '')}` | `{item.get('status', '')}` | "
+                f"{_escape_markdown_table_text(item.get('owner'))} | `{'yes' if item.get('blocking') else 'no'}` | {_normalize_text(item.get('notes'))} |"
             )
     else:
         lines.append("None recorded.")
@@ -256,15 +257,20 @@ def _string_list(value: Any) -> list[str]:
         raise ValueError("expected a list of strings")
     out: list[str] = []
     for item in value:
-        text = str(item).strip()
+        text = _escape_markdown_table_text(item)
         if text:
             out.append(text)
     return out
 
 
 def _normalize_text(value: Any) -> str:
-    text = str(value).strip() if value is not None else ""
+    text = _escape_markdown_table_text(value)
     return text or "none"
+
+
+def _escape_markdown_table_text(value: Any) -> str:
+    text = str(value).strip() if value is not None else ""
+    return text.replace("|", "\\|")
 
 
 def _render_table_list(items: list[str]) -> str:

--- a/scripts/render_module_dashboard.py
+++ b/scripts/render_module_dashboard.py
@@ -1,0 +1,293 @@
+#!/usr/bin/env python3
+"""Render human-readable module dashboard pages from the registry."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+DEFAULT_REGISTRY_PATH = Path("docs/registry/current_state_registry.yaml")
+
+
+def find_repo_root(start: Path) -> Path:
+    candidate = start if start.is_dir() else start.parent
+    for path in (candidate, *candidate.parents):
+        if (path / "AGENTS.md").exists() and (path / "docs").is_dir():
+            return path
+    raise RuntimeError("Could not find repository root.")
+
+
+def load_registry(registry_path: Path) -> dict[str, Any]:
+    payload = yaml.safe_load(registry_path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("registry payload must be a mapping")
+    return payload
+
+
+def build_component_index(payload: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    components = payload.get("components", {})
+    if not isinstance(components, dict):
+        raise ValueError("registry `components` must be a mapping")
+    out: dict[str, dict[str, Any]] = {}
+    for section_name in ("modules", "walkers", "orchestrators"):
+        entries = components.get(section_name, [])
+        if not isinstance(entries, list):
+            raise ValueError(f"registry `components.{section_name}` must be a list")
+        for entry in entries:
+            if not isinstance(entry, dict):
+                raise ValueError(f"registry `components.{section_name}` entries must be mappings")
+            component_id = entry.get("id")
+            if isinstance(component_id, str) and component_id:
+                out[component_id] = entry
+    return out
+
+
+def render_module_dashboard(payload: dict[str, Any], *, module_id: str) -> str:
+    module_dashboards = payload.get("module_dashboards", [])
+    if not isinstance(module_dashboards, list):
+        raise ValueError("registry `module_dashboards` must be a list")
+
+    dashboard_entry = next(
+        (entry for entry in module_dashboards if isinstance(entry, dict) and entry.get("id") == module_id),
+        None,
+    )
+    if dashboard_entry is None:
+        raise KeyError(f"module dashboard `{module_id}` not found in registry")
+
+    component_index = build_component_index(payload)
+    lines: list[str] = [
+        "<!-- GENERATED FILE: edit docs/registry/current_state_registry.yaml and rerun scripts/render_module_dashboard.py -->",
+        "",
+        f"# {dashboard_entry['name']}",
+        "",
+        f"_Last updated: {payload.get('last_updated', 'unknown')}_  ",
+        f"_Source of truth: `{DEFAULT_REGISTRY_PATH.as_posix()}`_  ",
+        f"_Owner: {dashboard_entry.get('owner_role', 'PM')}_",
+        "",
+        "## Mission",
+        "",
+        str(dashboard_entry.get("mission", "")).strip(),
+        "",
+        "## MVP Definition",
+        "",
+    ]
+    lines.extend(_render_bullets(_string_list(dashboard_entry.get("mvp_definition"))))
+    lines.extend(
+        [
+            "",
+            "## Current Overall Status",
+            "",
+            f"- Overall state: `{dashboard_entry.get('overall_state', 'unknown')}`",
+            f"- Delivery phase: `{dashboard_entry.get('delivery_phase', 'unknown')}`",
+            f"- Summary: {_normalize_text(dashboard_entry.get('summary'))}",
+            "- Current MVP blockers:",
+        ]
+    )
+    lines.extend(_render_indented_bullets(_string_list(dashboard_entry.get("current_mvp_blockers")), empty_text="none recorded"))
+    lines.extend(
+        [
+            "",
+            "## Journey Status",
+            "",
+            "| Stage | Goal | Status | Notes |",
+            "| --- | --- | --- | --- |",
+        ]
+    )
+    for stage in _mapping_list(dashboard_entry.get("journey_stages")):
+        lines.append(
+            f"| {stage.get('label', '')} | {_normalize_text(stage.get('goal'))} | "
+            f"`{stage.get('status', 'unknown')}` | {_normalize_text(stage.get('notes'))} |"
+        )
+
+    lines.extend(
+        [
+            "",
+            "## Capability Status",
+            "",
+            "| Capability | Layer | Current State | Implemented Now | Missing For MVP | Missing PRD | Needs New PRD Version? | Reason | Next Slice |",
+            "| --- | --- | --- | --- | --- | --- | --- | --- | --- |",
+        ]
+    )
+    for capability in _mapping_list(dashboard_entry.get("capabilities")):
+        component_ref = str(capability.get("component_ref", ""))
+        component = component_index.get(component_ref, {})
+        capability_name = str(component.get("name") or capability.get("name") or component_ref)
+        lines.append(
+            f"| {capability_name} | {capability.get('layer', '')} | `{capability.get('current_state', 'unknown')}` | "
+            f"{_render_table_list(_string_list(capability.get('implemented_now')))} | "
+            f"{_render_table_list(_string_list(capability.get('missing_for_mvp')))} | "
+            f"{_render_table_list(_string_list(capability.get('missing_prds')))} | "
+            f"`{'yes' if capability.get('needs_new_prd_version') else 'no'}` | "
+            f"{_normalize_text(capability.get('next_version_reason'))} | "
+            f"{_normalize_text(capability.get('next_slice'))} |"
+        )
+
+    lines.extend(
+        [
+            "",
+            "## MVP Gap Summary",
+            "",
+            "The following items are still required to declare Module 1 MVP complete:",
+            "",
+        ]
+    )
+    lines.extend(_render_bullets(_string_list(dashboard_entry.get("current_mvp_blockers"))))
+    lines.extend(
+        [
+            "",
+            "The following items are explicitly not required for Module 1 MVP:",
+            "",
+        ]
+    )
+    lines.extend(_render_bullets(_string_list(dashboard_entry.get("not_required_for_mvp"))))
+    lines.extend(
+        [
+            "",
+            "## PRD Lineage",
+            "",
+            "| Capability | Active PRD | Status | Supersedes | Next Needed PRD | Why |",
+            "| --- | --- | --- | --- | --- | --- |",
+        ]
+    )
+    for lineage in _mapping_list(dashboard_entry.get("prd_lineage")):
+        lines.append(
+            f"| {lineage.get('capability', '')} | {_normalize_text(lineage.get('active_prd'))} | "
+            f"`{lineage.get('status', 'unknown')}` | {_normalize_text(lineage.get('supersedes'))} | "
+            f"{_normalize_text(lineage.get('next_needed_prd'))} | {_normalize_text(lineage.get('why'))} |"
+        )
+
+    lines.extend(["", "## In Progress", ""])
+    in_progress_items = _mapping_list(dashboard_entry.get("in_progress_items"))
+    if in_progress_items:
+        lines.extend(
+            [
+                "| Item | Type | Status | Owner | Blocking? | Notes |",
+                "| --- | --- | --- | --- | --- | --- |",
+            ]
+        )
+        for item in in_progress_items:
+            lines.append(
+                f"| {item.get('id', '')} | `{item.get('type', '')}` | `{item.get('status', '')}` | "
+                f"{item.get('owner', '')} | `{'yes' if item.get('blocking') else 'no'}` | {_normalize_text(item.get('notes'))} |"
+            )
+    else:
+        lines.append("None recorded.")
+
+    lines.extend(["", "## Next Recommended Slices", ""])
+    lines.extend(_render_numbered(_string_list(dashboard_entry.get("next_recommended_slices"))))
+    lines.extend(["", "## Post-MVP Enhancements", ""])
+    lines.extend(_render_bullets(_string_list(dashboard_entry.get("post_mvp_enhancements"))))
+    lines.extend(["", "## Open Questions", ""])
+    lines.extend(_render_bullets(_string_list(dashboard_entry.get("open_questions"))))
+    lines.extend(["", "## Change Log", ""])
+    lines.extend(_render_bullets(_string_list(dashboard_entry.get("change_log"))))
+    lines.append("")
+    return "\n".join(lines)
+
+
+def render_dashboards(
+    payload: dict[str, Any],
+    *,
+    repo_root: Path,
+    module_id: str | None = None,
+) -> tuple[Path, ...]:
+    module_dashboards = payload.get("module_dashboards", [])
+    if not isinstance(module_dashboards, list):
+        raise ValueError("registry `module_dashboards` must be a list")
+
+    targets = [entry for entry in module_dashboards if isinstance(entry, dict)]
+    if module_id is not None:
+        targets = [entry for entry in targets if entry.get("id") == module_id]
+        if not targets:
+            raise KeyError(f"module dashboard `{module_id}` not found in registry")
+
+    written_paths: list[Path] = []
+    for entry in targets:
+        output_rel = entry.get("dashboard_path")
+        if not isinstance(output_rel, str) or not output_rel:
+            raise ValueError("module dashboard entries must declare a non-empty `dashboard_path`")
+        output_path = repo_root / output_rel
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(render_module_dashboard(payload, module_id=str(entry["id"])), encoding="utf-8")
+        written_paths.append(output_path)
+    return tuple(written_paths)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Render module dashboard pages from the current-state registry.")
+    parser.add_argument("--root", default=None, help="Repository root. Defaults to auto-detected root from the current working directory.")
+    parser.add_argument("--registry", default=str(DEFAULT_REGISTRY_PATH), help="Registry path relative to repo root.")
+    parser.add_argument("--module-id", default=None, help="Render only one module dashboard id.")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    repo_root = Path(args.root).resolve() if args.root else find_repo_root(Path.cwd())
+    registry_path = repo_root / args.registry
+    payload = load_registry(registry_path)
+    written_paths = render_dashboards(payload, repo_root=repo_root, module_id=args.module_id)
+    for path in written_paths:
+        print(path.relative_to(repo_root).as_posix())
+    return 0
+
+
+def _mapping_list(value: Any) -> list[dict[str, Any]]:
+    if value is None:
+        return []
+    if not isinstance(value, list):
+        raise ValueError("expected a list of mappings")
+    out: list[dict[str, Any]] = []
+    for item in value:
+        if not isinstance(item, dict):
+            raise ValueError("expected a list of mappings")
+        out.append(item)
+    return out
+
+
+def _string_list(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if not isinstance(value, list):
+        raise ValueError("expected a list of strings")
+    out: list[str] = []
+    for item in value:
+        text = str(item).strip()
+        if text:
+            out.append(text)
+    return out
+
+
+def _normalize_text(value: Any) -> str:
+    text = str(value).strip() if value is not None else ""
+    return text or "none"
+
+
+def _render_table_list(items: list[str]) -> str:
+    return "<br>".join(items) if items else "none"
+
+
+def _render_bullets(items: list[str]) -> list[str]:
+    if not items:
+        return ["- none"]
+    return [f"- {item}" for item in items]
+
+
+def _render_indented_bullets(items: list[str], *, empty_text: str) -> list[str]:
+    if not items:
+        return [f"  - {empty_text}"]
+    return [f"  - {item}" for item in items]
+
+
+def _render_numbered(items: list[str]) -> list[str]:
+    if not items:
+        return ["1. none"]
+    return [f"{index}. {item}" for index, item in enumerate(items, start=1)]
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/agent_runtime/test_dependency_hygiene.py
+++ b/tests/unit/agent_runtime/test_dependency_hygiene.py
@@ -176,6 +176,21 @@ def test_dependency_hygiene_skips_non_utf8_instruction_files(tmp_path: Path) -> 
     assert report.findings == ()
 
 
+def test_dependency_hygiene_maps_yaml_import_to_pyyaml_distribution(tmp_path: Path) -> None:
+    _write_pyproject(
+        tmp_path,
+        project_dependencies=["pydantic>=2.0,<3.0"],
+        optional_dependencies={"dev": ["PyYAML>=6.0,<7.0"]},
+    )
+    script_path = tmp_path / "scripts" / "render.py"
+    script_path.parent.mkdir(parents=True)
+    script_path.write_text("import yaml\n", encoding="utf-8")
+
+    report = build_dependency_hygiene_report(tmp_path)
+
+    assert report.findings == ()
+
+
 def test_check_dependency_hygiene_cli_writes_json_report(tmp_path: Path) -> None:
     _write_pyproject(
         tmp_path,

--- a/tests/unit/agent_runtime/test_drift_suite.py
+++ b/tests/unit/agent_runtime/test_drift_suite.py
@@ -19,7 +19,7 @@ def test_drift_suite_waives_findings_present_in_baseline(tmp_path: Path) -> None
     _write_minimal_repo(tmp_path)
     initial_report = build_drift_suite_report(tmp_path)
 
-    assert initial_report.stats.scans_run == 7
+    assert initial_report.stats.scans_run == 8
     assert initial_report.stats.total_findings == 1
     assert initial_report.stats.new_findings == 1
     assert initial_report.stats.waived_findings == 0
@@ -92,12 +92,13 @@ def test_run_all_cli_writes_combined_and_per_scanner_artifacts(tmp_path: Path) -
 
     assert payload["scan_name"] == "drift_suite"
     assert payload == written_payload
-    assert payload["stats"]["scans_run"] == 7
+    assert payload["stats"]["scans_run"] == 8
     assert payload["stats"]["new_findings"] == 1
     assert (artifact_dir / "architecture_boundaries.json").is_file()
     assert (artifact_dir / "canon_lineage.json").is_file()
     assert (artifact_dir / "dependency_hygiene.json").is_file()
     assert (artifact_dir / "instruction_surfaces.json").is_file()
+    assert (artifact_dir / "module_dashboard_freshness.json").is_file()
     assert (artifact_dir / "reference_integrity.json").is_file()
     assert (artifact_dir / "registry_alignment.json").is_file()
     assert (artifact_dir / "surface_liveness.json").is_file()
@@ -105,6 +106,7 @@ def test_run_all_cli_writes_combined_and_per_scanner_artifacts(tmp_path: Path) -
     assert "## Drift Monitor" in summary
     assert "### Architecture Boundaries" in summary
     assert "### Instruction Surfaces" in summary
+    assert "### Module Dashboard Freshness" in summary
     assert "### Reference Integrity" in summary
     assert "### Surface Liveness" in summary
 

--- a/tests/unit/agent_runtime/test_module_dashboard_freshness.py
+++ b/tests/unit/agent_runtime/test_module_dashboard_freshness.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import subprocess
+import sys
+
+from agent_runtime.drift.module_dashboard_freshness import build_module_dashboard_freshness_report
+from scripts.render_module_dashboard import load_registry, render_module_dashboard
+
+
+def test_module_dashboard_freshness_reports_no_findings_when_synced(tmp_path: Path) -> None:
+    registry_path = _write_registry(tmp_path)
+    payload = load_registry(registry_path)
+    dashboard_path = tmp_path / "docs" / "roadmap" / "module_1_var_dashboard.md"
+    dashboard_path.parent.mkdir(parents=True, exist_ok=True)
+    dashboard_path.write_text(render_module_dashboard(payload, module_id="MODULE-1-VAR"), encoding="utf-8")
+
+    report = build_module_dashboard_freshness_report(tmp_path)
+
+    assert report.stats.dashboards_declared == 1
+    assert report.stats.dashboards_checked == 1
+    assert report.stats.findings_count == 0
+    assert report.findings == ()
+
+
+def test_module_dashboard_freshness_reports_missing_dashboard(tmp_path: Path) -> None:
+    _write_registry(tmp_path)
+
+    report = build_module_dashboard_freshness_report(tmp_path)
+
+    assert report.stats.findings_count == 1
+    assert report.stats.missing_dashboards == 1
+    finding = report.findings[0]
+    assert finding.kind == "missing_generated_dashboard"
+    assert finding.dashboard_path == "docs/roadmap/module_1_var_dashboard.md"
+    assert "render_module_dashboard.py --module-id MODULE-1-VAR" in finding.message
+
+
+def test_module_dashboard_freshness_reports_stale_dashboard(tmp_path: Path) -> None:
+    _write_registry(tmp_path)
+    dashboard_path = tmp_path / "docs" / "roadmap" / "module_1_var_dashboard.md"
+    dashboard_path.parent.mkdir(parents=True, exist_ok=True)
+    dashboard_path.write_text("# stale\n", encoding="utf-8")
+
+    report = build_module_dashboard_freshness_report(tmp_path)
+
+    assert report.stats.findings_count == 1
+    assert report.stats.stale_dashboards == 1
+    finding = report.findings[0]
+    assert finding.kind == "stale_generated_dashboard"
+    assert finding.dashboard_path == "docs/roadmap/module_1_var_dashboard.md"
+
+
+def test_check_module_dashboard_freshness_cli_writes_json_report(tmp_path: Path) -> None:
+    _write_registry(tmp_path)
+    output_path = tmp_path / "artifacts" / "drift" / "module_dashboard_freshness.json"
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "scripts/drift/check_module_dashboard_freshness.py",
+            "--root",
+            str(tmp_path),
+            "--output",
+            str(output_path),
+        ],
+        cwd=Path(__file__).resolve().parents[3],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    payload = json.loads(completed.stdout)
+    written_payload = json.loads(output_path.read_text(encoding="utf-8"))
+
+    assert payload["scan_name"] == "module_dashboard_freshness"
+    assert payload["root"] == "."
+    assert payload == written_payload
+    assert payload["stats"]["findings_count"] == 1
+
+
+def _write_registry(root: Path) -> Path:
+    registry_path = root / "docs" / "registry" / "current_state_registry.yaml"
+    registry_path.parent.mkdir(parents=True, exist_ok=True)
+    registry_path.write_text(
+        "\n".join(
+            [
+                "version: 2",
+                "last_updated: 2026-04-19",
+                "module_dashboards:",
+                "  - id: MODULE-1-VAR",
+                '    name: "Module 1 Dashboard: End-to-End VaR Workflow"',
+                "    owner_role: PM",
+                "    dashboard_path: docs/roadmap/module_1_var_dashboard.md",
+                "    overall_state: MVP_PARTIAL",
+                "    delivery_phase: Phase 5",
+                "    mission: Test mission.",
+                "    mvp_definition:",
+                "      - deterministic analysis",
+                "    summary: Test summary.",
+                "    current_mvp_blockers:",
+                "      - Test blocker.",
+                "    not_required_for_mvp:",
+                "      - Test enhancement.",
+                "    journey_stages: []",
+                "    capabilities: []",
+                "    prd_lineage: []",
+                "    in_progress_items: []",
+                "    next_recommended_slices:",
+                "      - Next slice.",
+                "    post_mvp_enhancements:",
+                "      - Post MVP.",
+                "    open_questions:",
+                "      - Open question?",
+                "    change_log:",
+                '      - "2026-04-19: Seeded dashboard."',
+                "components:",
+                "  modules: []",
+                "  walkers: []",
+                "  orchestrators: []",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return registry_path

--- a/tests/unit/scripts/test_render_module_dashboard.py
+++ b/tests/unit/scripts/test_render_module_dashboard.py
@@ -56,6 +56,26 @@ def test_render_module_dashboard_cli_writes_dashboard_file(tmp_path: Path) -> No
     assert "# Module 1 Dashboard: End-to-End VaR Workflow" in dashboard_path.read_text(encoding="utf-8")
 
 
+def test_render_module_dashboard_escapes_pipe_characters_in_table_cells(tmp_path: Path) -> None:
+    registry_path = _write_registry(tmp_path)
+    payload = load_registry(registry_path)
+    payload["module_dashboards"][0]["journey_stages"][0]["label"] = "Deterministic | foundation"
+    payload["module_dashboards"][0]["journey_stages"][0]["goal"] = "canonical | analytics"
+    payload["module_dashboards"][0]["journey_stages"][0]["notes"] = "Risk | Analytics"
+    payload["module_dashboards"][0]["capabilities"][0]["implemented_now"] = ["get_risk_summary | get_risk_delta"]
+    payload["module_dashboards"][0]["capabilities"][0]["next_slice"] = "decide | live integration"
+    payload["module_dashboards"][0]["prd_lineage"][0]["capability"] = "Quant | Walker"
+
+    rendered = render_module_dashboard(payload, module_id="MODULE-1-VAR")
+
+    assert "Deterministic \\| foundation" in rendered
+    assert "canonical \\| analytics" in rendered
+    assert "Risk \\| Analytics" in rendered
+    assert "get_risk_summary \\| get_risk_delta" in rendered
+    assert "decide \\| live integration" in rendered
+    assert "Quant \\| Walker" in rendered
+
+
 def _write_registry(root: Path) -> Path:
     registry_path = root / "docs" / "registry" / "current_state_registry.yaml"
     registry_path.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/unit/scripts/test_render_module_dashboard.py
+++ b/tests/unit/scripts/test_render_module_dashboard.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+from pathlib import Path
+import subprocess
+import sys
+
+from scripts.render_module_dashboard import load_registry, render_dashboards, render_module_dashboard
+
+
+def test_render_module_dashboard_contains_expected_sections(tmp_path: Path) -> None:
+    registry_path = _write_registry(tmp_path)
+
+    payload = load_registry(registry_path)
+    rendered = render_module_dashboard(payload, module_id="MODULE-1-VAR")
+
+    assert "# Module 1 Dashboard: End-to-End VaR Workflow" in rendered
+    assert "## Capability Status" in rendered
+    assert "| Risk Analytics | module | `implemented` |" in rendered
+    assert "PRD-4.2-v2" in rendered
+    assert "## Next Recommended Slices" in rendered
+
+
+def test_render_dashboards_writes_markdown_file(tmp_path: Path) -> None:
+    registry_path = _write_registry(tmp_path)
+    payload = load_registry(registry_path)
+
+    written = render_dashboards(payload, repo_root=tmp_path, module_id="MODULE-1-VAR")
+
+    assert written == (tmp_path / "docs" / "roadmap" / "module_1_var_dashboard.md",)
+    contents = written[0].read_text(encoding="utf-8")
+    assert "Source of truth: `docs/registry/current_state_registry.yaml`" in contents
+
+
+def test_render_module_dashboard_cli_writes_dashboard_file(tmp_path: Path) -> None:
+    _write_registry(tmp_path)
+    (tmp_path / "AGENTS.md").write_text("# AGENTS\n", encoding="utf-8")
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "scripts/render_module_dashboard.py",
+            "--root",
+            str(tmp_path),
+            "--module-id",
+            "MODULE-1-VAR",
+        ],
+        cwd=Path(__file__).resolve().parents[3],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.stdout.strip() == "docs/roadmap/module_1_var_dashboard.md"
+    dashboard_path = tmp_path / "docs" / "roadmap" / "module_1_var_dashboard.md"
+    assert dashboard_path.is_file()
+    assert "# Module 1 Dashboard: End-to-End VaR Workflow" in dashboard_path.read_text(encoding="utf-8")
+
+
+def _write_registry(root: Path) -> Path:
+    registry_path = root / "docs" / "registry" / "current_state_registry.yaml"
+    registry_path.parent.mkdir(parents=True, exist_ok=True)
+    registry_path.write_text(
+        """
+version: 2
+last_updated: 2026-04-19
+
+module_dashboards:
+  - id: MODULE-1-VAR
+    name: "Module 1 Dashboard: End-to-End VaR Workflow"
+    owner_role: PM / Coordination Agent
+    dashboard_path: docs/roadmap/module_1_var_dashboard.md
+    overall_state: MVP_PARTIAL
+    delivery_phase: Phase 5
+    mission: Deliver a replayable, deterministic, explainable daily VaR investigation workflow.
+    mvp_definition:
+      - deterministic VaR retrieval and change-profile analysis
+      - trust / readiness assessment
+    summary: Deterministic core exists; multi-walker interpretation is still missing.
+    current_mvp_blockers:
+      - Quant Walker v2 contract not yet defined
+    not_required_for_mvp:
+      - Market Context Walker
+    journey_stages:
+      - label: Deterministic foundation
+        goal: canonical deterministic VaR analytics
+        status: done
+        notes: Risk Analytics is implemented.
+    capabilities:
+      - component_ref: MOD-RISK-ANALYTICS
+        layer: module
+        current_state: implemented
+        implemented_now:
+          - get_risk_summary
+        missing_for_mvp:
+          - none
+        missing_prds: []
+        needs_new_prd_version: false
+        next_version_reason: ""
+        next_slice: decide whether live integration is in MVP
+      - component_ref: WALKER-QUANT
+        layer: walker
+        current_state: delegate_only
+        implemented_now:
+          - summarize_change delegate
+        missing_for_mvp:
+          - interpretive output
+        missing_prds: []
+        needs_new_prd_version: true
+        next_version_reason: Current PRD is delegation-only.
+        next_slice: Author PRD-4.2-v2.
+    prd_lineage:
+      - capability: Quant Walker
+        active_prd: PRD-4.2-v1
+        status: active
+        supersedes: ""
+        next_needed_prd: PRD-4.2-v2
+        why: v1 is delegation-only.
+    in_progress_items: []
+    next_recommended_slices:
+      - Author PRD-4.2-v2
+    post_mvp_enhancements:
+      - Critic / Challenge Walker
+    open_questions:
+      - Is live-data integration in MVP?
+    change_log:
+      - "2026-04-19: Initial dashboard seed."
+
+components:
+  modules:
+    - id: MOD-RISK-ANALYTICS
+      name: Risk Analytics
+      status: implemented
+      contract_status: implemented
+  walkers:
+    - id: WALKER-QUANT
+      name: Quant Walker
+      status: implemented
+      contract_status: implemented
+  orchestrators: []
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    return registry_path

--- a/work_items/done/WI-8.1.1-module-1-dashboard-and-registry-governance-v1.md
+++ b/work_items/done/WI-8.1.1-module-1-dashboard-and-registry-governance-v1.md
@@ -1,0 +1,81 @@
+# WI-8.1.1
+
+## Status
+
+**DONE**
+
+## Linked PRD
+
+docs/prds/phase-8/PRD-8.1-module-dashboard-and-registry-governance-v1.md
+
+## Linked ADRs
+
+- ADR-001
+- ADR-002
+
+## Linked shared / delivery canon
+
+- `docs/roadmap/phased_implementation_roadmap.md`
+- `docs/registry/current_state_registry.yaml`
+- `docs/delivery/01_pm_operating_model.md`
+- `docs/delivery/05_repo_drift_monitoring.md`
+
+## Purpose
+
+First bounded slice for registry-backed module dashboards: extend the current-state registry with Module 1 dashboard fields, add a generator script, generate the Module 1 dashboard page under `docs/roadmap/`, and wire PM / review / drift-monitor instructions so the new status surface is governed rather than ad hoc.
+
+## Scope
+
+- Extend `docs/registry/current_state_registry.yaml` with:
+  - `module_dashboards`
+  - richer capability-level fields needed for Module 1 MVP tracking and PRD lineage
+- Add `scripts/render_module_dashboard.py`
+- Generate `docs/roadmap/module_1_var_dashboard.md` from registry state
+- Update PM / review / drift-monitor instruction and delivery canon surfaces so:
+  - PM owns registry-backed dashboard freshness
+  - review checks status-surface freshness when maturity/lineage changes
+  - drift-monitor treats generated module dashboard pages as governed status surfaces
+- Add unit tests for the renderer
+
+## Out of scope
+
+- dashboards for modules beyond Module 1
+- a web UI or external dashboard application
+- CI enforcement for dashboard regeneration
+- a full registry schema validator
+- any new product functionality under `src/`
+
+## Target area
+
+- `docs/registry/current_state_registry.yaml`
+- `docs/roadmap/module_1_var_dashboard.md`
+- `scripts/render_module_dashboard.py`
+- `tests/unit/scripts/test_render_module_dashboard.py`
+- `docs/delivery/01_pm_operating_model.md`
+- `docs/delivery/05_repo_drift_monitoring.md`
+- `prompts/agents/pm_agent_instruction.md`
+- `prompts/agents/review_agent_instruction.md`
+- `prompts/agents/drift_monitor_agent_instruction.md`
+
+## Acceptance criteria
+
+1. Module 1 dashboard page exists under `docs/roadmap/` and is generated from registry state
+2. The dashboard clearly states:
+   - what is implemented
+   - what is missing for MVP
+   - which PRDs are missing
+   - which existing PRDs require a new version
+3. Renderer unit tests pass
+4. Existing registry-alignment and instruction-surface tests still pass
+5. PM / review / drift-monitor surfaces all mention the new dashboard governance responsibilities explicitly
+
+## Verification
+
+- `python scripts/render_module_dashboard.py --module-id MODULE-1-VAR`
+- `pytest -q tests/unit/scripts/test_render_module_dashboard.py`
+- `pytest -q tests/unit/scripts/test_render_module_dashboard.py tests/unit/agent_runtime/test_registry_alignment.py tests/unit/agent_runtime/test_instruction_surfaces.py`
+
+## Notes
+
+- This WI records the governance trail for the initial Module 1 dashboard implementation already landed in the repository.
+- Future expansion to additional modules, CI enforcement, or dedicated dashboard drift scanning should be tracked as follow-on WIs under PRD-8.1 or its successor.


### PR DESCRIPTION
## What changed
- added a registry-backed renderer for Module 1 dashboard pages and seeded the first governed Module 1 VaR dashboard
- extended the current-state registry, governance docs, prompts, PRD trail, and work-item trail to make dashboard freshness part of the PM/review/drift workflow
- added a deterministic `module_dashboard_freshness` drift scanner and CLI so registry changes fail when the generated dashboard is missing or stale
- fixed dependency-hygiene normalization for `yaml` imports provided by the `PyYAML` distribution and added regression coverage

## Why
The new module dashboard process needed to be governed, reproducible, and auditable. Without a freshness check, the human-readable dashboard could drift away from the registry and stop being a trustworthy PM surface.

## Impact
- PM now has a generated Module 1 dashboard in `docs/roadmap/`
- drift monitoring now produces `artifacts/drift/module_dashboard_freshness.json`
- repo health checks can fail when the dashboard is not regenerated after registry updates

## Validation
- `pytest -q tests/unit/agent_runtime/test_dependency_hygiene.py tests/unit/agent_runtime/test_module_dashboard_freshness.py tests/unit/agent_runtime/test_drift_suite.py tests/unit/agent_runtime/test_reference_integrity.py tests/unit/agent_runtime/test_instruction_surfaces.py`
- `python scripts/drift/check_module_dashboard_freshness.py --root . --fail-on-findings`
- `python scripts/drift/run_all.py --root . --fail-on-findings`
