### PR TITLE
Bootstrap issue planner from backlog gaps

### DIFF
--- a/agent_runtime/README.md
+++ b/agent_runtime/README.md
@@ -104,6 +104,11 @@ now performs a lightweight backlog-materialization scan. If an implementation-re
 PRD names follow-on WI IDs that do not exist under the live backlog tree, the
 runtime bootstraps into an Issue Planner handoff instead of returning `noop`.
 
+If no runnable ready WI exists and no Issue Planner bootstrap is needed, the
+runtime can also inspect the registry for an actionable PRD gap. When the
+registry explicitly says a non-post-MVP PRD or PRD version should be authored
+next, the runtime bootstraps into a PRD/spec handoff instead of returning `noop`.
+
 ## Build the next runner invocation
 
 ```bash
@@ -115,7 +120,8 @@ typed runner prompt that a later execution layer can hand to the correct agent.
 
 That decision can now be a backlog bootstrap handoff as well as a normal ready-item
 relay step. For example, a merged PRD with issue-decomposition guidance but no
-materialized follow-on WI files can dispatch Issue Planner directly.
+materialized follow-on WI files can dispatch Issue Planner directly, and an
+empty backlog with an actionable registry PRD gap can dispatch PRD/spec directly.
 
 ## Dispatch through the local runner adapters
 

--- a/agent_runtime/README.md
+++ b/agent_runtime/README.md
@@ -99,6 +99,11 @@ The supervisor loop:
 - sleeps on `wait_for_reviews` and `noop`
 - stops cleanly on `human_update_repo`, `human_merge`, prepared manual handoffs, and failed runs
 
+When the live backlog has no runnable `work_items/ready/` entries, the runtime
+now performs a lightweight backlog-materialization scan. If an implementation-ready
+PRD names follow-on WI IDs that do not exist under the live backlog tree, the
+runtime bootstraps into an Issue Planner handoff instead of returning `noop`.
+
 ## Build the next runner invocation
 
 ```bash
@@ -107,6 +112,10 @@ The supervisor loop:
 
 This records the current decision in `.agent_runtime/state.db` and returns the
 typed runner prompt that a later execution layer can hand to the correct agent.
+
+That decision can now be a backlog bootstrap handoff as well as a normal ready-item
+relay step. For example, a merged PRD with issue-decomposition guidance but no
+materialized follow-on WI files can dispatch Issue Planner directly.
 
 ## Dispatch through the local runner adapters
 

--- a/agent_runtime/manual_supervisor_workflow.md
+++ b/agent_runtime/manual_supervisor_workflow.md
@@ -67,6 +67,10 @@ This returns JSON including:
 - `worktree.path`
 - `state_db_path`
 
+If there is no runnable live `ready/` WI, the runtime may still return an
+Issue Planner handoff when an implementation-ready PRD names follow-on WI IDs
+that have not yet been materialized under the live backlog tree.
+
 ### 2. Move into the allocated worktree
 
 ```bash

--- a/agent_runtime/manual_supervisor_workflow.md
+++ b/agent_runtime/manual_supervisor_workflow.md
@@ -71,6 +71,10 @@ If there is no runnable live `ready/` WI, the runtime may still return an
 Issue Planner handoff when an implementation-ready PRD names follow-on WI IDs
 that have not yet been materialized under the live backlog tree.
 
+If neither a runnable live `ready/` WI nor a backlog-materialization handoff
+exists, the runtime may instead return a PRD/spec handoff when the registry
+explicitly marks a non-post-MVP PRD gap as the next required slice.
+
 ### 2. Move into the allocated worktree
 
 ```bash

--- a/agent_runtime/orchestrator/execution.py
+++ b/agent_runtime/orchestrator/execution.py
@@ -78,11 +78,14 @@ def build_runner_execution(snapshot: RuntimeSnapshot, decision: TransitionDecisi
         )
 
     if decision.action is NextActionType.RUN_ISSUE_PLANNER:
+        missing_work_item_ids = tuple(item_id.strip() for item_id in decision.metadata.get("missing_work_item_ids", "").split(",") if item_id.strip())
         issue_planner_input = IssuePlannerRunnerInput(
             work_item_id=work_item.id,
             split_reason=decision.reason,
             work_item_path=str(work_item.path),
             linked_prd=work_item.linked_prd,
+            source_prd_path=decision.metadata.get("backlog_source_prd"),
+            missing_work_item_ids=missing_work_item_ids,
         )
         return RunnerExecution(
             runner_name=RunnerName.ISSUE_PLANNER,

--- a/agent_runtime/orchestrator/execution.py
+++ b/agent_runtime/orchestrator/execution.py
@@ -42,6 +42,27 @@ def build_runner_execution(snapshot: RuntimeSnapshot, decision: TransitionDecisi
     if decision.work_item_id is None:
         return None
 
+    if decision.action is NextActionType.RUN_SPEC and decision.metadata.get("bootstrap_mode") == "prd_gap":
+        spec_input = SpecRunnerInput(
+            work_item_id=decision.work_item_id,
+            blocked_reason=decision.reason,
+            work_item_path=str(decision.target_path or decision.metadata.get("registry_path") or "."),
+            linked_prd=decision.metadata.get("existing_prd_path") or None,
+            bootstrap_capability=decision.metadata.get("capability_name") or None,
+            target_prd_id=decision.metadata.get("target_prd_id") or None,
+            registry_path=decision.metadata.get("registry_path") or None,
+            next_slice=decision.metadata.get("next_slice") or None,
+        )
+        return RunnerExecution(
+            runner_name=RunnerName.SPEC,
+            work_item_id=decision.work_item_id,
+            prompt=build_spec_prompt(spec_input),
+            metadata={
+                **dict(decision.metadata),
+                "target_path": str(decision.target_path) if decision.target_path is not None else str(decision.metadata.get("registry_path") or "."),
+            },
+        )
+
     work_item = _find_work_item(snapshot, decision.work_item_id)
     pull_request = _find_pull_request(snapshot, decision.work_item_id)
     default_base_ref = f"origin/{pull_request.head_ref_name}" if pull_request is not None and pull_request.head_ref_name else "origin/main"

--- a/agent_runtime/orchestrator/graph.py
+++ b/agent_runtime/orchestrator/graph.py
@@ -35,7 +35,15 @@ from agent_runtime.storage.sqlite import (
 )
 
 from .github_sync import fetch_pull_requests
-from .state import BacklogMaterializationSnapshot, NextActionType, PrdBootstrapSnapshot, RuntimeSnapshot, TransitionDecision
+from .state import (
+    BacklogMaterializationSnapshot,
+    NextActionType,
+    PrdBootstrapSnapshot,
+    RuntimeSnapshot,
+    TransitionDecision,
+    WorkItemSnapshot,
+    WorkItemStage,
+)
 from .simulations import build_simulation_snapshot, simulation_names
 from .transitions import decide_next_action
 from .work_item_registry import load_work_items
@@ -121,31 +129,44 @@ def build_governance_decision(repo_root: Path) -> TransitionDecision | None:
     )
 
 
+def _has_runnable_ready_item(work_items: tuple[WorkItemSnapshot, ...]) -> bool:
+    completed_ids = {item.id for item in work_items if item.stage is WorkItemStage.DONE}
+    for item in work_items:
+        if item.stage is not WorkItemStage.READY:
+            continue
+        if all(not dependency.startswith("WI-") or dependency in completed_ids for dependency in item.dependencies):
+            return True
+    return False
+
+
 def build_runtime_snapshot(repo_root: Path, state_db_path: Path) -> RuntimeSnapshot:
     work_items, warnings = load_work_items(repo_root)
     pull_requests, github_warnings = fetch_pull_requests(repo_root, work_items)
     workflow_runs = load_workflow_runs(state_db_path)
-    backlog_materialization_report = build_backlog_materialization_report(repo_root)
-    backlog_materialization = tuple(
-        BacklogMaterializationSnapshot(
-            source_path=finding.source_path,
-            related_paths=finding.related_paths,
-            message=finding.message,
+    backlog_materialization: tuple[BacklogMaterializationSnapshot, ...] = ()
+    prd_bootstrap: tuple[PrdBootstrapSnapshot, ...] = ()
+    if not _has_runnable_ready_item(work_items):
+        backlog_materialization_report = build_backlog_materialization_report(repo_root)
+        backlog_materialization = tuple(
+            BacklogMaterializationSnapshot(
+                source_path=finding.source_path,
+                related_paths=finding.related_paths,
+                message=finding.message,
+            )
+            for finding in backlog_materialization_report.findings
+            if finding.kind == "missing_decomposed_work_items"
         )
-        for finding in backlog_materialization_report.findings
-        if finding.kind == "missing_decomposed_work_items"
-    )
-    prd_bootstrap = tuple(
-        PrdBootstrapSnapshot(
-            capability_name=candidate.capability_name,
-            target_prd_id=candidate.target_prd_id,
-            existing_prd_path=candidate.existing_prd_path,
-            registry_path=candidate.registry_path,
-            next_slice=candidate.next_slice,
-            next_version_reason=candidate.next_version_reason,
+        prd_bootstrap = tuple(
+            PrdBootstrapSnapshot(
+                capability_name=candidate.capability_name,
+                target_prd_id=candidate.target_prd_id,
+                existing_prd_path=candidate.existing_prd_path,
+                registry_path=candidate.registry_path,
+                next_slice=candidate.next_slice,
+                next_version_reason=candidate.next_version_reason,
+            )
+            for candidate in load_prd_bootstrap_candidates(repo_root)
         )
-        for candidate in load_prd_bootstrap_candidates(repo_root)
-    )
     # drift_critical_findings / drift_summary_md are intentionally not populated
     # here — running the full drift suite on every poll tick adds 5–10 s of latency.
     # Drift gating is handled by the --governance pre-step, which runs before the

--- a/agent_runtime/orchestrator/graph.py
+++ b/agent_runtime/orchestrator/graph.py
@@ -14,6 +14,7 @@ from agent_runtime.config.defaults import RuntimeDefaults, build_defaults
 from agent_runtime.drift.backlog_materialization import build_backlog_materialization_report
 from agent_runtime.notifications.slack import notify_human_gate, notify_runner_failed, send_morning_digest
 from agent_runtime.orchestrator.execution import build_runner_execution
+from agent_runtime.orchestrator.prd_bootstrap import load_prd_bootstrap_candidates
 from agent_runtime.orchestrator.pr_publication import maybe_publish_completed_coding_run
 from agent_runtime.orchestrator.supervisor import (
     classify_loop_payload,
@@ -34,7 +35,7 @@ from agent_runtime.storage.sqlite import (
 )
 
 from .github_sync import fetch_pull_requests
-from .state import BacklogMaterializationSnapshot, NextActionType, RuntimeSnapshot, TransitionDecision
+from .state import BacklogMaterializationSnapshot, NextActionType, PrdBootstrapSnapshot, RuntimeSnapshot, TransitionDecision
 from .simulations import build_simulation_snapshot, simulation_names
 from .transitions import decide_next_action
 from .work_item_registry import load_work_items
@@ -134,6 +135,17 @@ def build_runtime_snapshot(repo_root: Path, state_db_path: Path) -> RuntimeSnaps
         for finding in backlog_materialization_report.findings
         if finding.kind == "missing_decomposed_work_items"
     )
+    prd_bootstrap = tuple(
+        PrdBootstrapSnapshot(
+            capability_name=candidate.capability_name,
+            target_prd_id=candidate.target_prd_id,
+            existing_prd_path=candidate.existing_prd_path,
+            registry_path=candidate.registry_path,
+            next_slice=candidate.next_slice,
+            next_version_reason=candidate.next_version_reason,
+        )
+        for candidate in load_prd_bootstrap_candidates(repo_root)
+    )
     # drift_critical_findings / drift_summary_md are intentionally not populated
     # here — running the full drift suite on every poll tick adds 5–10 s of latency.
     # Drift gating is handled by the --governance pre-step, which runs before the
@@ -145,6 +157,7 @@ def build_runtime_snapshot(repo_root: Path, state_db_path: Path) -> RuntimeSnaps
         workflow_runs=workflow_runs,
         warnings=warnings + github_warnings,
         backlog_materialization=backlog_materialization,
+        prd_bootstrap=prd_bootstrap,
     )
 
 

--- a/agent_runtime/orchestrator/graph.py
+++ b/agent_runtime/orchestrator/graph.py
@@ -11,6 +11,7 @@ import logging
 from pathlib import Path
 
 from agent_runtime.config.defaults import RuntimeDefaults, build_defaults
+from agent_runtime.drift.backlog_materialization import build_backlog_materialization_report
 from agent_runtime.notifications.slack import notify_human_gate, notify_runner_failed, send_morning_digest
 from agent_runtime.orchestrator.execution import build_runner_execution
 from agent_runtime.orchestrator.pr_publication import maybe_publish_completed_coding_run
@@ -33,7 +34,7 @@ from agent_runtime.storage.sqlite import (
 )
 
 from .github_sync import fetch_pull_requests
-from .state import NextActionType, RuntimeSnapshot, TransitionDecision
+from .state import BacklogMaterializationSnapshot, NextActionType, RuntimeSnapshot, TransitionDecision
 from .simulations import build_simulation_snapshot, simulation_names
 from .transitions import decide_next_action
 from .work_item_registry import load_work_items
@@ -123,6 +124,16 @@ def build_runtime_snapshot(repo_root: Path, state_db_path: Path) -> RuntimeSnaps
     work_items, warnings = load_work_items(repo_root)
     pull_requests, github_warnings = fetch_pull_requests(repo_root, work_items)
     workflow_runs = load_workflow_runs(state_db_path)
+    backlog_materialization_report = build_backlog_materialization_report(repo_root)
+    backlog_materialization = tuple(
+        BacklogMaterializationSnapshot(
+            source_path=finding.source_path,
+            related_paths=finding.related_paths,
+            message=finding.message,
+        )
+        for finding in backlog_materialization_report.findings
+        if finding.kind == "missing_decomposed_work_items"
+    )
     # drift_critical_findings / drift_summary_md are intentionally not populated
     # here — running the full drift suite on every poll tick adds 5–10 s of latency.
     # Drift gating is handled by the --governance pre-step, which runs before the
@@ -133,6 +144,7 @@ def build_runtime_snapshot(repo_root: Path, state_db_path: Path) -> RuntimeSnaps
         pull_requests=pull_requests,
         workflow_runs=workflow_runs,
         warnings=warnings + github_warnings,
+        backlog_materialization=backlog_materialization,
     )
 
 

--- a/agent_runtime/orchestrator/prd_bootstrap.py
+++ b/agent_runtime/orchestrator/prd_bootstrap.py
@@ -31,48 +31,134 @@ def load_prd_bootstrap_candidates(repo_root: Path) -> tuple[PrdBootstrapCandidat
     new PRD or PRD version is needed *now* rather than in a post-MVP phase. This
     keeps empty-backlog routing deterministic and governed.
     """
-    try:
-        import yaml
-    except ImportError:
-        return ()
-
     registry_path = repo_root / REGISTRY_PATH
     if not registry_path.is_file():
         return ()
 
-    payload = yaml.safe_load(registry_path.read_text(encoding="utf-8"))
-    if not isinstance(payload, dict):
-        return ()
-
     candidates: list[PrdBootstrapCandidate] = []
-    for dashboard in payload.get("module_dashboards", ()):
-        if not isinstance(dashboard, dict):
+    for capability in _load_registry_capabilities(registry_path):
+        if not _is_actionable_prd_gap(capability):
             continue
-        for capability in dashboard.get("capabilities", ()):
-            if not isinstance(capability, dict):
-                continue
-            if not _is_actionable_prd_gap(capability):
-                continue
 
-            next_slice = str(capability.get("next_slice") or "").strip()
-            next_version_reason = str(capability.get("next_version_reason") or "").strip()
-            missing_prds = tuple(str(item).strip() for item in capability.get("missing_prds", ()) if str(item).strip())
-            target_prd_id = _extract_target_prd_id(next_slice, missing_prds)
-            existing_prd_id = _extract_existing_prd_id(next_version_reason, target_prd_id)
-            existing_prd_path = _find_prd_path_by_id(repo_root, existing_prd_id) if existing_prd_id is not None else None
-            capability_name = str(capability.get("name") or capability.get("component_ref") or "unknown capability")
-            candidates.append(
-                PrdBootstrapCandidate(
-                    capability_name=capability_name,
-                    target_prd_id=target_prd_id,
-                    existing_prd_path=existing_prd_path,
-                    registry_path=REGISTRY_PATH.as_posix(),
-                    next_slice=next_slice,
-                    next_version_reason=next_version_reason,
-                )
+        next_slice = str(capability.get("next_slice") or "").strip()
+        next_version_reason = str(capability.get("next_version_reason") or "").strip()
+        missing_prds = _coerce_string_tuple(capability.get("missing_prds"))
+        target_prd_id = _extract_target_prd_id(next_slice, missing_prds)
+        existing_prd_id = _extract_existing_prd_id(next_version_reason, target_prd_id)
+        existing_prd_path = _find_prd_path_by_id(repo_root, existing_prd_id) if existing_prd_id is not None else None
+        capability_name = str(capability.get("name") or capability.get("component_ref") or "unknown capability")
+        candidates.append(
+            PrdBootstrapCandidate(
+                capability_name=capability_name,
+                target_prd_id=target_prd_id,
+                existing_prd_path=existing_prd_path,
+                registry_path=REGISTRY_PATH.as_posix(),
+                next_slice=next_slice,
+                next_version_reason=next_version_reason,
             )
+        )
 
     return tuple(candidates)
+
+
+def _load_registry_capabilities(registry_path: Path) -> tuple[dict[str, object], ...]:
+    lines = registry_path.read_text(encoding="utf-8").splitlines()
+    capabilities: list[dict[str, object]] = []
+    in_capabilities = False
+    current: dict[str, object] | None = None
+    collecting_missing_prds = False
+
+    def finalize_current() -> None:
+        nonlocal current, collecting_missing_prds
+        if current is not None:
+            capabilities.append(current)
+        current = None
+        collecting_missing_prds = False
+
+    for raw_line in lines:
+        stripped = raw_line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        indent = len(raw_line) - len(raw_line.lstrip(" "))
+
+        if stripped == "capabilities:":
+            finalize_current()
+            in_capabilities = True
+            continue
+
+        if not in_capabilities:
+            continue
+
+        if indent <= 2 and stripped.endswith(":") and stripped != "capabilities:":
+            finalize_current()
+            in_capabilities = False
+            continue
+
+        if indent == 6 and stripped.startswith("- "):
+            finalize_current()
+            current = {}
+            collecting_missing_prds = False
+            _parse_capability_entry(current, stripped[2:])
+            continue
+
+        if current is None:
+            continue
+
+        if collecting_missing_prds:
+            if indent >= 8 and stripped.startswith("- "):
+                missing_prds = current.setdefault("missing_prds", [])
+                assert isinstance(missing_prds, list)
+                missing_prds.append(stripped[2:].strip())
+                continue
+            collecting_missing_prds = False
+
+        if indent >= 8:
+            key, _, value = stripped.partition(":")
+            if not _:
+                continue
+            key = key.strip()
+            value = value.strip()
+            if key == "missing_prds":
+                if value.startswith("[") and value.endswith("]"):
+                    current["missing_prds"] = _parse_inline_list(value)
+                else:
+                    current["missing_prds"] = []
+                    collecting_missing_prds = True
+                continue
+            current[key] = _parse_scalar(value)
+
+    finalize_current()
+    return tuple(capabilities)
+
+
+def _parse_capability_entry(current: dict[str, object], entry: str) -> None:
+    key, _, value = entry.partition(":")
+    if not _:
+        return
+    current[key.strip()] = _parse_scalar(value.strip())
+
+
+def _parse_inline_list(value: str) -> list[str]:
+    inner = value[1:-1].strip()
+    if not inner:
+        return []
+    return [item.strip().strip("'\"") for item in inner.split(",") if item.strip()]
+
+
+def _parse_scalar(value: str) -> object:
+    if value in {"true", "True"}:
+        return True
+    if value in {"false", "False"}:
+        return False
+    if value in {"[]", ""}:
+        return []
+    return value.strip().strip("'\"")
+
+
+def _coerce_string_tuple(value: object) -> tuple[str, ...]:
+    if not isinstance(value, list):
+        return ()
+    return tuple(str(item).strip() for item in value if str(item).strip())
 
 
 def _is_actionable_prd_gap(capability: dict[str, object]) -> bool:

--- a/agent_runtime/orchestrator/prd_bootstrap.py
+++ b/agent_runtime/orchestrator/prd_bootstrap.py
@@ -1,0 +1,125 @@
+"""Registry-driven PRD/spec bootstrap candidates for empty-backlog routing."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+import re
+
+
+REGISTRY_PATH = Path("docs/registry/current_state_registry.yaml")
+_AUTHOR_PRD_PATTERN = re.compile(r"\bauthor\b.*\bprd\b", re.IGNORECASE)
+_POST_MVP_PATTERN = re.compile(r"\bpost-mvp\b", re.IGNORECASE)
+_PRD_ID_PATTERN = re.compile(r"\b(PRD-[A-Za-z0-9.\-]+)\b")
+_PRD_ID_HEADER_PATTERN = re.compile(r"^\s*-\s+\*\*PRD ID:\*\*\s+(PRD-[A-Za-z0-9.\-]+)\s*$", re.MULTILINE)
+
+
+@dataclass(frozen=True, slots=True)
+class PrdBootstrapCandidate:
+    capability_name: str
+    target_prd_id: str | None
+    existing_prd_path: str | None
+    registry_path: str
+    next_slice: str
+    next_version_reason: str
+
+
+def load_prd_bootstrap_candidates(repo_root: Path) -> tuple[PrdBootstrapCandidate, ...]:
+    """Return actionable PRD/spec bootstrap candidates from the registry.
+
+    The runtime should only bootstrap into PRD/spec work when the registry says a
+    new PRD or PRD version is needed *now* rather than in a post-MVP phase. This
+    keeps empty-backlog routing deterministic and governed.
+    """
+    try:
+        import yaml
+    except ImportError:
+        return ()
+
+    registry_path = repo_root / REGISTRY_PATH
+    if not registry_path.is_file():
+        return ()
+
+    payload = yaml.safe_load(registry_path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        return ()
+
+    candidates: list[PrdBootstrapCandidate] = []
+    for dashboard in payload.get("module_dashboards", ()):
+        if not isinstance(dashboard, dict):
+            continue
+        for capability in dashboard.get("capabilities", ()):
+            if not isinstance(capability, dict):
+                continue
+            if not _is_actionable_prd_gap(capability):
+                continue
+
+            next_slice = str(capability.get("next_slice") or "").strip()
+            next_version_reason = str(capability.get("next_version_reason") or "").strip()
+            missing_prds = tuple(str(item).strip() for item in capability.get("missing_prds", ()) if str(item).strip())
+            target_prd_id = _extract_target_prd_id(next_slice, missing_prds)
+            existing_prd_id = _extract_existing_prd_id(next_version_reason, target_prd_id)
+            existing_prd_path = _find_prd_path_by_id(repo_root, existing_prd_id) if existing_prd_id is not None else None
+            capability_name = str(capability.get("name") or capability.get("component_ref") or "unknown capability")
+            candidates.append(
+                PrdBootstrapCandidate(
+                    capability_name=capability_name,
+                    target_prd_id=target_prd_id,
+                    existing_prd_path=existing_prd_path,
+                    registry_path=REGISTRY_PATH.as_posix(),
+                    next_slice=next_slice,
+                    next_version_reason=next_version_reason,
+                )
+            )
+
+    return tuple(candidates)
+
+
+def _is_actionable_prd_gap(capability: dict[str, object]) -> bool:
+    missing_prds = capability.get("missing_prds")
+    needs_new_prd_version = bool(capability.get("needs_new_prd_version"))
+    if not needs_new_prd_version and not missing_prds:
+        return False
+
+    next_slice = str(capability.get("next_slice") or "").strip()
+    next_version_reason = str(capability.get("next_version_reason") or "").strip()
+    if not _AUTHOR_PRD_PATTERN.search(next_slice):
+        return False
+    if _POST_MVP_PATTERN.search(next_slice) or _POST_MVP_PATTERN.search(next_version_reason):
+        return False
+    return True
+
+
+def _extract_target_prd_id(next_slice: str, missing_prds: tuple[str, ...]) -> str | None:
+    for missing_prd in missing_prds:
+        match = _PRD_ID_PATTERN.search(missing_prd)
+        if match is not None:
+            return match.group(1)
+    match = _PRD_ID_PATTERN.search(next_slice)
+    if match is None:
+        return None
+    return match.group(1)
+
+
+def _extract_existing_prd_id(next_version_reason: str, target_prd_id: str | None) -> str | None:
+    for match in _PRD_ID_PATTERN.finditer(next_version_reason):
+        prd_id = match.group(1)
+        if prd_id != target_prd_id:
+            return prd_id
+    return None
+
+
+def _find_prd_path_by_id(repo_root: Path, prd_id: str | None) -> str | None:
+    if not prd_id:
+        return None
+    docs_root = repo_root / "docs" / "prds"
+    if not docs_root.is_dir():
+        return None
+    for full_path in sorted(docs_root.rglob("*.md")):
+        contents = full_path.read_text(encoding="utf-8")
+        match = _PRD_ID_HEADER_PATTERN.search(contents)
+        if match is None:
+            continue
+        if match.group(1) == prd_id:
+            return full_path.relative_to(repo_root).as_posix()
+    return None

--- a/agent_runtime/orchestrator/prd_bootstrap.py
+++ b/agent_runtime/orchestrator/prd_bootstrap.py
@@ -65,11 +65,26 @@ def _load_registry_capabilities(registry_path: Path) -> tuple[dict[str, object],
     lines = registry_path.read_text(encoding="utf-8").splitlines()
     capabilities: list[dict[str, object]] = []
     in_capabilities = False
+    capabilities_indent: int | None = None
     current: dict[str, object] | None = None
     collecting_missing_prds = False
+    block_scalar_key: str | None = None
+    block_scalar_mode: str | None = None
+    block_scalar_indent: int | None = None
+    block_scalar_lines: list[str] = []
+
+    def flush_block_scalar() -> None:
+        nonlocal block_scalar_indent, block_scalar_key, block_scalar_lines, block_scalar_mode
+        if current is not None and block_scalar_key is not None and block_scalar_mode is not None:
+            current[block_scalar_key] = _finalize_block_scalar(block_scalar_lines, block_scalar_mode)
+        block_scalar_key = None
+        block_scalar_mode = None
+        block_scalar_indent = None
+        block_scalar_lines = []
 
     def finalize_current() -> None:
         nonlocal current, collecting_missing_prds
+        flush_block_scalar()
         if current is not None:
             capabilities.append(current)
         current = None
@@ -77,21 +92,34 @@ def _load_registry_capabilities(registry_path: Path) -> tuple[dict[str, object],
 
     for raw_line in lines:
         stripped = raw_line.strip()
-        if not stripped or stripped.startswith("#"):
+        if not stripped and block_scalar_key is None:
+            continue
+        if stripped.startswith("#") and block_scalar_key is None:
             continue
         indent = len(raw_line) - len(raw_line.lstrip(" "))
+
+        if block_scalar_key is not None and block_scalar_indent is not None:
+            if stripped and indent > block_scalar_indent:
+                block_scalar_lines.append(raw_line[block_scalar_indent + 2 :].rstrip())
+                continue
+            if not stripped and indent > block_scalar_indent:
+                block_scalar_lines.append("")
+                continue
+            flush_block_scalar()
 
         if stripped == "capabilities:":
             finalize_current()
             in_capabilities = True
+            capabilities_indent = indent
             continue
 
         if not in_capabilities:
             continue
 
-        if indent <= 2 and stripped.endswith(":") and stripped != "capabilities:":
+        if capabilities_indent is not None and indent <= capabilities_indent and stripped.endswith(":") and stripped != "capabilities:":
             finalize_current()
             in_capabilities = False
+            capabilities_indent = None
             continue
 
         if indent == 6 and stripped.startswith("- "):
@@ -125,6 +153,12 @@ def _load_registry_capabilities(registry_path: Path) -> tuple[dict[str, object],
                     current["missing_prds"] = []
                     collecting_missing_prds = True
                 continue
+            if value in {">", ">-", "|", "|-"}:
+                block_scalar_key = key
+                block_scalar_mode = "literal" if value.startswith("|") else "folded"
+                block_scalar_indent = indent
+                block_scalar_lines = []
+                continue
             current[key] = _parse_scalar(value)
 
     finalize_current()
@@ -153,6 +187,12 @@ def _parse_scalar(value: str) -> object:
     if value in {"[]", ""}:
         return []
     return value.strip().strip("'\"")
+
+
+def _finalize_block_scalar(lines: list[str], mode: str) -> str:
+    if mode == "literal":
+        return "\n".join(line.strip() for line in lines).strip()
+    return " ".join(line.strip() for line in lines if line.strip()).strip()
 
 
 def _coerce_string_tuple(value: object) -> tuple[str, ...]:

--- a/agent_runtime/orchestrator/state.py
+++ b/agent_runtime/orchestrator/state.py
@@ -65,6 +65,16 @@ class BacklogMaterializationSnapshot:
 
 
 @dataclass(frozen=True)
+class PrdBootstrapSnapshot:
+    capability_name: str
+    target_prd_id: str | None
+    existing_prd_path: str | None
+    registry_path: str
+    next_slice: str
+    next_version_reason: str
+
+
+@dataclass(frozen=True)
 class RuntimeSnapshot:
     work_items: tuple[WorkItemSnapshot, ...]
     pull_requests: tuple[PullRequestSnapshot, ...] = ()
@@ -73,6 +83,7 @@ class RuntimeSnapshot:
     drift_critical_findings: int = 0
     drift_summary_md: str | None = None
     backlog_materialization: tuple[BacklogMaterializationSnapshot, ...] = ()
+    prd_bootstrap: tuple[PrdBootstrapSnapshot, ...] = ()
 
 
 @dataclass(frozen=True)

--- a/agent_runtime/orchestrator/state.py
+++ b/agent_runtime/orchestrator/state.py
@@ -58,6 +58,13 @@ class PullRequestSnapshot:
 
 
 @dataclass(frozen=True)
+class BacklogMaterializationSnapshot:
+    source_path: str
+    related_paths: tuple[str, ...]
+    message: str
+
+
+@dataclass(frozen=True)
 class RuntimeSnapshot:
     work_items: tuple[WorkItemSnapshot, ...]
     pull_requests: tuple[PullRequestSnapshot, ...] = ()
@@ -65,6 +72,7 @@ class RuntimeSnapshot:
     warnings: tuple[str, ...] = ()
     drift_critical_findings: int = 0
     drift_summary_md: str | None = None
+    backlog_materialization: tuple[BacklogMaterializationSnapshot, ...] = ()
 
 
 @dataclass(frozen=True)

--- a/agent_runtime/orchestrator/transitions.py
+++ b/agent_runtime/orchestrator/transitions.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime
+import re
 
 from agent_runtime.storage.sqlite import WorkflowRunRecord
 
 from .state import (
+    BacklogMaterializationSnapshot,
     NextActionType,
     PullRequestSnapshot,
     RuntimeSnapshot,
@@ -25,6 +27,7 @@ _CODING_REPO_UPDATE_OUTCOMES = {"blocked", "completed", "needs_pm"}
 _REVIEW_CODING_OUTCOMES = {"changes_requested"}
 _REVIEW_REPO_UPDATE_OUTCOMES = {"blocked", "pass"}
 _SPEC_REPO_UPDATE_OUTCOMES = {"clarified", "blocked", "split_required"}
+_PRD_PATH_PATTERN = re.compile(r"docs/prds/[A-Za-z0-9_./-]+\.md")
 
 
 def _parse_workflow_run_timestamp(timestamp: str | None) -> float | None:
@@ -68,6 +71,15 @@ def _dependencies_satisfied(item: WorkItemSnapshot, snapshot: RuntimeSnapshot) -
         if dependency.startswith("WI-") and dependency not in completed_ids:
             return False
     return True
+
+
+def _extract_prd_path(linked_prd: str | None) -> str | None:
+    if linked_prd is None:
+        return None
+    match = _PRD_PATH_PATTERN.search(linked_prd)
+    if match is None:
+        return None
+    return match.group(0)
 
 
 def _work_item_changed_since_completion(item: WorkItemSnapshot, completed_at: str | None) -> bool:
@@ -253,6 +265,41 @@ def _decision_from_completed_coding_outcome(
     return None
 
 
+def _backlog_materialization_owner(
+    snapshot: RuntimeSnapshot,
+    finding: BacklogMaterializationSnapshot,
+) -> WorkItemSnapshot | None:
+    stage_priority = {
+        WorkItemStage.DONE: 0,
+        WorkItemStage.IN_PROGRESS: 1,
+        WorkItemStage.BLOCKED: 2,
+        WorkItemStage.READY: 3,
+    }
+    candidates = [work_item for work_item in snapshot.work_items if _extract_prd_path(work_item.linked_prd) == finding.source_path]
+    if not candidates:
+        return None
+    return sorted(candidates, key=lambda work_item: (stage_priority[work_item.stage], work_item.id))[0]
+
+
+def _decision_from_backlog_materialization(snapshot: RuntimeSnapshot) -> TransitionDecision | None:
+    for finding in snapshot.backlog_materialization:
+        owner = _backlog_materialization_owner(snapshot, finding)
+        if owner is None:
+            continue
+        return TransitionDecision(
+            action=NextActionType.RUN_ISSUE_PLANNER,
+            work_item_id=owner.id,
+            reason=finding.message,
+            target_path=owner.path,
+            metadata={
+                "backlog_trigger": "missing_decomposed_work_items",
+                "backlog_source_prd": finding.source_path,
+                "missing_work_item_ids": ",".join(finding.related_paths),
+            },
+        )
+    return None
+
+
 def _decide_for_work_item(
     work_item: WorkItemSnapshot,
     pull_request: PullRequestSnapshot | None,
@@ -383,6 +430,10 @@ def decide_next_action(snapshot: RuntimeSnapshot) -> TransitionDecision:
         )
         return _apply_drift_gate(snapshot, decision)
 
+    backlog_decision = _decision_from_backlog_materialization(snapshot)
+    if backlog_decision is not None:
+        return backlog_decision
+
     return TransitionDecision(
         action=NextActionType.NOOP,
         work_item_id=None,
@@ -416,5 +467,10 @@ def decide_all_actions(snapshot: RuntimeSnapshot) -> tuple[TransitionDecision, .
             workflow_runs_by_work_item.get(work_item.id),
         )
         decisions.append(_apply_drift_gate(snapshot, decision))
+
+    if not decisions:
+        backlog_decision = _decision_from_backlog_materialization(snapshot)
+        if backlog_decision is not None:
+            return (backlog_decision,)
 
     return tuple(decisions)

--- a/agent_runtime/orchestrator/transitions.py
+++ b/agent_runtime/orchestrator/transitions.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime
+from pathlib import Path
 import re
 
 from agent_runtime.storage.sqlite import WorkflowRunRecord
@@ -300,6 +301,32 @@ def _decision_from_backlog_materialization(snapshot: RuntimeSnapshot) -> Transit
     return None
 
 
+def _decision_from_prd_bootstrap(snapshot: RuntimeSnapshot) -> TransitionDecision | None:
+    for candidate in snapshot.prd_bootstrap:
+        target_prd_id = candidate.target_prd_id or f"{candidate.capability_name}-prd-bootstrap"
+        target_path = Path(candidate.existing_prd_path or candidate.registry_path)
+        reason = (
+            f"Registry indicates {candidate.capability_name} needs {target_prd_id}. "
+            f"{candidate.next_version_reason} Next slice: {candidate.next_slice}"
+        ).strip()
+        return TransitionDecision(
+            action=NextActionType.RUN_SPEC,
+            work_item_id=target_prd_id,
+            reason=reason,
+            target_path=target_path,
+            metadata={
+                "bootstrap_mode": "prd_gap",
+                "capability_name": candidate.capability_name,
+                "target_prd_id": candidate.target_prd_id or "",
+                "existing_prd_path": candidate.existing_prd_path or "",
+                "registry_path": candidate.registry_path,
+                "next_slice": candidate.next_slice,
+                "next_version_reason": candidate.next_version_reason,
+            },
+        )
+    return None
+
+
 def _decide_for_work_item(
     work_item: WorkItemSnapshot,
     pull_request: PullRequestSnapshot | None,
@@ -434,6 +461,10 @@ def decide_next_action(snapshot: RuntimeSnapshot) -> TransitionDecision:
     if backlog_decision is not None:
         return backlog_decision
 
+    prd_bootstrap_decision = _decision_from_prd_bootstrap(snapshot)
+    if prd_bootstrap_decision is not None:
+        return prd_bootstrap_decision
+
     return TransitionDecision(
         action=NextActionType.NOOP,
         work_item_id=None,
@@ -472,5 +503,8 @@ def decide_all_actions(snapshot: RuntimeSnapshot) -> tuple[TransitionDecision, .
         backlog_decision = _decision_from_backlog_materialization(snapshot)
         if backlog_decision is not None:
             return (backlog_decision,)
+        prd_bootstrap_decision = _decision_from_prd_bootstrap(snapshot)
+        if prd_bootstrap_decision is not None:
+            return (prd_bootstrap_decision,)
 
     return tuple(decisions)

--- a/agent_runtime/runners/issue_planner_runner.py
+++ b/agent_runtime/runners/issue_planner_runner.py
@@ -15,35 +15,56 @@ class IssuePlannerRunnerInput:
     split_reason: str
     work_item_path: str
     linked_prd: str | None = None
+    source_prd_path: str | None = None
+    missing_work_item_ids: tuple[str, ...] = ()
 
 
 def build_issue_planner_prompt(input_data: IssuePlannerRunnerInput) -> str:
     prompt = "Act only as the Issue Planner agent.\nWork from current `main`.\nRead:\n- AGENTS.md\n- prompts/agents/issue_planner_instruction.md\n"
-    if input_data.linked_prd:
+    if input_data.source_prd_path:
+        prompt += f"- {input_data.source_prd_path}\n"
+    elif input_data.linked_prd:
         prompt += f"- {input_data.linked_prd}\n"
+    prompt += f"- {input_data.work_item_path}\n\nContext:\n"
+    if input_data.source_prd_path and input_data.missing_work_item_ids:
+        missing_ids = ", ".join(input_data.missing_work_item_ids)
+        prompt += (
+            f"The linked implementation-ready PRD names follow-on work items that are not yet materialized in the live backlog.\n"
+            f"PRD: {input_data.source_prd_path}\n"
+            f"Missing work items: {missing_ids}\n"
+            f"Trigger: {input_data.split_reason}\n"
+            f"\n"
+            f"Your task:\n"
+            f"Materialize the missing follow-on work items for {input_data.source_prd_path} into bounded,\n"
+            f"sequenced backlog slices that can each be implemented in a single narrow PR. Do not redesign\n"
+            f"architecture. Do not change PRD semantics. If the PRD already names specific WI IDs, preserve them.\n"
+            f"Do not decompose {input_data.work_item_id} itself again unless the PRD text is insufficient.\n"
+            f"Name exact target files or package areas for each slice.\n"
+            f"\n"
+        )
+    else:
+        prompt += (
+            f"A PM assessment for {input_data.work_item_id} returned SPLIT_REQUIRED.\n"
+            f"Reason: {input_data.split_reason}\n"
+            f"\n"
+            f"Your task:\n"
+            f"Decompose {input_data.work_item_id} into bounded, sequenced work items that can each be\n"
+            f"implemented in a single narrow PR. Do not redesign architecture. Do not change PRD semantics.\n"
+            f"Keep each slice narrow and reviewable. Name exact target files or package areas for each slice.\n"
+            f"\n"
+        )
     prompt += (
-        f"- {input_data.work_item_path}\n"
-        f"\n"
-        f"Context:\n"
-        f"A PM assessment for {input_data.work_item_id} returned SPLIT_REQUIRED.\n"
-        f"Reason: {input_data.split_reason}\n"
-        f"\n"
-        f"Your task:\n"
-        f"Decompose {input_data.work_item_id} into bounded, sequenced work items that can each be\n"
-        f"implemented in a single narrow PR. Do not redesign architecture. Do not change PRD semantics.\n"
-        f"Keep each slice narrow and reviewable. Name exact target files or package areas for each slice.\n"
-        f"\n"
-        f"Return exactly:\n"
-        f"1. proposed new work item names and IDs\n"
-        f"2. purpose of each\n"
-        f"3. scope of each\n"
-        f"4. out of scope for each\n"
-        f"5. dependencies between the proposed slices\n"
-        f"6. exact target area for each\n"
-        f"7. acceptance criteria for each\n"
-        f"8. test intent for each\n"
-        f"9. why this decomposition unblocks the original work item\n"
-        f"10. any residual blocker that would need spec or human escalation\n"
+        "Return exactly:\n"
+        "1. proposed new work item names and IDs\n"
+        "2. purpose of each\n"
+        "3. scope of each\n"
+        "4. out of scope for each\n"
+        "5. dependencies between the proposed slices\n"
+        "6. exact target area for each\n"
+        "7. acceptance criteria for each\n"
+        "8. test intent for each\n"
+        "9. why this decomposition unblocks the original work item\n"
+        "10. any residual blocker that would need spec or human escalation\n"
     )
     return prompt
 

--- a/agent_runtime/runners/spec_runner.py
+++ b/agent_runtime/runners/spec_runner.py
@@ -21,9 +21,30 @@ class SpecRunnerInput:
     blocked_reason: str
     work_item_path: str
     linked_prd: str | None = None
+    bootstrap_capability: str | None = None
+    target_prd_id: str | None = None
+    registry_path: str | None = None
+    next_slice: str | None = None
 
 
 def build_spec_prompt(input_data: SpecRunnerInput) -> str:
+    if input_data.bootstrap_capability or input_data.target_prd_id:
+        prompt = (
+            "Act only as the spec-resolution agent.\n"
+            f"Bootstrap PRD/spec drafting for {input_data.bootstrap_capability or input_data.work_item_id}.\n"
+            f"Target PRD: {input_data.target_prd_id or 'unspecified'}\n"
+            f"Registry source: {input_data.registry_path or input_data.work_item_path}\n"
+        )
+        if input_data.linked_prd:
+            prompt += f"Current PRD: {input_data.linked_prd}\n"
+        prompt += f"Relevant artifact: {input_data.work_item_path}\nReason: {input_data.blocked_reason}\n"
+        if input_data.next_slice:
+            prompt += f"Requested next slice: {input_data.next_slice}\n"
+        prompt += (
+            "Draft or update the necessary PRD/spec so the contract gap is explicit and downstream PM/coding work can proceed.\nDo not write code.\n"
+        )
+        return prompt
+
     return (
         "Act only as the spec-resolution agent.\n"
         f"Resolve the blocker for {input_data.work_item_id}.\n"

--- a/agent_runtime/tests/test_issue_planner_runner.py
+++ b/agent_runtime/tests/test_issue_planner_runner.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 from agent_runtime.orchestrator.execution import build_runner_execution
 from agent_runtime.orchestrator.state import (
+    BacklogMaterializationSnapshot,
     NextActionType,
     RuntimeSnapshot,
     TransitionDecision,
@@ -79,6 +80,21 @@ def test_build_issue_planner_prompt_instructs_narrow_slices() -> None:
     )
     prompt = build_issue_planner_prompt(input_data)
     assert "narrow" in prompt.lower()
+
+
+def test_build_issue_planner_prompt_handles_backlog_materialization_context() -> None:
+    input_data = IssuePlannerRunnerInput(
+        work_item_id="WI-4.2.3-quant-walker-v2-implementation-prd",
+        split_reason="Implementation-ready PRD follow-on WIs are missing from the live backlog.",
+        work_item_path="work_items/done/WI-4.2.3-quant-walker-v2-implementation-prd.md",
+        linked_prd="`docs/prds/phase-2/PRD-4.2-quant-walker-v2.md` (primary deliverable).",
+        source_prd_path="docs/prds/phase-2/PRD-4.2-quant-walker-v2.md",
+        missing_work_item_ids=("WI-4.2.4", "WI-4.2.5", "WI-4.2.6", "WI-4.2.7"),
+    )
+    prompt = build_issue_planner_prompt(input_data)
+    assert "Materialize the missing follow-on work items" in prompt
+    assert "Do not decompose WI-4.2.3-quant-walker-v2-implementation-prd itself again" in prompt
+    assert "WI-4.2.4, WI-4.2.5, WI-4.2.6, WI-4.2.7" in prompt
 
 
 # ---------------------------------------------------------------------------
@@ -222,3 +238,75 @@ def test_run_issue_planner_decision_builds_issue_planner_execution() -> None:
         assert execution.work_item_id == "WI-1.1.4-risk-summary-core-service"
         assert "Issue Planner agent" in execution.prompt
         assert "PRD-1.1-v2" in execution.prompt
+
+
+def test_empty_ready_queue_with_backlog_materialization_routes_to_issue_planner() -> None:
+    with tempfile.TemporaryDirectory() as temp_dir:
+        work_item_path = Path(temp_dir) / "WI-4.2.3-quant-walker-v2-implementation-prd.md"
+        work_item_path.write_text(
+            "# WI-4.2.3\n\n## Linked PRD\n\n`docs/prds/phase-2/PRD-4.2-quant-walker-v2.md` (primary deliverable).\n",
+            encoding="utf-8",
+        )
+        snapshot = RuntimeSnapshot(
+            work_items=(
+                WorkItemSnapshot(
+                    id="WI-4.2.3-quant-walker-v2-implementation-prd",
+                    title="WI-4.2.3",
+                    path=work_item_path,
+                    stage=WorkItemStage.DONE,
+                    linked_prd="`docs/prds/phase-2/PRD-4.2-quant-walker-v2.md` (primary deliverable).",
+                ),
+            ),
+            backlog_materialization=(
+                BacklogMaterializationSnapshot(
+                    source_path="docs/prds/phase-2/PRD-4.2-quant-walker-v2.md",
+                    related_paths=("WI-4.2.4", "WI-4.2.5", "WI-4.2.6", "WI-4.2.7"),
+                    message="Implementation-ready PRD follow-on WIs are missing from the live backlog.",
+                ),
+            ),
+        )
+
+        decision = decide_next_action(snapshot)
+
+        assert decision.action is NextActionType.RUN_ISSUE_PLANNER
+        assert decision.work_item_id == "WI-4.2.3-quant-walker-v2-implementation-prd"
+        assert decision.metadata["backlog_source_prd"] == "docs/prds/phase-2/PRD-4.2-quant-walker-v2.md"
+        assert decision.metadata["missing_work_item_ids"] == "WI-4.2.4,WI-4.2.5,WI-4.2.6,WI-4.2.7"
+
+
+def test_backlog_materialization_decision_builds_issue_planner_execution() -> None:
+    with tempfile.TemporaryDirectory() as temp_dir:
+        work_item_path = Path(temp_dir) / "WI-4.2.3-quant-walker-v2-implementation-prd.md"
+        work_item_path.write_text(
+            "# WI-4.2.3\n\n## Linked PRD\n\n`docs/prds/phase-2/PRD-4.2-quant-walker-v2.md` (primary deliverable).\n",
+            encoding="utf-8",
+        )
+
+        snapshot = RuntimeSnapshot(
+            work_items=(
+                WorkItemSnapshot(
+                    id="WI-4.2.3-quant-walker-v2-implementation-prd",
+                    title="WI-4.2.3",
+                    path=work_item_path,
+                    stage=WorkItemStage.DONE,
+                    linked_prd="`docs/prds/phase-2/PRD-4.2-quant-walker-v2.md` (primary deliverable).",
+                ),
+            ),
+        )
+        decision = TransitionDecision(
+            action=NextActionType.RUN_ISSUE_PLANNER,
+            work_item_id="WI-4.2.3-quant-walker-v2-implementation-prd",
+            reason="Implementation-ready PRD follow-on WIs are missing from the live backlog.",
+            target_path=work_item_path,
+            metadata={
+                "backlog_source_prd": "docs/prds/phase-2/PRD-4.2-quant-walker-v2.md",
+                "missing_work_item_ids": "WI-4.2.4,WI-4.2.5,WI-4.2.6,WI-4.2.7",
+            },
+        )
+
+        execution = build_runner_execution(snapshot, decision)
+
+        assert execution is not None
+        assert execution.runner_name is RunnerName.ISSUE_PLANNER
+        assert "Materialize the missing follow-on work items" in execution.prompt
+        assert "WI-4.2.4, WI-4.2.5, WI-4.2.6, WI-4.2.7" in execution.prompt

--- a/agent_runtime/tests/test_spec_runner.py
+++ b/agent_runtime/tests/test_spec_runner.py
@@ -250,6 +250,53 @@ def test_load_prd_bootstrap_candidates_returns_actionable_now_candidate_only(tmp
     assert candidate.existing_prd_path == "docs/prds/phase-2/PRD-5.1-daily-risk-investigation-orchestrator-v1.md"
 
 
+def test_load_prd_bootstrap_candidates_handles_folded_scalars_and_stops_before_prd_lineage(tmp_path: Path) -> None:
+    registry_path = tmp_path / "docs" / "registry" / "current_state_registry.yaml"
+    registry_path.parent.mkdir(parents=True, exist_ok=True)
+    registry_path.write_text(
+        "\n".join(
+            [
+                "module_dashboards:",
+                "  - id: DASH-1",
+                "    capabilities:",
+                "      - component_ref: ORCH-DAILY-RISK-INVESTIGATION",
+                "        needs_new_prd_version: true",
+                "        missing_prds: []",
+                "        next_version_reason: >-",
+                "          PRD-5.1 intentionally excludes quant routing",
+                "          and richer orchestration behavior required for MVP.",
+                "        next_slice: >-",
+                "          Author PRD-5.1-v2 for multi-walker orchestration.",
+                "      - component_ref: WALKER-QUANT",
+                "        needs_new_prd_version: false",
+                "        missing_prds: []",
+                "        next_version_reason: >-",
+                "          PRD-4.2-v2 is merged; remaining gap is implementation.",
+                "        next_slice: Deliver WI-4.2.4-WI-4.2.7 per PRD-4.2-v2.",
+                "    prd_lineage:",
+                "      - capability: Risk Analytics",
+                "        active_prd: PRD-1.1-v2",
+                "        status: active",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    prd_path = tmp_path / "docs" / "prds" / "phase-2" / "PRD-5.1-daily-risk-investigation-orchestrator-v1.md"
+    prd_path.parent.mkdir(parents=True, exist_ok=True)
+    prd_path.write_text("# PRD-5.1\n\n- **PRD ID:** PRD-5.1\n", encoding="utf-8")
+
+    candidates = load_prd_bootstrap_candidates(tmp_path)
+
+    assert len(candidates) == 1
+    candidate = candidates[0]
+    assert candidate.capability_name == "ORCH-DAILY-RISK-INVESTIGATION"
+    assert candidate.target_prd_id == "PRD-5.1-v2"
+    assert candidate.existing_prd_path == "docs/prds/phase-2/PRD-5.1-daily-risk-investigation-orchestrator-v1.md"
+    assert candidate.next_version_reason == "PRD-5.1 intentionally excludes quant routing and richer orchestration behavior required for MVP."
+    assert candidate.next_slice == "Author PRD-5.1-v2 for multi-walker orchestration."
+
+
 # --- PM → Spec escalation transition tests ---
 
 

--- a/agent_runtime/tests/test_spec_runner.py
+++ b/agent_runtime/tests/test_spec_runner.py
@@ -9,15 +9,19 @@ import tempfile
 from unittest.mock import patch
 
 from agent_runtime.config.settings import get_settings
+from agent_runtime.orchestrator.execution import build_runner_execution
+from agent_runtime.orchestrator.prd_bootstrap import load_prd_bootstrap_candidates
 from agent_runtime.orchestrator.state import (
     NextActionType,
+    PrdBootstrapSnapshot,
     RuntimeSnapshot,
+    TransitionDecision,
     WorkItemSnapshot,
     WorkItemStage,
 )
 from agent_runtime.orchestrator.transitions import decide_all_actions, decide_next_action
 from agent_runtime.runners.contracts import RunnerDispatchStatus, RunnerExecution, RunnerName
-from agent_runtime.runners.spec_runner import dispatch_spec_execution
+from agent_runtime.runners.spec_runner import SpecRunnerInput, build_spec_prompt, dispatch_spec_execution
 from agent_runtime.storage.sqlite import WorkflowRunRecord
 
 
@@ -188,6 +192,64 @@ def test_dispatch_spec_execution_rejects_unknown_backend() -> None:
         assert raised, "Expected ValidationError for unknown BackendType"
 
 
+def test_build_spec_prompt_handles_prd_bootstrap_context() -> None:
+    prompt = build_spec_prompt(
+        SpecRunnerInput(
+            work_item_id="PRD-5.1-v2",
+            blocked_reason="Registry indicates a new orchestrator PRD is required.",
+            work_item_path="docs/prds/phase-2/PRD-5.1-daily-risk-investigation-orchestrator-v1.md",
+            linked_prd="docs/prds/phase-2/PRD-5.1-daily-risk-investigation-orchestrator-v1.md",
+            bootstrap_capability="ORCH-DAILY-RISK-INVESTIGATION",
+            target_prd_id="PRD-5.1-v2",
+            registry_path="docs/registry/current_state_registry.yaml",
+            next_slice="Author PRD-5.1-v2 for multi-walker orchestration.",
+        )
+    )
+
+    assert "Bootstrap PRD/spec drafting" in prompt
+    assert "Target PRD: PRD-5.1-v2" in prompt
+    assert "Current PRD: docs/prds/phase-2/PRD-5.1-daily-risk-investigation-orchestrator-v1.md" in prompt
+    assert "Requested next slice: Author PRD-5.1-v2 for multi-walker orchestration." in prompt
+
+
+def test_load_prd_bootstrap_candidates_returns_actionable_now_candidate_only(tmp_path: Path) -> None:
+    registry_path = tmp_path / "docs" / "registry" / "current_state_registry.yaml"
+    registry_path.parent.mkdir(parents=True, exist_ok=True)
+    registry_path.write_text(
+        "\n".join(
+            [
+                "module_dashboards:",
+                "  - id: DASH-1",
+                "    capabilities:",
+                "      - component_ref: ORCH-DAILY-RISK-INVESTIGATION",
+                "        needs_new_prd_version: true",
+                "        missing_prds: []",
+                "        next_version_reason: Current orchestrator is bounded by PRD-5.1.",
+                "        next_slice: Author PRD-5.1-v2 for multi-walker orchestration.",
+                "      - component_ref: WALKER-GOVERNANCE-REPORTING",
+                "        needs_new_prd_version: true",
+                "        missing_prds:",
+                "          - PRD-TBD-Governance-Reporting-Walker-v1",
+                "        next_version_reason: Post-MVP after other implementations land.",
+                "        next_slice: Post-MVP — author Governance / Reporting Walker v1 PRD after dependencies land.",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    prd_path = tmp_path / "docs" / "prds" / "phase-2" / "PRD-5.1-daily-risk-investigation-orchestrator-v1.md"
+    prd_path.parent.mkdir(parents=True, exist_ok=True)
+    prd_path.write_text("# PRD-5.1\n\n- **PRD ID:** PRD-5.1\n", encoding="utf-8")
+
+    candidates = load_prd_bootstrap_candidates(tmp_path)
+
+    assert len(candidates) == 1
+    candidate = candidates[0]
+    assert candidate.capability_name == "ORCH-DAILY-RISK-INVESTIGATION"
+    assert candidate.target_prd_id == "PRD-5.1-v2"
+    assert candidate.existing_prd_path == "docs/prds/phase-2/PRD-5.1-daily-risk-investigation-orchestrator-v1.md"
+
+
 # --- PM → Spec escalation transition tests ---
 
 
@@ -354,6 +416,54 @@ def test_decide_all_actions_includes_spec_escalation() -> None:
         actions_by_id = {d.work_item_id: d.action for d in decisions}
         assert actions_by_id["WI-A"] is NextActionType.RUN_SPEC
         assert actions_by_id["WI-B"] is NextActionType.RUN_PM
+
+
+def test_empty_ready_queue_with_prd_bootstrap_routes_to_spec() -> None:
+    snapshot = RuntimeSnapshot(
+        work_items=(),
+        prd_bootstrap=(
+            PrdBootstrapSnapshot(
+                capability_name="ORCH-DAILY-RISK-INVESTIGATION",
+                target_prd_id="PRD-5.1-v2",
+                existing_prd_path="docs/prds/phase-2/PRD-5.1-daily-risk-investigation-orchestrator-v1.md",
+                registry_path="docs/registry/current_state_registry.yaml",
+                next_slice="Author PRD-5.1-v2 for multi-walker orchestration.",
+                next_version_reason="PRD-5.1 intentionally excludes quant/time-series routing and richer orchestration behavior required for Module 1 MVP.",
+            ),
+        ),
+    )
+
+    decision = decide_next_action(snapshot)
+
+    assert decision.action is NextActionType.RUN_SPEC
+    assert decision.work_item_id == "PRD-5.1-v2"
+    assert decision.metadata["bootstrap_mode"] == "prd_gap"
+    assert decision.metadata["existing_prd_path"] == "docs/prds/phase-2/PRD-5.1-daily-risk-investigation-orchestrator-v1.md"
+
+
+def test_prd_bootstrap_decision_builds_spec_execution() -> None:
+    decision = TransitionDecision(
+        action=NextActionType.RUN_SPEC,
+        work_item_id="PRD-5.1-v2",
+        reason="Registry indicates ORCH-DAILY-RISK-INVESTIGATION needs PRD-5.1-v2.",
+        target_path=Path("docs/prds/phase-2/PRD-5.1-daily-risk-investigation-orchestrator-v1.md"),
+        metadata={
+            "bootstrap_mode": "prd_gap",
+            "capability_name": "ORCH-DAILY-RISK-INVESTIGATION",
+            "target_prd_id": "PRD-5.1-v2",
+            "existing_prd_path": "docs/prds/phase-2/PRD-5.1-daily-risk-investigation-orchestrator-v1.md",
+            "registry_path": "docs/registry/current_state_registry.yaml",
+            "next_slice": "Author PRD-5.1-v2 for multi-walker orchestration.",
+            "next_version_reason": "PRD-5.1 intentionally excludes quant/time-series routing and richer orchestration behavior required for Module 1 MVP.",
+        },
+    )
+
+    execution = build_runner_execution(RuntimeSnapshot(work_items=()), decision)
+
+    assert execution is not None
+    assert execution.runner_name is RunnerName.SPEC
+    assert "Bootstrap PRD/spec drafting for ORCH-DAILY-RISK-INVESTIGATION." in execution.prompt
+    assert "Target PRD: PRD-5.1-v2" in execution.prompt
 
 
 # --- Workflow run ordering tests ---

--- a/agent_runtime/tests/test_transitions.py
+++ b/agent_runtime/tests/test_transitions.py
@@ -7,6 +7,7 @@ import os
 from pathlib import Path
 import sqlite3
 import tempfile
+from types import SimpleNamespace
 from typing import Any
 from unittest.mock import patch
 
@@ -24,7 +25,7 @@ from agent_runtime.orchestrator.state import (
     WorkItemSnapshot,
     WorkItemStage,
 )
-from agent_runtime.orchestrator.graph import find_repo_root
+from agent_runtime.orchestrator.graph import build_runtime_snapshot, find_repo_root
 from agent_runtime.orchestrator.execution import build_runner_execution
 from agent_runtime.orchestrator.simulations import build_simulation_snapshot, simulation_names
 from agent_runtime.orchestrator.transitions import decide_next_action
@@ -61,6 +62,80 @@ def test_ready_item_without_pr_routes_to_pm() -> None:
     decision = decide_next_action(snapshot)
 
     assert decision.action is NextActionType.RUN_PM
+
+
+def test_build_runtime_snapshot_skips_bootstrap_scans_when_runnable_ready_item_exists(tmp_path: Path) -> None:
+    ready_item = WorkItemSnapshot(
+        id="WI-1.1.3-risk-summary-history-service",
+        title="WI-1.1.3",
+        path=tmp_path / "work_items" / "ready" / "WI-1.1.3-risk-summary-history-service.md",
+        stage=WorkItemStage.READY,
+        dependencies=(),
+    )
+
+    with (
+        patch("agent_runtime.orchestrator.graph.load_work_items", return_value=((ready_item,), ())),
+        patch("agent_runtime.orchestrator.graph.fetch_pull_requests", return_value=((), ())),
+        patch("agent_runtime.orchestrator.graph.load_workflow_runs", return_value=()),
+        patch("agent_runtime.orchestrator.graph.build_backlog_materialization_report") as backlog_mock,
+        patch("agent_runtime.orchestrator.graph.load_prd_bootstrap_candidates") as prd_mock,
+    ):
+        snapshot = build_runtime_snapshot(tmp_path, tmp_path / "state.db")
+
+    assert snapshot.backlog_materialization == ()
+    assert snapshot.prd_bootstrap == ()
+    backlog_mock.assert_not_called()
+    prd_mock.assert_not_called()
+
+
+def test_build_runtime_snapshot_runs_bootstrap_scans_when_ready_item_is_dependency_blocked(tmp_path: Path) -> None:
+    ready_item = WorkItemSnapshot(
+        id="WI-1.1.4-risk-summary-core-service",
+        title="WI-1.1.4",
+        path=tmp_path / "work_items" / "ready" / "WI-1.1.4-risk-summary-core-service.md",
+        stage=WorkItemStage.READY,
+        dependencies=("WI-1.1.3-risk-summary-history-service",),
+    )
+    backlog_report = SimpleNamespace(
+        findings=(
+            SimpleNamespace(
+                kind="missing_decomposed_work_items",
+                source_path="docs/prds/phase-2/PRD-4.2-quant-walker-v2.md",
+                related_paths=("WI-4.2.4",),
+                message="PRD follow-on work items are missing.",
+            ),
+        )
+    )
+    prd_candidate = SimpleNamespace(
+        capability_name="ORCH-DAILY-RISK-INVESTIGATION",
+        target_prd_id="PRD-5.1-v2",
+        existing_prd_path="docs/prds/phase-2/PRD-5.1-daily-risk-investigation-orchestrator-v1.md",
+        registry_path="docs/registry/current_state_registry.yaml",
+        next_slice="Author PRD-5.1-v2 for multi-walker orchestration.",
+        next_version_reason="PRD-5.1-v1 excludes orchestration needed for MVP.",
+    )
+
+    with (
+        patch("agent_runtime.orchestrator.graph.load_work_items", return_value=((ready_item,), ())),
+        patch("agent_runtime.orchestrator.graph.fetch_pull_requests", return_value=((), ())),
+        patch("agent_runtime.orchestrator.graph.load_workflow_runs", return_value=()),
+        patch(
+            "agent_runtime.orchestrator.graph.build_backlog_materialization_report",
+            return_value=backlog_report,
+        ) as backlog_mock,
+        patch(
+            "agent_runtime.orchestrator.graph.load_prd_bootstrap_candidates",
+            return_value=(prd_candidate,),
+        ) as prd_mock,
+    ):
+        snapshot = build_runtime_snapshot(tmp_path, tmp_path / "state.db")
+
+    assert len(snapshot.backlog_materialization) == 1
+    assert snapshot.backlog_materialization[0].source_path == "docs/prds/phase-2/PRD-4.2-quant-walker-v2.md"
+    assert len(snapshot.prd_bootstrap) == 1
+    assert snapshot.prd_bootstrap[0].target_prd_id == "PRD-5.1-v2"
+    backlog_mock.assert_called_once_with(tmp_path)
+    prd_mock.assert_called_once_with(tmp_path)
 
 
 def test_completed_pm_ready_outcome_routes_to_coding() -> None:


### PR DESCRIPTION
## Summary
- bootstrap `agent_runtime` into `run_issue_planner` when the live ready queue is empty but an implementation-ready PRD names missing follow-on WIs
- bootstrap `agent_runtime` into `run_spec` when the ready queue is empty, no backlog-materialization handoff exists, and the registry marks a non-post-MVP PRD gap as the next required slice
- tailor Issue Planner and PRD/spec prompts for these bootstrap cases and document the semi-automatic behavior

## Verification
- `PYTHONPATH=/Users/thomas/.codex/worktrees/ae1f/risk-manager pytest -q agent_runtime/tests/test_issue_planner_runner.py agent_runtime/tests/test_transitions.py`
- `PYTHONPATH=/Users/thomas/.codex/worktrees/ae1f/risk-manager pytest -q agent_runtime/tests/test_spec_runner.py agent_runtime/tests/test_transitions.py`
- `PYTHONPATH=/Users/thomas/.codex/worktrees/ae1f/risk-manager python3 -m agent_runtime --dispatch`
  - returned `run_issue_planner` for `WI-4.2.3-quant-walker-v2-implementation-prd`
  - targeted `docs/prds/phase-2/PRD-4.2-quant-walker-v2.md`
  - identified missing `WI-4.2.4, WI-4.2.5, WI-4.2.6, WI-4.2.7`
- `PYTHONPATH=/Users/thomas/.codex/worktrees/ae1f/risk-manager python3 - <<'PY' ... PY`
  - real registry exposes actionable PRD bootstrap candidate `PRD-5.1-v2`
  - synthetic empty-backlog snapshot resolves to `run_spec`
