### PR TITLE
docs(runtime): enforce runtime-managed execution checkout policy

### DIFF
--- a/.claude/commands/deliver-wi.md
+++ b/.claude/commands/deliver-wi.md
@@ -163,10 +163,14 @@ The user opens a new chat, selects the recommended model, then pastes the whole 
 After the prompt block, always print:
 
 ```text
-Before the agent starts:
+Before the agent starts, refresh the control checkout:
   git fetch origin && git switch main && git pull --ff-only origin main
-For coding: create a fresh branch from main.
-For review: checkout the PR head branch.
+If using agent_runtime:
+  python -m agent_runtime --dispatch
+  Then use only the returned worktree path and branch for that run.
+If running manually outside agent_runtime:
+  For coding: create a fresh branch from main.
+  For review: inspect the PR head in an isolated checkout.
 ```
 
 ## Step 7 — Optionally suggest agent runtime tracking

--- a/.cursor/skills/deliver-wi/SKILL.md
+++ b/.cursor/skills/deliver-wi/SKILL.md
@@ -163,10 +163,14 @@ The user opens a new chat, selects the recommended model, then pastes the whole 
 After the prompt block, always print:
 
 ```text
-Before the agent starts:
+Before the agent starts, refresh the control checkout:
   git fetch origin && git switch main && git pull --ff-only origin main
-For coding: create a fresh branch from main.
-For review: checkout the PR head branch.
+If using agent_runtime:
+  python -m agent_runtime --dispatch
+  Then use only the returned worktree path and branch for that run.
+If running manually outside agent_runtime:
+  For coding: create a fresh branch from main.
+  For review: inspect the PR head in an isolated checkout.
 ```
 
 ## Step 7 — Optionally suggest agent runtime tracking

--- a/.github/skills/deliver-wi/SKILL.md
+++ b/.github/skills/deliver-wi/SKILL.md
@@ -163,10 +163,14 @@ The user opens a new chat, selects the recommended model, then pastes the whole 
 After the prompt block, always print:
 
 ```text
-Before the agent starts:
+Before the agent starts, refresh the control checkout:
   git fetch origin && git switch main && git pull --ff-only origin main
-For coding: create a fresh branch from main.
-For review: checkout the PR head branch.
+If using agent_runtime:
+  python -m agent_runtime --dispatch
+  Then use only the returned worktree path and branch for that run.
+If running manually outside agent_runtime:
+  For coding: create a fresh branch from main.
+  For review: inspect the PR head in an isolated checkout.
 ```
 
 ## Step 7 — Optionally suggest agent runtime tracking

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,17 +111,30 @@ In Cursor, invoke by name in chat using the generated mirrors under `.cursor/ski
 <!-- END GENERATED SKILLS SECTION -->
 ## Freshness and branching rule
 
-Before any PM, coding, review, or drift-monitor pass:
+Refresh the control checkout before any PM, coding, review, or drift-monitor pass:
 
 1. git fetch origin
 2. git switch main
 3. git pull --ff-only origin main
 
-For reviews, then checkout the latest PR head. For coding, create a fresh branch from main.
+Then follow one of these two modes only:
 
-New implementation work must start from the latest `main`.
+### Manual direct mode
 
-Each bounded implementation slice should use a fresh branch created from current `main`.
+- use this only when a human is invoking an agent outside `agent_runtime`
+- PM, spec, issue-planner, coding, and drift-monitor work start from the refreshed control checkout
+- new implementation work must start from the latest `main`
+- each bounded implementation slice should use a fresh feature branch created from current `main`
+- review work should inspect the PR head in an isolated checkout rather than reusing unrelated local state
+
+### Runtime-managed mode
+
+- `agent_runtime` is the authority for execution checkout state
+- the control checkout stays on refreshed `main` and is used only for dispatch, inspection, and human repo maintenance
+- the real PM, spec, issue-planner, coding, and review work happens only in the runtime-allocated worktree for that run
+- agents must not run `git switch main`, `git worktree add`, or create a second feature branch inside a runtime-managed session
+- new coding work without an existing PR starts from a runtime-created worktree based on current `origin/main`
+- review and PR-follow-up coding work use the runtime-managed worktree for the PR head branch, not a second checkout from local `main`
 
 Agents must not continue from stale local state when canon, PR state, or linked contracts may have changed.
 

--- a/agent_runtime/README.md
+++ b/agent_runtime/README.md
@@ -121,6 +121,10 @@ both the execution metadata and the runner result.
 The lease is intentionally kept active after dispatch so a later execution layer
 can continue from the same isolated checkout.
 
+In runtime-managed mode, the allocated worktree and branch are authoritative for
+that run. The human control checkout remains on refreshed `main` and should not
+be used for the real PM/spec/coding/review work.
+
 By default the PM runner remains in manual `prepared` mode. You can opt in to
 the first real backend by setting:
 
@@ -254,8 +258,10 @@ The current runtime is designed for a semi-automatic loop:
 .venv/bin/python -m agent_runtime --dispatch
 ```
 
-1. Open the returned `worktree.path` and run the real PM/spec/coding/review agent
-manually in that isolated checkout using the returned `runner.prompt`.
+1. Open the returned `worktree.path` and run the real PM/spec/coding/review
+agent manually in that isolated checkout using the returned `runner.prompt`.
+The runtime-managed worktree and branch are the only checkout state the agent
+should use for that run.
 
 1. When that manual agent session finishes, record the reviewed outcome back into
 the runtime:

--- a/agent_runtime/drift/instruction_surfaces.py
+++ b/agent_runtime/drift/instruction_surfaces.py
@@ -74,8 +74,8 @@ RUNTIME_MANAGED_INVOCATION_EXPECTATIONS: tuple[tuple[Path, tuple[str, ...]], ...
     (
         INVOCATION_TEMPLATES_DIR / "pm_invocation.md",
         (
-            "`agent_runtime`",
-            "Do not switch to `main`",
+            "agent_runtime",
+            "switch to main",
             "create another worktree",
             "create another branch",
         ),
@@ -83,19 +83,19 @@ RUNTIME_MANAGED_INVOCATION_EXPECTATIONS: tuple[tuple[Path, tuple[str, ...]], ...
     (
         INVOCATION_TEMPLATES_DIR / "coding_invocation.md",
         (
-            "`agent_runtime`",
-            "Do not switch to `main`",
-            "Do not create another worktree",
-            "Do not create another branch",
+            "agent_runtime",
+            "switch to main",
+            "create another worktree",
+            "create another branch",
         ),
     ),
     (
         INVOCATION_TEMPLATES_DIR / "review_invocation.md",
         (
-            "`agent_runtime`",
-            "Do not switch to `main`",
-            "Do not create another worktree",
-            "Do not create another branch",
+            "agent_runtime",
+            "switch to main",
+            "create another worktree",
+            "create another branch",
         ),
     ),
 )

--- a/agent_runtime/drift/instruction_surfaces.py
+++ b/agent_runtime/drift/instruction_surfaces.py
@@ -346,6 +346,20 @@ def _append_runtime_managed_invocation_findings(findings: list[InstructionSurfac
     for path, required_tokens in RUNTIME_MANAGED_INVOCATION_EXPECTATIONS:
         full_path = repo_root / path
         if not full_path.is_file():
+            findings.append(
+                InstructionSurfaceFinding(
+                    kind="missing_runtime_managed_invocation_template",
+                    severity=INSTRUCTION_SURFACE_SEVERITY,
+                    drift_class="operational-instruction drift",
+                    owner="repository maintenance",
+                    source_path=path.as_posix(),
+                    related_paths=required_tokens,
+                    message=(
+                        f"Expected invocation template `{path.as_posix()}` is missing, so runtime-managed checkout guidance "
+                        f"cannot be validated: {', '.join(f'`{token}`' for token in required_tokens)}."
+                    ),
+                )
+            )
             continue
         contents = full_path.read_text(encoding="utf-8")
         missing = tuple(token for token in required_tokens if token not in contents)

--- a/agent_runtime/drift/instruction_surfaces.py
+++ b/agent_runtime/drift/instruction_surfaces.py
@@ -10,6 +10,7 @@ GITHUB_AGENTS_DIR = Path(".github/agents")
 PROMPT_AGENTS_DIR = Path("prompts/agents")
 DRIFT_PROMPT_PATH = Path("prompts/drift_monitor/repo_health_audit_prompt.md")
 COPILOT_INSTRUCTIONS_PATH = Path(".github/copilot-instructions.md")
+INVOCATION_TEMPLATES_DIR = Path("prompts/agents/invocation_templates")
 
 FRESHNESS_TRIAD = (
     "git fetch origin",
@@ -69,6 +70,36 @@ DRIFT_ENTRYPOINT_FILES: tuple[Path, ...] = (
     Path("prompts/drift_monitor/repo_health_audit_prompt.md"),
 )
 
+RUNTIME_MANAGED_INVOCATION_EXPECTATIONS: tuple[tuple[Path, tuple[str, ...]], ...] = (
+    (
+        INVOCATION_TEMPLATES_DIR / "pm_invocation.md",
+        (
+            "`agent_runtime`",
+            "Do not switch to `main`",
+            "create another worktree",
+            "create another branch",
+        ),
+    ),
+    (
+        INVOCATION_TEMPLATES_DIR / "coding_invocation.md",
+        (
+            "`agent_runtime`",
+            "Do not switch to `main`",
+            "Do not create another worktree",
+            "Do not create another branch",
+        ),
+    ),
+    (
+        INVOCATION_TEMPLATES_DIR / "review_invocation.md",
+        (
+            "`agent_runtime`",
+            "Do not switch to `main`",
+            "Do not create another worktree",
+            "Do not create another branch",
+        ),
+    ),
+)
+
 INSTRUCTION_SURFACE_SEVERITY = "major"
 BACKTICK_TOKEN_PATTERN = re.compile(r"`([^`\n]+)`")
 BACKTICK_LIST_ITEM_PATTERN = re.compile(r"^\s*(?:-|\d+\.)\s+`([^`\n]+)`\s*$")
@@ -126,6 +157,7 @@ def build_instruction_surface_report(root: Path) -> InstructionSurfaceReport:
         _append_freshness_findings(findings, repo_root, path)
 
     _append_drift_entrypoint_findings(findings, repo_root)
+    _append_runtime_managed_invocation_findings(findings, repo_root)
 
     findings.sort(key=lambda finding: (finding.source_path, finding.kind, finding.related_paths))
     return InstructionSurfaceReport(
@@ -310,6 +342,31 @@ def _append_drift_entrypoint_findings(findings: list[InstructionSurfaceFinding],
             )
 
 
+def _append_runtime_managed_invocation_findings(findings: list[InstructionSurfaceFinding], repo_root: Path) -> None:
+    for path, required_tokens in RUNTIME_MANAGED_INVOCATION_EXPECTATIONS:
+        full_path = repo_root / path
+        if not full_path.is_file():
+            continue
+        contents = full_path.read_text(encoding="utf-8")
+        missing = tuple(token for token in required_tokens if token not in contents)
+        if not missing:
+            continue
+        findings.append(
+            InstructionSurfaceFinding(
+                kind="missing_runtime_managed_checkout_rule",
+                severity=INSTRUCTION_SURFACE_SEVERITY,
+                drift_class="operational-instruction drift",
+                owner="repository maintenance",
+                source_path=path.as_posix(),
+                related_paths=missing,
+                message=(
+                    f"Invocation template `{path.as_posix()}` is missing runtime-managed checkout guidance: "
+                    f"{', '.join(f'`{token}`' for token in missing)}."
+                ),
+            )
+        )
+
+
 def _freshness_rule_files(repo_root: Path) -> tuple[Path, ...]:
     candidates = [
         Path("AGENTS.md"),
@@ -326,6 +383,7 @@ def _instruction_files_scanned(repo_root: Path, freshness_rule_files: tuple[Path
         Path("AGENTS.md"),
         COPILOT_INSTRUCTIONS_PATH,
         DRIFT_PROMPT_PATH,
+        *(path for path, _ in RUNTIME_MANAGED_INVOCATION_EXPECTATIONS),
         *AGENTS_REFERENCE_FILES,
         *(path for path, _ in README_EXPECTATIONS),
         *DRIFT_ENTRYPOINT_FILES,

--- a/agent_runtime/manual_supervisor_workflow.md
+++ b/agent_runtime/manual_supervisor_workflow.md
@@ -203,9 +203,11 @@ sqlite3 .agent_runtime/state.db 'select run_id, work_item_id, runner_name, branc
 
 ## Operational rules
 
+- keep the control checkout on refreshed `main`; do not do the real agent work there
 - one dispatched run should use one worktree
 - do not reuse a worktree for a different work item
-- do not perform the real agent work in the control checkout
+- do not switch a runtime-managed session back to `main`
+- do not allocate another worktree or create another feature branch inside a runtime-managed session
 - record the real outcome before releasing the run whenever possible
 - release finished worktrees promptly so lease state stays trustworthy
 

--- a/agent_runtime/orchestrator/worktree_manager.py
+++ b/agent_runtime/orchestrator/worktree_manager.py
@@ -64,7 +64,7 @@ def _inject_runtime_checkout_context(prompt: str, lease: WorktreeLeaseRecord) ->
         "- do all work only in this worktree\n"
         "- do not switch to `main`\n"
         "- do not create another worktree\n"
-        "- do not create another branch unless the runtime explicitly instructs it\n"
+        "- do not create another branch\n"
     )
     if context_block in prompt:
         return prompt

--- a/agent_runtime/orchestrator/worktree_manager.py
+++ b/agent_runtime/orchestrator/worktree_manager.py
@@ -52,6 +52,25 @@ def _build_branch_name(execution: RunnerExecution, run_id: str) -> str:
     return f"codex/{branch_slug}-{run_id.split('-')[-1]}"
 
 
+def _inject_runtime_checkout_context(prompt: str, lease: WorktreeLeaseRecord) -> str:
+    context_block = (
+        "Execution checkout (agent_runtime authoritative):\n"
+        f"- run_id: {lease.run_id}\n"
+        f"- worktree_path: {lease.worktree_path}\n"
+        f"- branch_name: {lease.branch_name}\n"
+        f"- base_ref: {lease.base_ref}\n"
+        "\n"
+        "Checkout rule:\n"
+        "- do all work only in this worktree\n"
+        "- do not switch to `main`\n"
+        "- do not create another worktree\n"
+        "- do not create another branch unless the runtime explicitly instructs it\n"
+    )
+    if context_block in prompt:
+        return prompt
+    return f"{context_block}\n{prompt}"
+
+
 def _best_effort_git(repo_root: Path, *args: str) -> RuntimeError | None:
     try:
         _git(repo_root, *args)
@@ -111,12 +130,13 @@ def allocate_worktree(
 def bind_worktree_to_execution(execution: RunnerExecution, lease: WorktreeLeaseRecord) -> RunnerExecution:
     metadata = {
         **dict(execution.metadata),
+        "execution_mode": "runtime_managed",
         "run_id": lease.run_id,
         "worktree_path": lease.worktree_path,
         "branch_name": lease.branch_name,
         "base_ref": lease.base_ref,
     }
-    return replace(execution, metadata=metadata)
+    return replace(execution, prompt=_inject_runtime_checkout_context(execution.prompt, lease), metadata=metadata)
 
 
 def release_worktree(defaults: RuntimeDefaults, db_path: Path, run_id: str) -> str:

--- a/agent_runtime/runners/coding_runner.py
+++ b/agent_runtime/runners/coding_runner.py
@@ -30,6 +30,10 @@ def build_coding_prompt(input_data: CodingRunnerInput) -> str:
         prompt += f" ({input_data.pr_url})"
     if input_data.base_ref is not None:
         prompt += f"\nBase ref: {input_data.base_ref}"
+    prompt += (
+        "\nIf dispatched by agent_runtime, treat the allocated worktree and branch as authoritative."
+        "\nDo not switch to `main`, allocate another worktree, or create another branch inside this run."
+    )
     if input_data.drift_summary is not None:
         prompt += f"\n\n## Current repo drift state\n\n{input_data.drift_summary}"
     return prompt

--- a/agent_runtime/runners/pm_runner.py
+++ b/agent_runtime/runners/pm_runner.py
@@ -30,6 +30,10 @@ def build_pm_prompt(input_data: PMRunnerInput) -> str:
     )
     if input_data.linked_prd is not None:
         prompt += f"\nLinked PRD: {input_data.linked_prd}."
+    prompt += (
+        "\nIf dispatched by agent_runtime, treat the allocated worktree and branch as authoritative."
+        "\nDo not switch to `main`, allocate another worktree, or create another branch inside this run."
+    )
     return prompt
 
 

--- a/agent_runtime/runners/review_runner.py
+++ b/agent_runtime/runners/review_runner.py
@@ -29,6 +29,10 @@ def build_review_prompt(input_data: ReviewRunnerInput) -> str:
         prompt += f"\nPR URL: {input_data.pr_url}"
     if input_data.base_ref is not None:
         prompt += f"\nBase ref: {input_data.base_ref}"
+    prompt += (
+        "\nIf dispatched by agent_runtime, treat the allocated review worktree and branch as authoritative."
+        "\nDo not switch to `main`, allocate another worktree, or create another branch inside this run."
+    )
     return prompt
 
 

--- a/agent_runtime/tests/test_coding_runner.py
+++ b/agent_runtime/tests/test_coding_runner.py
@@ -8,8 +8,21 @@ import subprocess
 from unittest.mock import patch
 
 from agent_runtime.config.settings import get_settings
-from agent_runtime.runners.coding_runner import dispatch_coding_execution
 from agent_runtime.runners.contracts import RunnerDispatchStatus, RunnerExecution, RunnerName
+from agent_runtime.runners.coding_runner import CodingRunnerInput, build_coding_prompt, dispatch_coding_execution
+
+
+def test_build_coding_prompt_includes_runtime_managed_checkout_rule() -> None:
+    prompt = build_coding_prompt(
+        CodingRunnerInput(
+            work_item_id="WI-1.1.4-risk-summary-core-service",
+            task_summary="Implement the bounded slice.",
+            base_ref="origin/main",
+        )
+    )
+
+    assert "agent_runtime" in prompt
+    assert "Do not switch to `main`" in prompt
 
 
 def test_dispatch_coding_execution_prepared_backend_when_explicitly_set() -> None:

--- a/agent_runtime/tests/test_pm_runner.py
+++ b/agent_runtime/tests/test_pm_runner.py
@@ -9,7 +9,24 @@ from unittest.mock import patch
 
 from agent_runtime.config.settings import get_settings
 from agent_runtime.runners.contracts import RunnerDispatchStatus, RunnerExecution, RunnerName
-from agent_runtime.runners.pm_runner import dispatch_pm_execution
+from agent_runtime.runners.pm_runner import build_pm_prompt, dispatch_pm_execution
+
+
+def test_build_pm_prompt_includes_runtime_managed_checkout_rule() -> None:
+    prompt = build_pm_prompt(
+        input_data=type(
+            "PMInput",
+            (),
+            {
+                "work_item_id": "WI-1.1.4-risk-summary-core-service",
+                "work_item_path": "work_items/ready/WI-1.1.4-risk-summary-core-service.md",
+                "linked_prd": "docs/prds/phase-1/PRD-1.1-risk-summary-service-v2.md",
+            },
+        )()
+    )
+
+    assert "agent_runtime" in prompt
+    assert "Do not switch to `main`" in prompt
 
 
 def test_dispatch_pm_execution_uses_prepared_backend_by_default() -> None:

--- a/agent_runtime/tests/test_review_runner.py
+++ b/agent_runtime/tests/test_review_runner.py
@@ -9,7 +9,20 @@ from unittest.mock import patch
 
 from agent_runtime.config.settings import get_settings
 from agent_runtime.runners.contracts import RunnerDispatchStatus, RunnerExecution, RunnerName
-from agent_runtime.runners.review_runner import dispatch_review_execution
+from agent_runtime.runners.review_runner import ReviewRunnerInput, build_review_prompt, dispatch_review_execution
+
+
+def test_build_review_prompt_includes_runtime_managed_checkout_rule() -> None:
+    prompt = build_review_prompt(
+        ReviewRunnerInput(
+            work_item_id="WI-1.1.4-risk-summary-core-service",
+            pr_number=71,
+            base_ref="origin/main",
+        )
+    )
+
+    assert "agent_runtime" in prompt
+    assert "Do not switch to `main`" in prompt
 
 
 def test_dispatch_review_execution_prepared_backend_when_explicitly_set() -> None:

--- a/agent_runtime/tests/test_worktree_manager.py
+++ b/agent_runtime/tests/test_worktree_manager.py
@@ -57,7 +57,10 @@ def test_allocate_reuse_and_release_worktree() -> None:
         assert Path(lease.worktree_path).is_dir()
 
         bound_execution = bind_worktree_to_execution(execution, lease)
+        assert bound_execution.prompt.startswith("Execution checkout (agent_runtime authoritative):")
+        assert lease.run_id in bound_execution.prompt
         assert bound_execution.metadata["run_id"] == lease.run_id
+        assert bound_execution.metadata["execution_mode"] == "runtime_managed"
         assert bound_execution.metadata["worktree_path"] == lease.worktree_path
 
         reused = allocate_worktree(defaults, db_path, execution)

--- a/prompts/agents/coding_agent_instruction.md
+++ b/prompts/agents/coding_agent_instruction.md
@@ -48,6 +48,13 @@ Do not widen scope because adjacent work looks convenient.
 
 If the work belongs in a deterministic service, do not introduce AI behavior or fuzzy logic.
 
+### Use the runtime-managed checkout when present
+
+If the handoff came from `agent_runtime`, the allocated worktree and branch are
+authoritative for the run. Do not switch the runtime-managed session back to
+`main`, do not allocate another worktree, and do not create a second feature
+branch inside that session.
+
 ### Prefer established libraries
 
 Use established libraries such as `numpy`, `scipy`, `pyarrow`, `duckdb`, and `statsmodels` where they fit the workload and are already available in the repository environment rather than inventing custom numerical or data-processing infrastructure.
@@ -142,7 +149,16 @@ Required action:
 2. Commit the lifecycle move on the same feature branch used for the slice.
 3. Push the branch so the PR reflects in-progress state while coding/review is active.
 
-Suggested commands:
+Suggested commands for runtime-managed mode:
+
+```bash
+git status --short --branch
+git mv work_items/ready/{WI-ID}-*.md work_items/in_progress/
+git commit -m "chore: move {WI-ID} to in_progress [coding start]"
+git push origin HEAD
+```
+
+Suggested commands for manual direct mode:
 
 ```bash
 git fetch origin

--- a/prompts/agents/invocation_templates/coding_invocation.md
+++ b/prompts/agents/invocation_templates/coding_invocation.md
@@ -5,7 +5,7 @@ You are the Coding Agent for this repository.
 Work from the governed execution checkout for this task.
 
 Execution mode:
-- If this handoff is run through `agent_runtime`, the runtime-managed worktree and branch for this run are authoritative. Do not switch to `main`. Do not create another worktree. Do not create another branch.
+- If this handoff is run through agent_runtime, the runtime-managed worktree and branch for this run are authoritative. Do not switch to main. Do not create another worktree. Do not create another branch.
 - If this handoff is run manually outside `agent_runtime`, refresh the control checkout on current `main` and create a fresh feature branch from current `main` before coding.
 
 Read:

--- a/prompts/agents/invocation_templates/coding_invocation.md
+++ b/prompts/agents/invocation_templates/coding_invocation.md
@@ -2,7 +2,11 @@
 
 You are the Coding Agent for this repository.
 
-Work from fresh current `main`.
+Work from the governed execution checkout for this task.
+
+Execution mode:
+- If this handoff is run through `agent_runtime`, the runtime-managed worktree and branch for this run are authoritative. Do not switch to `main`. Do not create another worktree. Do not create another branch.
+- If this handoff is run manually outside `agent_runtime`, refresh the control checkout on current `main` and create a fresh feature branch from current `main` before coding.
 
 Read:
 - AGENTS.md
@@ -32,7 +36,8 @@ Stop conditions:
 <BULLETED_STOP_CONDITIONS — when the agent should stop and report a blocker>
 
 Execution notes:
-- create a fresh branch from current `main`
+- in `agent_runtime` mode, use the allocated worktree and branch exactly as provided
+- in manual mode, create a fresh branch from current `main`
 - keep the PR narrow and reviewable
 - include tests
 - report any blocker immediately

--- a/prompts/agents/invocation_templates/pm_invocation.md
+++ b/prompts/agents/invocation_templates/pm_invocation.md
@@ -2,7 +2,11 @@
 
 You are the PM / Coordination Agent for this repository.
 
-Work from current `main`.
+Work from the governed execution checkout for this task.
+
+Execution mode:
+- If this handoff is run through `agent_runtime`, the runtime-managed worktree and branch for this run are authoritative. Do not switch to `main`, create another worktree, or create another branch.
+- If this handoff is run manually outside `agent_runtime`, use the refreshed control checkout on current `main`.
 
 Read in order:
 - AGENTS.md

--- a/prompts/agents/invocation_templates/pm_invocation.md
+++ b/prompts/agents/invocation_templates/pm_invocation.md
@@ -5,7 +5,7 @@ You are the PM / Coordination Agent for this repository.
 Work from the governed execution checkout for this task.
 
 Execution mode:
-- If this handoff is run through `agent_runtime`, the runtime-managed worktree and branch for this run are authoritative. Do not switch to `main`, create another worktree, or create another branch.
+- If this handoff is run through agent_runtime, the runtime-managed worktree and branch for this run are authoritative. Do not switch to main. Do not create another worktree. Do not create another branch.
 - If this handoff is run manually outside `agent_runtime`, use the refreshed control checkout on current `main`.
 
 Read in order:

--- a/prompts/agents/invocation_templates/review_invocation.md
+++ b/prompts/agents/invocation_templates/review_invocation.md
@@ -5,7 +5,7 @@ You are the Review Agent for this repository.
 Work from the governed execution checkout for this task.
 
 Execution mode:
-- If this handoff is run through `agent_runtime`, the runtime-managed review worktree for this run is authoritative. Do not switch to `main`. Do not create another worktree. Do not create another branch.
+- If this handoff is run through agent_runtime, the runtime-managed review worktree for this run is authoritative. Do not switch to main. Do not create another worktree. Do not create another branch.
 - If this handoff is run manually outside `agent_runtime`, refresh the control checkout on current `main` and then inspect the PR head in an isolated review checkout.
 
 Read:

--- a/prompts/agents/invocation_templates/review_invocation.md
+++ b/prompts/agents/invocation_templates/review_invocation.md
@@ -2,7 +2,11 @@
 
 You are the Review Agent for this repository.
 
-Work from current `main`, then checkout the PR head.
+Work from the governed execution checkout for this task.
+
+Execution mode:
+- If this handoff is run through `agent_runtime`, the runtime-managed review worktree for this run is authoritative. Do not switch to `main`. Do not create another worktree. Do not create another branch.
+- If this handoff is run manually outside `agent_runtime`, refresh the control checkout on current `main` and then inspect the PR head in an isolated review checkout.
 
 Read:
 - AGENTS.md

--- a/prompts/agents/pm_agent_instruction.md
+++ b/prompts/agents/pm_agent_instruction.md
@@ -79,6 +79,13 @@ Do not issue a coding brief until the intended write area is concrete enough tha
 
 If you cannot name what the tests need to prove, the slice is not ready.
 
+### Make execution mode explicit in handoff
+
+When issuing a coding, review, or issue-planner handoff, state whether the next
+session is runtime-managed or manual. Runtime-managed handoffs must treat the
+allocated worktree and branch as authoritative and must not tell the next agent
+to create a different checkout.
+
 ### Enforce shared-infrastructure dependency clarity
 
 If a slice touches cross-cutting infrastructure (for example telemetry), the

--- a/prompts/agents/review_agent_instruction.md
+++ b/prompts/agents/review_agent_instruction.md
@@ -154,6 +154,17 @@ Do not issue PASS if CI is failing on checks attributable to the PR changes.
 After posting APPROVE to GitHub, and only when the verdict is PASS, commit
 the work-item lifecycle move to the feature branch:
 
+Runtime-managed mode:
+
+```bash
+git status --short --branch
+git mv work_items/in_progress/{WI-ID}-*.md work_items/done/ 2>/dev/null || git mv work_items/ready/{WI-ID}-*.md work_items/done/
+git commit -m "chore: move {WI-ID} to done [review PASS]"
+git push origin HEAD
+```
+
+Manual direct mode:
+
 ```bash
 git fetch origin {branch}
 git switch main

--- a/skills/deliver-wi/SKILL.md
+++ b/skills/deliver-wi/SKILL.md
@@ -162,10 +162,14 @@ The user opens a new chat, selects the recommended model, then pastes the whole 
 After the prompt block, always print:
 
 ```text
-Before the agent starts:
+Before the agent starts, refresh the control checkout:
   git fetch origin && git switch main && git pull --ff-only origin main
-For coding: create a fresh branch from main.
-For review: checkout the PR head branch.
+If using agent_runtime:
+  python -m agent_runtime --dispatch
+  Then use only the returned worktree path and branch for that run.
+If running manually outside agent_runtime:
+  For coding: create a fresh branch from main.
+  For review: inspect the PR head in an isolated checkout.
 ```
 
 ## Step 7 — Optionally suggest agent runtime tracking

--- a/tests/unit/agent_runtime/test_drift_suite.py
+++ b/tests/unit/agent_runtime/test_drift_suite.py
@@ -473,6 +473,8 @@ def _write_instruction_surfaces(root: Path) -> None:
     )
     prompt_drift_dir = root / "prompts" / "drift_monitor"
     prompt_drift_dir.mkdir(parents=True, exist_ok=True)
+    invocation_templates_dir = prompt_agents_dir / "invocation_templates"
+    invocation_templates_dir.mkdir(parents=True, exist_ok=True)
     script_dir = root / "scripts" / "drift"
     script_dir.mkdir(parents=True, exist_ok=True)
     script_dir.joinpath("run_all.py").write_text("print('drift')\n", encoding="utf-8")
@@ -504,3 +506,23 @@ def _write_instruction_surfaces(root: Path) -> None:
     }
     for filename, content in prompt_agent_contents.items():
         (prompt_agents_dir / filename).write_text(content, encoding="utf-8")
+
+    invocation_template_contents = {
+        "pm_invocation.md": (
+            "You are the PM agent.\n"
+            "Execution mode:\n"
+            "- If this handoff is run through agent_runtime, the runtime-managed worktree and branch for this run are authoritative. Do not switch to main. Do not create another worktree. Do not create another branch.\n"
+        ),
+        "coding_invocation.md": (
+            "You are the Coding Agent.\n"
+            "Execution mode:\n"
+            "- If this handoff is run through agent_runtime, the runtime-managed worktree and branch for this run are authoritative. Do not switch to main. Do not create another worktree. Do not create another branch.\n"
+        ),
+        "review_invocation.md": (
+            "You are the Review Agent.\n"
+            "Execution mode:\n"
+            "- If this handoff is run through agent_runtime, the runtime-managed review worktree for this run is authoritative. Do not switch to main. Do not create another worktree. Do not create another branch.\n"
+        ),
+    }
+    for filename, content in invocation_template_contents.items():
+        (invocation_templates_dir / filename).write_text(content, encoding="utf-8")

--- a/tests/unit/agent_runtime/test_instruction_surfaces.py
+++ b/tests/unit/agent_runtime/test_instruction_surfaces.py
@@ -129,6 +129,19 @@ def test_instruction_surface_report_detects_missing_runtime_managed_checkout_rul
     assert finding.source_path == "prompts/agents/invocation_templates/coding_invocation.md"
 
 
+def test_instruction_surface_report_detects_missing_runtime_managed_invocation_template(tmp_path: Path) -> None:
+    _write_instruction_surfaces(tmp_path)
+    prompt_path = tmp_path / "prompts" / "agents" / "invocation_templates" / "coding_invocation.md"
+    prompt_path.unlink()
+
+    report = build_instruction_surface_report(tmp_path)
+
+    assert report.stats.findings_count == 1
+    finding = report.findings[0]
+    assert finding.kind == "missing_runtime_managed_invocation_template"
+    assert finding.source_path == "prompts/agents/invocation_templates/coding_invocation.md"
+
+
 def test_check_instruction_surfaces_cli_writes_json_report(tmp_path: Path) -> None:
     _write_instruction_surfaces(tmp_path)
     output_path = tmp_path / "artifacts" / "drift" / "instruction_surfaces.json"

--- a/tests/unit/agent_runtime/test_instruction_surfaces.py
+++ b/tests/unit/agent_runtime/test_instruction_surfaces.py
@@ -116,6 +116,19 @@ def test_instruction_surface_report_detects_missing_drift_suite_entrypoint(tmp_p
     assert finding.source_path == "prompts/drift_monitor/repo_health_audit_prompt.md"
 
 
+def test_instruction_surface_report_detects_missing_runtime_managed_checkout_rule(tmp_path: Path) -> None:
+    _write_instruction_surfaces(tmp_path)
+    prompt_path = tmp_path / "prompts" / "agents" / "invocation_templates" / "coding_invocation.md"
+    prompt_path.write_text("# Coding invocation\n", encoding="utf-8")
+
+    report = build_instruction_surface_report(tmp_path)
+
+    assert report.stats.findings_count == 1
+    finding = report.findings[0]
+    assert finding.kind == "missing_runtime_managed_checkout_rule"
+    assert finding.source_path == "prompts/agents/invocation_templates/coding_invocation.md"
+
+
 def test_check_instruction_surfaces_cli_writes_json_report(tmp_path: Path) -> None:
     _write_instruction_surfaces(tmp_path)
     output_path = tmp_path / "artifacts" / "drift" / "instruction_surfaces.json"
@@ -229,6 +242,8 @@ def _write_instruction_surfaces(root: Path) -> None:
     )
     prompt_drift_dir = root / "prompts" / "drift_monitor"
     prompt_drift_dir.mkdir(parents=True, exist_ok=True)
+    invocation_templates_dir = prompt_agents_dir / "invocation_templates"
+    invocation_templates_dir.mkdir(parents=True, exist_ok=True)
     script_dir = root / "scripts" / "drift"
     script_dir.mkdir(parents=True, exist_ok=True)
     script_dir.joinpath("run_all.py").write_text("print('drift')\n", encoding="utf-8")
@@ -260,3 +275,23 @@ def _write_instruction_surfaces(root: Path) -> None:
     }
     for filename, content in prompt_agent_contents.items():
         (prompt_agents_dir / filename).write_text(content, encoding="utf-8")
+
+    invocation_template_contents = {
+        "pm_invocation.md": (
+            "You are the PM agent.\n"
+            "Execution mode:\n"
+            "- If this handoff is run through `agent_runtime`, the runtime-managed worktree and branch for this run are authoritative. Do not switch to `main`, create another worktree, or create another branch.\n"
+        ),
+        "coding_invocation.md": (
+            "You are the Coding Agent.\n"
+            "Execution mode:\n"
+            "- If this handoff is run through `agent_runtime`, the runtime-managed worktree and branch for this run are authoritative. Do not switch to `main`. Do not create another worktree. Do not create another branch.\n"
+        ),
+        "review_invocation.md": (
+            "You are the Review Agent.\n"
+            "Execution mode:\n"
+            "- If this handoff is run through `agent_runtime`, the runtime-managed review worktree for this run is authoritative. Do not switch to `main`. Do not create another worktree. Do not create another branch.\n"
+        ),
+    }
+    for filename, content in invocation_template_contents.items():
+        (invocation_templates_dir / filename).write_text(content, encoding="utf-8")

--- a/tests/unit/agent_runtime/test_instruction_surfaces.py
+++ b/tests/unit/agent_runtime/test_instruction_surfaces.py
@@ -280,17 +280,17 @@ def _write_instruction_surfaces(root: Path) -> None:
         "pm_invocation.md": (
             "You are the PM agent.\n"
             "Execution mode:\n"
-            "- If this handoff is run through `agent_runtime`, the runtime-managed worktree and branch for this run are authoritative. Do not switch to `main`, create another worktree, or create another branch.\n"
+            "- If this handoff is run through agent_runtime, the runtime-managed worktree and branch for this run are authoritative. Do not switch to main. Do not create another worktree. Do not create another branch.\n"
         ),
         "coding_invocation.md": (
             "You are the Coding Agent.\n"
             "Execution mode:\n"
-            "- If this handoff is run through `agent_runtime`, the runtime-managed worktree and branch for this run are authoritative. Do not switch to `main`. Do not create another worktree. Do not create another branch.\n"
+            "- If this handoff is run through agent_runtime, the runtime-managed worktree and branch for this run are authoritative. Do not switch to main. Do not create another worktree. Do not create another branch.\n"
         ),
         "review_invocation.md": (
             "You are the Review Agent.\n"
             "Execution mode:\n"
-            "- If this handoff is run through `agent_runtime`, the runtime-managed review worktree for this run is authoritative. Do not switch to `main`. Do not create another worktree. Do not create another branch.\n"
+            "- If this handoff is run through agent_runtime, the runtime-managed review worktree for this run is authoritative. Do not switch to main. Do not create another worktree. Do not create another branch.\n"
         ),
     }
     for filename, content in invocation_template_contents.items():


### PR DESCRIPTION
## Summary
- define a strict control-checkout vs runtime-managed execution-checkout policy in repo canon
- update PM/coding/review instructions and invocation templates so runtime-managed sessions stop creating their own checkout state
- inject authoritative worktree metadata into runtime-bound prompts and extend instruction-surface drift checks to enforce the policy

## Testing
- pytest agent_runtime/tests/test_pm_runner.py agent_runtime/tests/test_coding_runner.py agent_runtime/tests/test_review_runner.py agent_runtime/tests/test_worktree_manager.py agent_runtime/tests/test_transitions.py tests/unit/agent_runtime/test_instruction_surfaces.py tests/unit/agent_runtime/test_drift_suite.py
