### PR TITLE
chore(work-items): promote WI-5.1.4 to done after PR #177

### DIFF
--- a/work_items/done/WI-5.1.4-replay-determinism-tests.md
+++ b/work_items/done/WI-5.1.4-replay-determinism-tests.md
@@ -2,11 +2,11 @@
 
 ## Status
 
-**READY** — WI-5.1.3 is merged on `main`; replay coverage is partially present, but the public-entrypoint determinism gap is still open.
+**DONE** — Merged to `main` via [PR #177](https://github.com/tomanizer/risk-manager/pull/177). Replay/determinism tests for the public `start_daily_run` entrypoint are on `main`.
 
 ## Blocker
 
-- None. PM can assign this residual replay slice to Coding Agent.
+- None. Work complete.
 
 ## Linked PRD
 
@@ -32,7 +32,12 @@ Current state on `main`:
 - `generated_at` determinism helper coverage already exists in [tests/unit/orchestrators/daily_risk_investigation/test_generated_at.py](tests/unit/orchestrators/daily_risk_investigation/test_generated_at.py)
 - telemetry is already included in the implementation and covered separately by [tests/unit/orchestrators/daily_risk_investigation/test_telemetry.py](tests/unit/orchestrators/daily_risk_investigation/test_telemetry.py)
 
-The missing replay guard is an end-to-end equality assertion over the full `DailyRunResult` returned by `start_daily_run`.
+The missing replay guard was an end-to-end equality assertion over the full `DailyRunResult` returned by `start_daily_run`; PR #177 closed it.
+
+## Completion evidence on `main`
+
+- [tests/unit/orchestrators/daily_risk_investigation/test_replay_determinism.py](tests/unit/orchestrators/daily_risk_investigation/test_replay_determinism.py) — happy-path and `BLOCKED_READINESS` two-invocation `DailyRunResult` equality for `start_daily_run`.
+- Merge: [PR #177](https://github.com/tomanizer/risk-manager/pull/177).
 
 ## Scope
 


### PR DESCRIPTION
## Summary

Follow-up to merged [PR #177](https://github.com/tomanizer/risk-manager/pull/177): the implementation is on `main`, but the work item file remained under `work_items/in_progress/`.

## Changes

- `git mv` `WI-5.1.4-replay-determinism-tests.md` → `work_items/done/`
- Status set to **DONE** with link to PR #177
- **Completion evidence** section: test file path + merge link

## Verification

- `pytest tests/unit/agent_runtime/test_drift_suite.py::test_repo_drift_suite_has_no_new_findings -q` passes locally

No code or test changes.

Made with [Cursor](https://cursor.com)