### PR TITLE
Harden agent_runtime worktree handling

### DIFF
--- a/.claude/commands/deliver-wi.md
+++ b/.claude/commands/deliver-wi.md
@@ -47,7 +47,11 @@ Recommended model: Sonnet (or equivalent mid-tier)
 
 You are the PM / Coordination Agent for this repository.
 
-Work from current `main`.
+Work from the governed execution checkout for this task.
+
+Execution mode:
+- If this handoff is run through agent_runtime, the runtime-managed worktree and branch for this run are authoritative. Do not switch to main. Do not create another worktree. Do not create another branch.
+- If this handoff is run manually outside `agent_runtime`, use the refreshed control checkout on current `main`.
 
 Read in order:
 - AGENTS.md
@@ -167,9 +171,10 @@ Before the agent starts, refresh the control checkout:
   git fetch origin && git switch main && git pull --ff-only origin main
 If using agent_runtime:
   python -m agent_runtime --dispatch
-  Then use only the returned worktree path and branch for that run.
+  Then use only the returned worktree path and checkout context for that run.
 If running manually outside agent_runtime:
-  For coding: create a fresh branch from main.
+  For coding, PRD/spec authoring, or issue-planner edits: create a fresh branch from main.
+  For PM or drift-monitor analysis: use the refreshed control checkout on main.
   For review: inspect the PR head in an isolated checkout.
 ```
 

--- a/.claude/commands/new-prd.md
+++ b/.claude/commands/new-prd.md
@@ -108,7 +108,11 @@ The user opens a new chat, selects the recommended model, then pastes the whole 
 After the prompt block, always print:
 
 ```text
-Before the agent starts:
+Before the agent starts, refresh the control checkout:
   git fetch origin && git switch main && git pull --ff-only origin main
-For PRD authoring: work from a fresh branch created from main.
+If using agent_runtime:
+  python -m agent_runtime --dispatch
+  Then use only the returned worktree path and checkout context for that run.
+If running manually outside agent_runtime:
+  For PRD authoring: work from a fresh branch created from main.
 ```

--- a/.claude/commands/run-drift.md
+++ b/.claude/commands/run-drift.md
@@ -61,8 +61,13 @@ Recommended model: Sonnet (or equivalent mid-tier)
 After the prompt block, always print:
 
 ```text
-Before the agent starts:
+Before the agent starts, refresh the control checkout:
   git fetch origin && git switch main && git pull --ff-only origin main
+If using agent_runtime:
+  python -m agent_runtime --dispatch
+  Then use only the returned worktree path and checkout context for that run.
+If running manually outside agent_runtime:
+  Run the drift monitor from the refreshed control checkout on main.
 ```
 
 ## Hard stops

--- a/.cursor/rules/agent-relay.mdc
+++ b/.cursor/rules/agent-relay.mdc
@@ -15,12 +15,13 @@ This repository uses a governed multi-agent relay. You are the **operator**, not
 ## What you must do when the user asks to work on a work item
 
 1. Print `[deliver-wi] Skill active. Finding next work item and building agent prompt...` immediately.
-2. Run freshness gate first: `git fetch origin && git switch main && git pull --ff-only origin main`.
+2. Run the freshness gate first on the control checkout: `git fetch origin && git switch main && git pull --ff-only origin main`.
 3. Select work items from refreshed `main` state only (not stale feature branches).
-4. Read the WI file, linked PRD, `AGENTS.md`, and any ADRs listed in the WI dependencies.
-5. Fill the correct invocation template from `prompts/agents/invocation_templates/`.
-6. Output the filled prompt in a code block with the header: `Paste this into a FRESH [Role] agent session (new chat / new Codex session):`
-7. Stop. Do not implement anything.
+4. If the chosen handoff will run through `agent_runtime`, treat the returned worktree and checkout context as authoritative for that run. Never tell a runtime-managed session to switch back to `main`, allocate another worktree, or create another branch.
+5. Read the WI file, linked PRD, `AGENTS.md`, and any ADRs listed in the WI dependencies.
+6. Fill the correct invocation template from `prompts/agents/invocation_templates/`.
+7. Output the filled prompt in a code block with the header: `Paste this into a FRESH [Role] agent session (new chat / new Codex session):`
+8. Stop. Do not implement anything.
 
 ## What you must NEVER do
 

--- a/.cursor/skills/deliver-wi/SKILL.md
+++ b/.cursor/skills/deliver-wi/SKILL.md
@@ -47,7 +47,11 @@ Recommended model: Sonnet (or equivalent mid-tier)
 
 You are the PM / Coordination Agent for this repository.
 
-Work from current `main`.
+Work from the governed execution checkout for this task.
+
+Execution mode:
+- If this handoff is run through agent_runtime, the runtime-managed worktree and branch for this run are authoritative. Do not switch to main. Do not create another worktree. Do not create another branch.
+- If this handoff is run manually outside `agent_runtime`, use the refreshed control checkout on current `main`.
 
 Read in order:
 - AGENTS.md
@@ -167,9 +171,10 @@ Before the agent starts, refresh the control checkout:
   git fetch origin && git switch main && git pull --ff-only origin main
 If using agent_runtime:
   python -m agent_runtime --dispatch
-  Then use only the returned worktree path and branch for that run.
+  Then use only the returned worktree path and checkout context for that run.
 If running manually outside agent_runtime:
-  For coding: create a fresh branch from main.
+  For coding, PRD/spec authoring, or issue-planner edits: create a fresh branch from main.
+  For PM or drift-monitor analysis: use the refreshed control checkout on main.
   For review: inspect the PR head in an isolated checkout.
 ```
 

--- a/.cursor/skills/new-prd/SKILL.md
+++ b/.cursor/skills/new-prd/SKILL.md
@@ -108,7 +108,11 @@ The user opens a new chat, selects the recommended model, then pastes the whole 
 After the prompt block, always print:
 
 ```text
-Before the agent starts:
+Before the agent starts, refresh the control checkout:
   git fetch origin && git switch main && git pull --ff-only origin main
-For PRD authoring: work from a fresh branch created from main.
+If using agent_runtime:
+  python -m agent_runtime --dispatch
+  Then use only the returned worktree path and checkout context for that run.
+If running manually outside agent_runtime:
+  For PRD authoring: work from a fresh branch created from main.
 ```

--- a/.cursor/skills/run-drift/SKILL.md
+++ b/.cursor/skills/run-drift/SKILL.md
@@ -61,8 +61,13 @@ Recommended model: Sonnet (or equivalent mid-tier)
 After the prompt block, always print:
 
 ```text
-Before the agent starts:
+Before the agent starts, refresh the control checkout:
   git fetch origin && git switch main && git pull --ff-only origin main
+If using agent_runtime:
+  python -m agent_runtime --dispatch
+  Then use only the returned worktree path and checkout context for that run.
+If running manually outside agent_runtime:
+  Run the drift monitor from the refreshed control checkout on main.
 ```
 
 ## Hard stops

--- a/.github/agents/coding.agent.md
+++ b/.github/agents/coding.agent.md
@@ -18,10 +18,17 @@ The instruction file contains the full reading list for engineering docs, checkl
 
 Before starting implementation:
 
-1. `git fetch origin`
-2. `git switch main`
-3. `git pull --ff-only origin main`
-4. create a fresh branch from current `main` for this bounded slice
+1. If running manually outside `agent_runtime`:
+   - `git fetch origin`
+   - `git switch main`
+   - `git pull --ff-only origin main`
+   - create a fresh branch from current `main` for this bounded slice
+2. If dispatched by `agent_runtime`:
+   - use only the allocated worktree and injected checkout context for this run
+   - do not switch to `main`
+   - do not create another worktree
+   - do not create another branch
+   - if the checkout is detached at a PR head, push follow-up commits to the runtime-provided PR head target
 
 You must:
 

--- a/.github/agents/drift-monitor.agent.md
+++ b/.github/agents/drift-monitor.agent.md
@@ -16,9 +16,15 @@ The instruction file contains the full reading list, audit priorities, and opera
 
 Before starting analysis:
 
-1. `git fetch origin`
-2. `git switch main`
-3. `git pull --ff-only origin main`
+1. If running manually outside `agent_runtime`:
+   - `git fetch origin`
+   - `git switch main`
+   - `git pull --ff-only origin main`
+2. If dispatched by `agent_runtime`:
+   - use only the allocated worktree and injected checkout context for this run
+   - do not switch to `main`
+   - do not create another worktree
+   - do not create another branch
 
 Run deterministic scanners first when available:
 

--- a/.github/agents/issue-planner.agent.md
+++ b/.github/agents/issue-planner.agent.md
@@ -16,6 +16,19 @@ Read first:
 
 The instruction file contains the full reading list and decomposition rules.
 
+Before starting:
+
+1. If running manually outside `agent_runtime`:
+   - `git fetch origin`
+   - `git switch main`
+   - `git pull --ff-only origin main`
+   - create a fresh branch from current `main` for the decomposition change
+2. If dispatched by `agent_runtime`:
+   - use only the allocated worktree and injected checkout context for this run
+   - do not switch to `main`
+   - do not create another worktree
+   - do not create another branch
+
 You must:
 
 - keep slices narrow and reviewable

--- a/.github/agents/pm.agent.md
+++ b/.github/agents/pm.agent.md
@@ -18,9 +18,15 @@ The instruction file contains the full reading list for delivery docs, checklist
 
 Before starting analysis:
 
-1. `git fetch origin`
-2. `git switch main`
-3. `git pull --ff-only origin main`
+1. If running manually outside `agent_runtime`:
+   - `git fetch origin`
+   - `git switch main`
+   - `git pull --ff-only origin main`
+2. If dispatched by `agent_runtime`:
+   - use only the allocated worktree and injected checkout context for this run
+   - do not switch to `main`
+   - do not create another worktree
+   - do not create another branch
 
 You must:
 

--- a/.github/agents/prd-spec.agent.md
+++ b/.github/agents/prd-spec.agent.md
@@ -15,6 +15,19 @@ Read first:
 
 The instruction file contains the full reading list for methodology docs, engineering docs, and operating rules.
 
+Before starting:
+
+1. If running manually outside `agent_runtime`:
+   - `git fetch origin`
+   - `git switch main`
+   - `git pull --ff-only origin main`
+   - create a fresh branch from current `main` for this PRD or specification update
+2. If dispatched by `agent_runtime`:
+   - use only the allocated worktree and injected checkout context for this run
+   - do not switch to `main`
+   - do not create another worktree
+   - do not create another branch
+
 Your job is to produce bounded, implementation-ready PRDs and specifications.
 
 You must:

--- a/.github/agents/review.agent.md
+++ b/.github/agents/review.agent.md
@@ -20,10 +20,17 @@ The instruction file contains the full review priorities and operating rules.
 
 Before reviewing:
 
-1. `git fetch origin`
-2. `git switch main`
-3. `git pull --ff-only origin main`
-4. inspect the latest PR head and latest review comments
+1. If running manually outside `agent_runtime`:
+   - `git fetch origin`
+   - `git switch main`
+   - `git pull --ff-only origin main`
+   - inspect the latest PR head and latest review comments from an isolated review checkout
+2. If dispatched by `agent_runtime`:
+   - use only the allocated review worktree and injected checkout context for this run
+   - do not switch to `main`
+   - do not create another worktree
+   - do not create another branch
+   - if the checkout is detached at a PR head, push lifecycle or merge-readiness follow-up commits to the runtime-provided PR head target
 
 You must:
 

--- a/.github/skills/deliver-wi/SKILL.md
+++ b/.github/skills/deliver-wi/SKILL.md
@@ -47,7 +47,11 @@ Recommended model: Sonnet (or equivalent mid-tier)
 
 You are the PM / Coordination Agent for this repository.
 
-Work from current `main`.
+Work from the governed execution checkout for this task.
+
+Execution mode:
+- If this handoff is run through agent_runtime, the runtime-managed worktree and branch for this run are authoritative. Do not switch to main. Do not create another worktree. Do not create another branch.
+- If this handoff is run manually outside `agent_runtime`, use the refreshed control checkout on current `main`.
 
 Read in order:
 - AGENTS.md
@@ -167,9 +171,10 @@ Before the agent starts, refresh the control checkout:
   git fetch origin && git switch main && git pull --ff-only origin main
 If using agent_runtime:
   python -m agent_runtime --dispatch
-  Then use only the returned worktree path and branch for that run.
+  Then use only the returned worktree path and checkout context for that run.
 If running manually outside agent_runtime:
-  For coding: create a fresh branch from main.
+  For coding, PRD/spec authoring, or issue-planner edits: create a fresh branch from main.
+  For PM or drift-monitor analysis: use the refreshed control checkout on main.
   For review: inspect the PR head in an isolated checkout.
 ```
 

--- a/.github/skills/new-prd/SKILL.md
+++ b/.github/skills/new-prd/SKILL.md
@@ -108,7 +108,11 @@ The user opens a new chat, selects the recommended model, then pastes the whole 
 After the prompt block, always print:
 
 ```text
-Before the agent starts:
+Before the agent starts, refresh the control checkout:
   git fetch origin && git switch main && git pull --ff-only origin main
-For PRD authoring: work from a fresh branch created from main.
+If using agent_runtime:
+  python -m agent_runtime --dispatch
+  Then use only the returned worktree path and checkout context for that run.
+If running manually outside agent_runtime:
+  For PRD authoring: work from a fresh branch created from main.
 ```

--- a/.github/skills/run-drift/SKILL.md
+++ b/.github/skills/run-drift/SKILL.md
@@ -61,8 +61,13 @@ Recommended model: Sonnet (or equivalent mid-tier)
 After the prompt block, always print:
 
 ```text
-Before the agent starts:
+Before the agent starts, refresh the control checkout:
   git fetch origin && git switch main && git pull --ff-only origin main
+If using agent_runtime:
+  python -m agent_runtime --dispatch
+  Then use only the returned worktree path and checkout context for that run.
+If running manually outside agent_runtime:
+  Run the drift monitor from the refreshed control checkout on main.
 ```
 
 ## Hard stops

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,10 +131,11 @@ Then follow one of these two modes only:
 
 - `agent_runtime` is the authority for execution checkout state
 - the control checkout stays on refreshed `main` and is used only for dispatch, inspection, and human repo maintenance
-- the real PM, spec, issue-planner, coding, and review work happens only in the runtime-allocated worktree for that run
+- the real PM, spec, issue-planner, coding, review, and drift-monitor work happens only in the runtime-allocated worktree for that run
 - agents must not run `git switch main`, `git worktree add`, or create a second feature branch inside a runtime-managed session
 - new coding work without an existing PR starts from a runtime-created worktree based on current `origin/main`
-- review and PR-follow-up coding work use the runtime-managed worktree for the PR head branch, not a second checkout from local `main`
+- review and PR-follow-up coding work use the runtime-managed checkout for the PR head lineage, not a second branch from local `main`
+- when the runtime provides a detached PR-head checkout, agents must keep working in that checkout and use the provided PR head push target rather than creating a local branch
 
 Agents must not continue from stale local state when canon, PR state, or linked contracts may have changed.
 

--- a/agent_runtime/README.md
+++ b/agent_runtime/README.md
@@ -140,6 +140,11 @@ In runtime-managed mode, the allocated worktree and branch are authoritative for
 that run. The human control checkout remains on refreshed `main` and should not
 be used for the real PM/spec/coding/review work.
 
+For PR-linked coding and review runs, the runtime may allocate a detached
+checkout at the PR head instead of creating a second local branch. When that
+happens, the injected checkout context is authoritative, including the PR-head
+push target.
+
 By default the PM runner remains in manual `prepared` mode. You can opt in to
 the first real backend by setting:
 
@@ -263,6 +268,9 @@ runtime cycle to move straight into PR-aware routing.
 Use this when a runner has finished and its isolated worktree is no longer
 needed.
 
+Release deletes only runtime-owned local branches. PR-linked detached checkouts
+do not delete the PR head branch from the control checkout.
+
 ## Semi-Automatic Supervised Workflow
 
 The current runtime is designed for a semi-automatic loop:
@@ -275,8 +283,10 @@ The current runtime is designed for a semi-automatic loop:
 
 1. Open the returned `worktree.path` and run the real PM/spec/coding/review
 agent manually in that isolated checkout using the returned `runner.prompt`.
-The runtime-managed worktree and branch are the only checkout state the agent
-should use for that run.
+The runtime-managed worktree and checkout context are the only checkout state
+the agent should use for that run. If the prompt says the checkout is detached
+at a PR head, keep working there and use the provided push target instead of
+creating another branch.
 
 1. When that manual agent session finishes, record the reviewed outcome back into
 the runtime:

--- a/agent_runtime/drift/instruction_surfaces.py
+++ b/agent_runtime/drift/instruction_surfaces.py
@@ -81,6 +81,24 @@ RUNTIME_MANAGED_INVOCATION_EXPECTATIONS: tuple[tuple[Path, tuple[str, ...]], ...
         ),
     ),
     (
+        INVOCATION_TEMPLATES_DIR / "prd_spec_invocation.md",
+        (
+            "agent_runtime",
+            "switch to `main`",
+            "create another worktree",
+            "create another branch",
+        ),
+    ),
+    (
+        INVOCATION_TEMPLATES_DIR / "issue_planner_invocation.md",
+        (
+            "agent_runtime",
+            "switch to `main`",
+            "create another worktree",
+            "create another branch",
+        ),
+    ),
+    (
         INVOCATION_TEMPLATES_DIR / "coding_invocation.md",
         (
             "agent_runtime",
@@ -94,6 +112,15 @@ RUNTIME_MANAGED_INVOCATION_EXPECTATIONS: tuple[tuple[Path, tuple[str, ...]], ...
         (
             "agent_runtime",
             "switch to main",
+            "create another worktree",
+            "create another branch",
+        ),
+    ),
+    (
+        INVOCATION_TEMPLATES_DIR / "drift_monitor_invocation.md",
+        (
+            "agent_runtime",
+            "switch to `main`",
             "create another worktree",
             "create another branch",
         ),

--- a/agent_runtime/manual_supervisor_workflow.md
+++ b/agent_runtime/manual_supervisor_workflow.md
@@ -83,6 +83,10 @@ cd /absolute/path/from/worktree.path
 
 Do the real PM/spec/coding/review work only inside that worktree.
 
+If the runtime checkout context says the run is attached to a PR head in a
+detached checkout, keep working in that detached checkout and use the provided
+PR head push target instead of creating a local branch.
+
 ### 3. Launch the matching agent manually
 
 Use the returned `runner.name` to decide which agent to run:
@@ -216,6 +220,7 @@ sqlite3 .agent_runtime/state.db 'select run_id, work_item_id, runner_name, branc
 - do not reuse a worktree for a different work item
 - do not switch a runtime-managed session back to `main`
 - do not allocate another worktree or create another feature branch inside a runtime-managed session
+- when the runtime provides a detached PR-head checkout, push follow-up commits to the provided PR head target instead of creating a local branch
 - record the real outcome before releasing the run whenever possible
 - release finished worktrees promptly so lease state stays trustworthy
 

--- a/agent_runtime/orchestrator/execution.py
+++ b/agent_runtime/orchestrator/execution.py
@@ -65,11 +65,14 @@ def build_runner_execution(snapshot: RuntimeSnapshot, decision: TransitionDecisi
 
     work_item = _find_work_item(snapshot, decision.work_item_id)
     pull_request = _find_pull_request(snapshot, decision.work_item_id)
-    default_base_ref = f"origin/{pull_request.head_ref_name}" if pull_request is not None and pull_request.head_ref_name else "origin/main"
+    default_base_ref = f"origin/{pull_request.base_ref_name}" if pull_request is not None and pull_request.base_ref_name else "origin/main"
     base_metadata = {
         **dict(decision.metadata),
         "base_ref": default_base_ref,
     }
+    if pull_request is not None and pull_request.head_ref_name:
+        base_metadata["pr_head_branch"] = pull_request.head_ref_name
+        base_metadata["checkout_ref"] = f"origin/{pull_request.head_ref_name}"
 
     if decision.action is NextActionType.RUN_PM:
         pm_input = PMRunnerInput(
@@ -122,11 +125,14 @@ def build_runner_execution(snapshot: RuntimeSnapshot, decision: TransitionDecisi
             pr_number=pull_request.number if pull_request is not None else None,
             pr_url=pull_request.url if pull_request is not None else None,
             base_ref=base_metadata["base_ref"],
+            pr_head_branch=pull_request.head_ref_name if pull_request is not None else None,
             drift_summary=snapshot.drift_summary_md,
         )
         metadata = {**base_metadata, "target_path": str(work_item.path)}
         if pull_request is not None:
             metadata["pr_number"] = str(pull_request.number)
+            metadata["checkout_detached"] = "true"
+            metadata["branch_owned_by_runtime"] = "false"
             if pull_request.url is not None:
                 metadata["pr_url"] = pull_request.url
         return RunnerExecution(
@@ -144,11 +150,14 @@ def build_runner_execution(snapshot: RuntimeSnapshot, decision: TransitionDecisi
             pr_number=pull_request.number,
             pr_url=pull_request.url,
             base_ref=base_metadata["base_ref"],
+            pr_head_branch=pull_request.head_ref_name,
         )
         metadata = {
             **base_metadata,
             "target_path": str(work_item.path),
             "pr_number": str(pull_request.number),
+            "checkout_detached": "true",
+            "branch_owned_by_runtime": "false",
         }
         if pull_request.url is not None:
             metadata["pr_url"] = pull_request.url

--- a/agent_runtime/orchestrator/execution.py
+++ b/agent_runtime/orchestrator/execution.py
@@ -70,9 +70,6 @@ def build_runner_execution(snapshot: RuntimeSnapshot, decision: TransitionDecisi
         **dict(decision.metadata),
         "base_ref": default_base_ref,
     }
-    if pull_request is not None and pull_request.head_ref_name:
-        base_metadata["pr_head_branch"] = pull_request.head_ref_name
-        base_metadata["checkout_ref"] = f"origin/{pull_request.head_ref_name}"
 
     if decision.action is NextActionType.RUN_PM:
         pm_input = PMRunnerInput(
@@ -129,8 +126,10 @@ def build_runner_execution(snapshot: RuntimeSnapshot, decision: TransitionDecisi
             drift_summary=snapshot.drift_summary_md,
         )
         metadata = {**base_metadata, "target_path": str(work_item.path)}
-        if pull_request is not None:
+        if pull_request is not None and pull_request.head_ref_name:
             metadata["pr_number"] = str(pull_request.number)
+            metadata["pr_head_branch"] = pull_request.head_ref_name
+            metadata["checkout_ref"] = f"origin/{pull_request.head_ref_name}"
             metadata["checkout_detached"] = "true"
             metadata["branch_owned_by_runtime"] = "false"
             if pull_request.url is not None:
@@ -145,6 +144,8 @@ def build_runner_execution(snapshot: RuntimeSnapshot, decision: TransitionDecisi
     if decision.action is NextActionType.RUN_REVIEW:
         if pull_request is None:
             raise RuntimeError("review execution requires an attached pull request")
+        if not pull_request.head_ref_name:
+            raise RuntimeError("review execution requires a PR head branch name")
         review_input = ReviewRunnerInput(
             work_item_id=work_item.id,
             pr_number=pull_request.number,
@@ -156,6 +157,8 @@ def build_runner_execution(snapshot: RuntimeSnapshot, decision: TransitionDecisi
             **base_metadata,
             "target_path": str(work_item.path),
             "pr_number": str(pull_request.number),
+            "pr_head_branch": pull_request.head_ref_name,
+            "checkout_ref": f"origin/{pull_request.head_ref_name}",
             "checkout_detached": "true",
             "branch_owned_by_runtime": "false",
         }

--- a/agent_runtime/orchestrator/github_sync.py
+++ b/agent_runtime/orchestrator/github_sync.py
@@ -30,6 +30,7 @@ query($owner: String!, $name: String!, $cursor: String) {
         url
         isDraft
         headRefName
+        baseRefName
         updatedAt
         title
         body
@@ -234,6 +235,7 @@ def build_pull_request_snapshots(
             is_draft=bool(raw_node.get("isDraft")),
             url=str(raw_node.get("url")) if raw_node.get("url") else None,
             head_ref_name=str(raw_node.get("headRefName")) if raw_node.get("headRefName") else None,
+            base_ref_name=str(raw_node.get("baseRefName")) if raw_node.get("baseRefName") else None,
             updated_at=str(raw_node.get("updatedAt")) if raw_node.get("updatedAt") else None,
             unresolved_review_threads=unresolved_review_threads,
             has_new_review_comments=False,

--- a/agent_runtime/orchestrator/parallel_dispatch.py
+++ b/agent_runtime/orchestrator/parallel_dispatch.py
@@ -26,11 +26,11 @@ from agent_runtime.orchestrator.pr_publication import maybe_publish_completed_co
 from agent_runtime.orchestrator.worktree_manager import (
     allocate_worktree,
     bind_worktree_to_execution,
+    has_reusable_active_worktree_lease,
 )
 from agent_runtime.runners.contracts import RunnerDispatchStatus, RunnerResult
 from agent_runtime.storage.sqlite import (
     WorkflowRunRecord,
-    load_active_worktree_lease,
     load_workflow_run,
     mark_workflow_run_running,
     record_workflow_outcome,
@@ -172,13 +172,17 @@ def _dispatch_one(
     }
 
 
-def _has_active_lease(defaults: RuntimeDefaults, decision: TransitionDecision) -> bool:
-    """Return True if the work item already has an active worktree lease."""
+def _has_active_lease(defaults: RuntimeDefaults, snapshot: RuntimeSnapshot, decision: TransitionDecision) -> bool:
+    """Return True if the work item already has a reusable active worktree lease."""
     if decision.work_item_id is None:
         return False
-    runner_name = decision.action.value.replace("run_", "")
-    lease = load_active_worktree_lease(defaults.state_db_path, decision.work_item_id, runner_name)
-    return lease is not None
+    try:
+        execution = build_runner_execution(snapshot, decision)
+    except RuntimeError:
+        return False
+    if execution is None:
+        return False
+    return has_reusable_active_worktree_lease(defaults, defaults.state_db_path, execution)
 
 
 def run_parallel_step(
@@ -193,7 +197,7 @@ def run_parallel_step(
     """
     all_decisions = decide_all_actions(snapshot)
 
-    dispatchable = [d for d in all_decisions if d.action in _DISPATCHABLE_ACTIONS and not _has_active_lease(defaults, d)][
+    dispatchable = [d for d in all_decisions if d.action in _DISPATCHABLE_ACTIONS and not _has_active_lease(defaults, snapshot, d)][
         : defaults.max_concurrent_runs
     ]
 

--- a/agent_runtime/orchestrator/state.py
+++ b/agent_runtime/orchestrator/state.py
@@ -49,6 +49,7 @@ class PullRequestSnapshot:
     is_draft: bool
     url: str | None = None
     head_ref_name: str | None = None
+    base_ref_name: str | None = None
     updated_at: str | None = None
     unresolved_review_threads: int = 0
     has_new_review_comments: bool = False

--- a/agent_runtime/orchestrator/worktree_manager.py
+++ b/agent_runtime/orchestrator/worktree_manager.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import replace
+from dataclasses import dataclass, replace
 from datetime import UTC, datetime
 from pathlib import Path
 import re
@@ -19,6 +19,15 @@ from agent_runtime.storage.sqlite import (
     load_worktree_lease,
     mark_worktree_lease_released,
 )
+
+
+@dataclass(frozen=True)
+class CheckoutRequest:
+    base_ref: str
+    checkout_ref: str
+    checkout_detached: bool
+    branch_owned_by_runtime: bool
+    pr_head_branch: str | None = None
 
 
 def _slugify(value: str) -> str:
@@ -101,20 +110,123 @@ def _is_valid_worktree(path: Path) -> bool:
     return result.returncode == 0 and result.stdout.strip() == "true"
 
 
+def _build_checkout_request(execution: RunnerExecution) -> CheckoutRequest:
+    base_ref = execution.metadata.get("base_ref", "origin/main")
+    checkout_ref = execution.metadata.get("checkout_ref", base_ref)
+    return CheckoutRequest(
+        base_ref=base_ref,
+        checkout_ref=checkout_ref,
+        checkout_detached=execution.metadata.get("checkout_detached") == "true",
+        branch_owned_by_runtime=execution.metadata.get("branch_owned_by_runtime", "true") != "false",
+        pr_head_branch=execution.metadata.get("pr_head_branch"),
+    )
+
+
+def _should_fetch_origin(request: CheckoutRequest) -> bool:
+    return request.base_ref.startswith("origin/") or request.checkout_ref.startswith("origin/")
+
+
+def _git_stdout(repo_root: Path, *args: str) -> str:
+    try:
+        result = subprocess.run(
+            ["git", *args],
+            cwd=repo_root,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except subprocess.CalledProcessError as error:
+        stderr = error.stderr.strip()
+        detail = f"\n{stderr}" if stderr else ""
+        raise RuntimeError(f"git command failed: {' '.join(error.cmd)}{detail}") from error
+    return result.stdout.strip()
+
+
+def _current_branch_name(path: Path) -> str | None:
+    result = subprocess.run(
+        ["git", "symbolic-ref", "--quiet", "--short", "HEAD"],
+        cwd=path,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        return None
+    branch_name = result.stdout.strip()
+    return branch_name or None
+
+
+def _resolve_commit(repo_root: Path, ref: str) -> str:
+    return _git_stdout(repo_root, "rev-parse", f"{ref}^{{commit}}")
+
+
+def _lease_matches_checkout_request(
+    repo_root: Path,
+    lease: WorktreeLeaseRecord,
+    request: CheckoutRequest,
+) -> bool:
+    worktree_path = Path(lease.worktree_path)
+    if not _is_valid_worktree(worktree_path):
+        return False
+    if lease.base_ref != request.base_ref:
+        return False
+    if lease.branch_owned_by_runtime != request.branch_owned_by_runtime:
+        return False
+    if request.pr_head_branch is not None and lease.branch_name != request.pr_head_branch:
+        return False
+
+    current_branch_name = _current_branch_name(worktree_path)
+    current_detached = current_branch_name is None
+    if current_detached != request.checkout_detached:
+        return False
+
+    if request.checkout_detached:
+        return _resolve_commit(worktree_path, "HEAD") == _resolve_commit(repo_root, request.checkout_ref)
+    return current_branch_name == lease.branch_name
+
+
+def has_reusable_active_worktree_lease(
+    defaults: RuntimeDefaults,
+    db_path: Path,
+    execution: RunnerExecution,
+) -> bool:
+    request = _build_checkout_request(execution)
+    if _should_fetch_origin(request):
+        _git(defaults.repo_root, "fetch", "origin")
+
+    existing = load_active_worktree_lease(db_path, execution.work_item_id, execution.runner_name.value)
+    if existing is None:
+        return False
+    return _lease_matches_checkout_request(defaults.repo_root, existing, request)
+
+
 def _cleanup_stale_lease(defaults: RuntimeDefaults, db_path: Path, lease: WorktreeLeaseRecord) -> None:
+    _best_effort_git(defaults.repo_root, "worktree", "remove", "--force", lease.worktree_path)
     _best_effort_git(defaults.repo_root, "worktree", "prune")
     if lease.branch_owned_by_runtime:
         _best_effort_git(defaults.repo_root, "branch", "-D", lease.branch_name)
     mark_worktree_lease_released(db_path, lease.run_id)
 
 
-def _checkout_plan(execution: RunnerExecution, run_id: str) -> tuple[str, str, bool, bool]:
-    base_ref = execution.metadata.get("base_ref", "origin/main")
-    checkout_ref = execution.metadata.get("checkout_ref", base_ref)
-    checkout_detached = execution.metadata.get("checkout_detached") == "true"
-    branch_owned_by_runtime = execution.metadata.get("branch_owned_by_runtime", "true") != "false"
-    branch_name = execution.metadata.get("pr_head_branch") or _build_branch_name(execution, run_id)
-    return branch_name, checkout_ref, checkout_detached, branch_owned_by_runtime
+def _checkout_plan(execution: RunnerExecution, run_id: str) -> tuple[CheckoutRequest, str]:
+    request = _build_checkout_request(execution)
+    branch_name = request.pr_head_branch or _build_branch_name(execution, run_id)
+    return request, branch_name
+
+
+def _cleanup_unclaimed_worktree(
+    defaults: RuntimeDefaults,
+    worktree_path: Path,
+    branch_name: str,
+    branch_owned_by_runtime: bool,
+) -> None:
+    cleanup_error = _best_effort_git(defaults.repo_root, "worktree", "remove", "--force", str(worktree_path))
+    if branch_owned_by_runtime:
+        error = _best_effort_git(defaults.repo_root, "branch", "-D", branch_name)
+        if cleanup_error is None and error is not None:
+            cleanup_error = error
+    if cleanup_error is not None:
+        raise cleanup_error
 
 
 def allocate_worktree(
@@ -122,41 +234,48 @@ def allocate_worktree(
     db_path: Path,
     execution: RunnerExecution,
 ) -> WorktreeLeaseRecord:
+    request = _build_checkout_request(execution)
+    if _should_fetch_origin(request):
+        _git(defaults.repo_root, "fetch", "origin")
+
     existing = load_active_worktree_lease(db_path, execution.work_item_id, execution.runner_name.value)
     if existing is not None:
-        worktree_path = Path(existing.worktree_path)
-        if _is_valid_worktree(worktree_path):
+        if _lease_matches_checkout_request(defaults.repo_root, existing, request):
             return existing
         _cleanup_stale_lease(defaults, db_path, existing)
 
     run_id = _build_run_id(execution)
-    base_ref = execution.metadata.get("base_ref", "origin/main")
-    branch_name, checkout_ref, checkout_detached, branch_owned_by_runtime = _checkout_plan(execution, run_id)
+    request, branch_name = _checkout_plan(execution, run_id)
     worktree_dirname = _slugify(f"{execution.runner_name.value}-{execution.work_item_id}-{run_id.split('-')[-1]}")
     worktree_path = defaults.worktree_root_path / worktree_dirname
 
     defaults.worktree_root_path.mkdir(parents=True, exist_ok=True)
-    if checkout_ref.startswith("origin/") or base_ref.startswith("origin/"):
-        _git(defaults.repo_root, "fetch", "origin")
-    if checkout_detached:
-        _git(defaults.repo_root, "worktree", "add", "--detach", str(worktree_path), checkout_ref)
+    if request.checkout_detached:
+        _git(defaults.repo_root, "worktree", "add", "--detach", str(worktree_path), request.checkout_ref)
     else:
-        _git(defaults.repo_root, "worktree", "add", "-b", branch_name, str(worktree_path), checkout_ref)
+        _git(defaults.repo_root, "worktree", "add", "-b", branch_name, str(worktree_path), request.checkout_ref)
 
     lease = WorktreeLeaseRecord(
         run_id=run_id,
         work_item_id=execution.work_item_id,
         runner_name=execution.runner_name.value,
         branch_name=branch_name,
-        base_ref=base_ref,
+        base_ref=request.base_ref,
         worktree_path=str(worktree_path),
         status="active",
-        branch_owned_by_runtime=branch_owned_by_runtime,
+        branch_owned_by_runtime=request.branch_owned_by_runtime,
     )
     try:
         insert_worktree_lease(db_path, lease)
     except sqlite3.IntegrityError:
+        cleanup_error: RuntimeError | None = None
+        try:
+            _cleanup_unclaimed_worktree(defaults, worktree_path, branch_name, request.branch_owned_by_runtime)
+        except RuntimeError as error:
+            cleanup_error = error
         concurrent_lease = load_active_worktree_lease(db_path, execution.work_item_id, execution.runner_name.value)
+        if cleanup_error is not None:
+            raise cleanup_error
         if concurrent_lease is None:
             raise
         return concurrent_lease

--- a/agent_runtime/orchestrator/worktree_manager.py
+++ b/agent_runtime/orchestrator/worktree_manager.py
@@ -52,13 +52,19 @@ def _build_branch_name(execution: RunnerExecution, run_id: str) -> str:
     return f"codex/{branch_slug}-{run_id.split('-')[-1]}"
 
 
-def _inject_runtime_checkout_context(prompt: str, lease: WorktreeLeaseRecord) -> str:
+def _inject_runtime_checkout_context(prompt: str, lease: WorktreeLeaseRecord, metadata: dict[str, str]) -> str:
     context_block = (
         "Execution checkout (agent_runtime authoritative):\n"
         f"- run_id: {lease.run_id}\n"
         f"- worktree_path: {lease.worktree_path}\n"
         f"- branch_name: {lease.branch_name}\n"
         f"- base_ref: {lease.base_ref}\n"
+    )
+    if metadata.get("checkout_detached") == "true" and metadata.get("checkout_ref"):
+        context_block += f"- checkout_ref: {metadata['checkout_ref']}\n"
+    if metadata.get("pr_head_branch"):
+        context_block += f"- pr_head_branch: {metadata['pr_head_branch']}\n"
+    context_block += (
         "\n"
         "Checkout rule:\n"
         "- do all work only in this worktree\n"
@@ -66,6 +72,8 @@ def _inject_runtime_checkout_context(prompt: str, lease: WorktreeLeaseRecord) ->
         "- do not create another worktree\n"
         "- do not create another branch\n"
     )
+    if metadata.get("checkout_detached") == "true" and metadata.get("pr_head_branch"):
+        context_block += f"- when pushing follow-up commits, use `git push origin HEAD:{metadata['pr_head_branch']}`\n"
     if context_block in prompt:
         return prompt
     return f"{context_block}\n{prompt}"
@@ -79,10 +87,34 @@ def _best_effort_git(repo_root: Path, *args: str) -> RuntimeError | None:
     return None
 
 
+def _is_valid_worktree(path: Path) -> bool:
+    if not path.exists() or not (path / ".git").exists():
+        return False
+
+    result = subprocess.run(
+        ["git", "rev-parse", "--is-inside-work-tree"],
+        cwd=path,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    return result.returncode == 0 and result.stdout.strip() == "true"
+
+
 def _cleanup_stale_lease(defaults: RuntimeDefaults, db_path: Path, lease: WorktreeLeaseRecord) -> None:
     _best_effort_git(defaults.repo_root, "worktree", "prune")
-    _best_effort_git(defaults.repo_root, "branch", "-D", lease.branch_name)
+    if lease.branch_owned_by_runtime:
+        _best_effort_git(defaults.repo_root, "branch", "-D", lease.branch_name)
     mark_worktree_lease_released(db_path, lease.run_id)
+
+
+def _checkout_plan(execution: RunnerExecution, run_id: str) -> tuple[str, str, bool, bool]:
+    base_ref = execution.metadata.get("base_ref", "origin/main")
+    checkout_ref = execution.metadata.get("checkout_ref", base_ref)
+    checkout_detached = execution.metadata.get("checkout_detached") == "true"
+    branch_owned_by_runtime = execution.metadata.get("branch_owned_by_runtime", "true") != "false"
+    branch_name = execution.metadata.get("pr_head_branch") or _build_branch_name(execution, run_id)
+    return branch_name, checkout_ref, checkout_detached, branch_owned_by_runtime
 
 
 def allocate_worktree(
@@ -93,20 +125,23 @@ def allocate_worktree(
     existing = load_active_worktree_lease(db_path, execution.work_item_id, execution.runner_name.value)
     if existing is not None:
         worktree_path = Path(existing.worktree_path)
-        if worktree_path.exists() and (worktree_path / ".git").exists():
+        if _is_valid_worktree(worktree_path):
             return existing
         _cleanup_stale_lease(defaults, db_path, existing)
 
     run_id = _build_run_id(execution)
-    branch_name = _build_branch_name(execution, run_id)
     base_ref = execution.metadata.get("base_ref", "origin/main")
+    branch_name, checkout_ref, checkout_detached, branch_owned_by_runtime = _checkout_plan(execution, run_id)
     worktree_dirname = _slugify(f"{execution.runner_name.value}-{execution.work_item_id}-{run_id.split('-')[-1]}")
     worktree_path = defaults.worktree_root_path / worktree_dirname
 
     defaults.worktree_root_path.mkdir(parents=True, exist_ok=True)
-    if base_ref.startswith("origin/"):
+    if checkout_ref.startswith("origin/") or base_ref.startswith("origin/"):
         _git(defaults.repo_root, "fetch", "origin")
-    _git(defaults.repo_root, "worktree", "add", "-b", branch_name, str(worktree_path), base_ref)
+    if checkout_detached:
+        _git(defaults.repo_root, "worktree", "add", "--detach", str(worktree_path), checkout_ref)
+    else:
+        _git(defaults.repo_root, "worktree", "add", "-b", branch_name, str(worktree_path), checkout_ref)
 
     lease = WorktreeLeaseRecord(
         run_id=run_id,
@@ -116,6 +151,7 @@ def allocate_worktree(
         base_ref=base_ref,
         worktree_path=str(worktree_path),
         status="active",
+        branch_owned_by_runtime=branch_owned_by_runtime,
     )
     try:
         insert_worktree_lease(db_path, lease)
@@ -135,8 +171,9 @@ def bind_worktree_to_execution(execution: RunnerExecution, lease: WorktreeLeaseR
         "worktree_path": lease.worktree_path,
         "branch_name": lease.branch_name,
         "base_ref": lease.base_ref,
+        "branch_owned_by_runtime": "true" if lease.branch_owned_by_runtime else "false",
     }
-    return replace(execution, prompt=_inject_runtime_checkout_context(execution.prompt, lease), metadata=metadata)
+    return replace(execution, prompt=_inject_runtime_checkout_context(execution.prompt, lease, metadata), metadata=metadata)
 
 
 def release_worktree(defaults: RuntimeDefaults, db_path: Path, run_id: str) -> str:
@@ -152,9 +189,10 @@ def release_worktree(defaults: RuntimeDefaults, db_path: Path, run_id: str) -> s
         if error is not None:
             cleanup_error = error
 
-        error = _best_effort_git(defaults.repo_root, "branch", "-D", lease.branch_name)
-        if cleanup_error is None and error is not None:
-            cleanup_error = error
+        if lease.branch_owned_by_runtime:
+            error = _best_effort_git(defaults.repo_root, "branch", "-D", lease.branch_name)
+            if cleanup_error is None and error is not None:
+                cleanup_error = error
     finally:
         mark_worktree_lease_released(db_path, run_id)
 

--- a/agent_runtime/orchestrator/worktree_manager.py
+++ b/agent_runtime/orchestrator/worktree_manager.py
@@ -113,11 +113,15 @@ def _is_valid_worktree(path: Path) -> bool:
 def _build_checkout_request(execution: RunnerExecution) -> CheckoutRequest:
     base_ref = execution.metadata.get("base_ref", "origin/main")
     checkout_ref = execution.metadata.get("checkout_ref", base_ref)
+    checkout_detached = execution.metadata.get("checkout_detached") == "true"
+    branch_owned_by_runtime = execution.metadata.get("branch_owned_by_runtime", "true") != "false"
+    if checkout_detached:
+        branch_owned_by_runtime = False
     return CheckoutRequest(
         base_ref=base_ref,
         checkout_ref=checkout_ref,
-        checkout_detached=execution.metadata.get("checkout_detached") == "true",
-        branch_owned_by_runtime=execution.metadata.get("branch_owned_by_runtime", "true") != "false",
+        checkout_detached=checkout_detached,
+        branch_owned_by_runtime=branch_owned_by_runtime,
         pr_head_branch=execution.metadata.get("pr_head_branch"),
     )
 

--- a/agent_runtime/runners/coding_runner.py
+++ b/agent_runtime/runners/coding_runner.py
@@ -34,8 +34,8 @@ def build_coding_prompt(input_data: CodingRunnerInput) -> str:
     if input_data.pr_head_branch is not None:
         prompt += f"\nPR head branch: {input_data.pr_head_branch}"
     prompt += (
-        "\nIf dispatched by agent_runtime, treat the allocated worktree and branch as authoritative."
-        "\nDo not switch to `main`, allocate another worktree, or create another branch inside this run."
+        "\nIf dispatched by agent_runtime, treat the allocated worktree and checkout context as authoritative."
+        "\nDo not switch to `main`, allocate another worktree, or change branch state inside this run."
     )
     if input_data.pr_head_branch is not None:
         prompt += (

--- a/agent_runtime/runners/coding_runner.py
+++ b/agent_runtime/runners/coding_runner.py
@@ -19,6 +19,7 @@ class CodingRunnerInput:
     pr_number: int | None = None
     pr_url: str | None = None
     base_ref: str | None = None
+    pr_head_branch: str | None = None
     drift_summary: str | None = None
 
 
@@ -29,11 +30,18 @@ def build_coding_prompt(input_data: CodingRunnerInput) -> str:
     if input_data.pr_url is not None:
         prompt += f" ({input_data.pr_url})"
     if input_data.base_ref is not None:
-        prompt += f"\nBase ref: {input_data.base_ref}"
+        prompt += f"\nPR base ref: {input_data.base_ref}"
+    if input_data.pr_head_branch is not None:
+        prompt += f"\nPR head branch: {input_data.pr_head_branch}"
     prompt += (
         "\nIf dispatched by agent_runtime, treat the allocated worktree and branch as authoritative."
         "\nDo not switch to `main`, allocate another worktree, or create another branch inside this run."
     )
+    if input_data.pr_head_branch is not None:
+        prompt += (
+            "\nIf the runtime checkout is detached at the PR head, keep working in that detached checkout and "
+            f"push follow-up commits with `git push origin HEAD:{input_data.pr_head_branch}`."
+        )
     if input_data.drift_summary is not None:
         prompt += f"\n\n## Current repo drift state\n\n{input_data.drift_summary}"
     return prompt

--- a/agent_runtime/runners/drift_monitor_runner.py
+++ b/agent_runtime/runners/drift_monitor_runner.py
@@ -24,7 +24,9 @@ class DriftMonitorRunnerInput:
 def build_drift_monitor_prompt(input_data: DriftMonitorRunnerInput) -> str:
     prompt = (
         "Act only as the Drift Monitor agent.\n"
-        "Work from current `main`.\n"
+        "If dispatched by agent_runtime, treat the allocated worktree as authoritative and do not switch to `main`, "
+        "create another worktree, or create another branch.\n"
+        "If running manually outside agent_runtime, work from refreshed current `main`.\n"
         "Read:\n"
         "- AGENTS.md\n"
         "- prompts/agents/drift_monitor_agent_instruction.md\n"

--- a/agent_runtime/runners/issue_planner_runner.py
+++ b/agent_runtime/runners/issue_planner_runner.py
@@ -20,7 +20,15 @@ class IssuePlannerRunnerInput:
 
 
 def build_issue_planner_prompt(input_data: IssuePlannerRunnerInput) -> str:
-    prompt = "Act only as the Issue Planner agent.\nWork from current `main`.\nRead:\n- AGENTS.md\n- prompts/agents/issue_planner_instruction.md\n"
+    prompt = (
+        "Act only as the Issue Planner agent.\n"
+        "If dispatched by agent_runtime, treat the allocated worktree as authoritative and do not switch to `main`, "
+        "create another worktree, or create another branch.\n"
+        "If running manually outside agent_runtime, refresh current `main` and create a fresh branch from current `main` before editing work items.\n"
+        "Read:\n"
+        "- AGENTS.md\n"
+        "- prompts/agents/issue_planner_instruction.md\n"
+    )
     if input_data.source_prd_path:
         prompt += f"- {input_data.source_prd_path}\n"
     elif input_data.linked_prd:

--- a/agent_runtime/runners/prompt_loader.py
+++ b/agent_runtime/runners/prompt_loader.py
@@ -13,9 +13,11 @@ _log = get_logger(__name__)
 
 _INSTRUCTION_FILES: dict[RunnerName, str] = {
     RunnerName.PM: "prompts/agents/pm_agent_instruction.md",
-    RunnerName.SPEC: "prompts/agents/risk_methodology_spec_agent_instruction.md",
+    RunnerName.SPEC: "prompts/agents/prd_spec_agent_instruction.md",
+    RunnerName.ISSUE_PLANNER: "prompts/agents/issue_planner_instruction.md",
     RunnerName.CODING: "prompts/agents/coding_agent_instruction.md",
     RunnerName.REVIEW: "prompts/agents/review_agent_instruction.md",
+    RunnerName.DRIFT_MONITOR: "prompts/agents/drift_monitor_agent_instruction.md",
 }
 
 

--- a/agent_runtime/runners/review_runner.py
+++ b/agent_runtime/runners/review_runner.py
@@ -33,7 +33,7 @@ def build_review_prompt(input_data: ReviewRunnerInput) -> str:
     if input_data.pr_head_branch is not None:
         prompt += f"\nPR head branch: {input_data.pr_head_branch}"
     prompt += (
-        "\nIf dispatched by agent_runtime, treat the allocated review worktree and branch as authoritative."
+        "\nIf dispatched by agent_runtime, treat the allocated review worktree and checkout context as authoritative."
         "\nDo not switch to `main`, allocate another worktree, or create another branch inside this run."
     )
     if input_data.pr_head_branch is not None:

--- a/agent_runtime/runners/review_runner.py
+++ b/agent_runtime/runners/review_runner.py
@@ -21,6 +21,7 @@ class ReviewRunnerInput:
     pr_number: int
     pr_url: str | None = None
     base_ref: str | None = None
+    pr_head_branch: str | None = None
 
 
 def build_review_prompt(input_data: ReviewRunnerInput) -> str:
@@ -28,11 +29,18 @@ def build_review_prompt(input_data: ReviewRunnerInput) -> str:
     if input_data.pr_url is not None:
         prompt += f"\nPR URL: {input_data.pr_url}"
     if input_data.base_ref is not None:
-        prompt += f"\nBase ref: {input_data.base_ref}"
+        prompt += f"\nPR base ref: {input_data.base_ref}"
+    if input_data.pr_head_branch is not None:
+        prompt += f"\nPR head branch: {input_data.pr_head_branch}"
     prompt += (
         "\nIf dispatched by agent_runtime, treat the allocated review worktree and branch as authoritative."
         "\nDo not switch to `main`, allocate another worktree, or create another branch inside this run."
     )
+    if input_data.pr_head_branch is not None:
+        prompt += (
+            "\nIf the runtime checkout is detached at the PR head, do not create a local branch; "
+            f"push any PASS lifecycle commit with `git push origin HEAD:{input_data.pr_head_branch}`."
+        )
     return prompt
 
 

--- a/agent_runtime/runners/spec_runner.py
+++ b/agent_runtime/runners/spec_runner.py
@@ -41,7 +41,10 @@ def build_spec_prompt(input_data: SpecRunnerInput) -> str:
         if input_data.next_slice:
             prompt += f"Requested next slice: {input_data.next_slice}\n"
         prompt += (
-            "Draft or update the necessary PRD/spec so the contract gap is explicit and downstream PM/coding work can proceed.\nDo not write code.\n"
+            "Draft or update the necessary PRD/spec so the contract gap is explicit and downstream PM/coding work can proceed.\n"
+            "If dispatched by agent_runtime, treat the allocated worktree as authoritative and do not switch to `main`, create another worktree, or create another branch.\n"
+            "If running manually outside agent_runtime, refresh current `main` and create a fresh branch from current `main` before authoring the PRD/spec update.\n"
+            "Do not write code.\n"
         )
         return prompt
 
@@ -49,7 +52,9 @@ def build_spec_prompt(input_data: SpecRunnerInput) -> str:
         "Act only as the spec-resolution agent.\n"
         f"Resolve the blocker for {input_data.work_item_id}.\n"
         f"Work item: {input_data.work_item_path}\n"
-        f"Blocked reason: {input_data.blocked_reason}"
+        f"Blocked reason: {input_data.blocked_reason}\n"
+        "If dispatched by agent_runtime, treat the allocated worktree as authoritative and do not switch to `main`, create another worktree, or create another branch.\n"
+        "If running manually outside agent_runtime, refresh current `main` and create a fresh branch from current `main` before authoring the PRD/spec update."
     )
 
 

--- a/agent_runtime/storage/sqlite.py
+++ b/agent_runtime/storage/sqlite.py
@@ -69,6 +69,7 @@ CREATE TABLE IF NOT EXISTS worktree_leases (
     work_item_id TEXT NOT NULL,
     runner_name TEXT NOT NULL,
     branch_name TEXT NOT NULL,
+    branch_owned_by_runtime INTEGER NOT NULL DEFAULT 1,
     base_ref TEXT NOT NULL,
     worktree_path TEXT NOT NULL UNIQUE,
     status TEXT NOT NULL,
@@ -133,6 +134,7 @@ EXPECTED_WORKTREE_LEASE_COLUMNS = (
     "work_item_id",
     "runner_name",
     "branch_name",
+    "branch_owned_by_runtime",
     "base_ref",
     "worktree_path",
     "status",
@@ -179,6 +181,10 @@ _DEFAULT_COLUMN_DEFINITIONS = {
     "updated_at": "TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP",
 }
 
+_WORKTREE_LEASE_DEFAULT_COLUMN_DEFINITIONS = {
+    "branch_owned_by_runtime": "INTEGER NOT NULL DEFAULT 1",
+}
+
 
 @dataclass(frozen=True)
 class WorkflowRunRecord:
@@ -210,6 +216,7 @@ class WorktreeLeaseRecord:
     base_ref: str
     worktree_path: str
     status: str
+    branch_owned_by_runtime: bool = True
     created_at: str | None = None
     released_at: str | None = None
 
@@ -309,11 +316,24 @@ def _ensure_expected_columns(connection: sqlite3.Connection) -> None:
         connection.execute(f"ALTER TABLE workflow_runs ADD COLUMN {column_name} {column_definition}")
 
 
+def _ensure_expected_worktree_lease_columns(connection: sqlite3.Connection) -> None:
+    rows = connection.execute("PRAGMA table_info(worktree_leases)").fetchall()
+    actual_columns = {row[1] for row in rows}
+    for column_name in EXPECTED_WORKTREE_LEASE_COLUMNS:
+        if column_name in actual_columns:
+            continue
+        column_definition = _WORKTREE_LEASE_DEFAULT_COLUMN_DEFINITIONS.get(column_name)
+        if column_definition is None:
+            continue
+        connection.execute(f"ALTER TABLE worktree_leases ADD COLUMN {column_name} {column_definition}")
+
+
 def initialize_database(db_path: Path) -> None:
     db_path.parent.mkdir(parents=True, exist_ok=True)
     with sqlite3.connect(db_path) as connection:
         connection.executescript(SCHEMA)
         _ensure_expected_columns(connection)
+        _ensure_expected_worktree_lease_columns(connection)
         _verify_workflow_runs_schema(connection)
         _verify_worktree_leases_schema(connection)
         _verify_workflow_events_schema(connection)
@@ -527,17 +547,19 @@ def insert_worktree_lease(db_path: Path, record: WorktreeLeaseRecord) -> None:
                 work_item_id,
                 runner_name,
                 branch_name,
+                branch_owned_by_runtime,
                 base_ref,
                 worktree_path,
                 status,
                 created_at,
                 released_at
             )
-            VALUES (?, ?, ?, ?, ?, ?, ?, COALESCE(?, CURRENT_TIMESTAMP), ?)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, COALESCE(?, CURRENT_TIMESTAMP), ?)
             ON CONFLICT(run_id) DO UPDATE SET
                 work_item_id = excluded.work_item_id,
                 runner_name = excluded.runner_name,
                 branch_name = excluded.branch_name,
+                branch_owned_by_runtime = excluded.branch_owned_by_runtime,
                 base_ref = excluded.base_ref,
                 worktree_path = excluded.worktree_path,
                 status = excluded.status,
@@ -548,6 +570,7 @@ def insert_worktree_lease(db_path: Path, record: WorktreeLeaseRecord) -> None:
                 record.work_item_id,
                 record.runner_name,
                 record.branch_name,
+                int(record.branch_owned_by_runtime),
                 record.base_ref,
                 record.worktree_path,
                 record.status,
@@ -569,6 +592,7 @@ def load_active_worktree_lease(db_path: Path, work_item_id: str, runner_name: st
                 work_item_id,
                 runner_name,
                 branch_name,
+                branch_owned_by_runtime,
                 base_ref,
                 worktree_path,
                 status,
@@ -596,6 +620,7 @@ def load_worktree_lease(db_path: Path, run_id: str) -> WorktreeLeaseRecord | Non
                 work_item_id,
                 runner_name,
                 branch_name,
+                branch_owned_by_runtime,
                 base_ref,
                 worktree_path,
                 status,
@@ -721,6 +746,7 @@ def _row_to_worktree_lease(row: sqlite3.Row | None) -> WorktreeLeaseRecord | Non
         base_ref=str(row["base_ref"]),
         worktree_path=str(row["worktree_path"]),
         status=str(row["status"]),
+        branch_owned_by_runtime=bool(row["branch_owned_by_runtime"]),
         created_at=str(row["created_at"]) if row["created_at"] is not None else None,
         released_at=str(row["released_at"]) if row["released_at"] is not None else None,
     )

--- a/agent_runtime/tests/test_coding_runner.py
+++ b/agent_runtime/tests/test_coding_runner.py
@@ -18,11 +18,15 @@ def test_build_coding_prompt_includes_runtime_managed_checkout_rule() -> None:
             work_item_id="WI-1.1.4-risk-summary-core-service",
             task_summary="Implement the bounded slice.",
             base_ref="origin/main",
+            pr_head_branch="codex/wi-1-1-4",
         )
     )
 
     assert "agent_runtime" in prompt
     assert "Do not switch to `main`" in prompt
+    assert "PR base ref: origin/main" in prompt
+    assert "PR head branch: codex/wi-1-1-4" in prompt
+    assert "git push origin HEAD:codex/wi-1-1-4" in prompt
 
 
 def test_dispatch_coding_execution_prepared_backend_when_explicitly_set() -> None:

--- a/agent_runtime/tests/test_coding_runner.py
+++ b/agent_runtime/tests/test_coding_runner.py
@@ -24,6 +24,8 @@ def test_build_coding_prompt_includes_runtime_managed_checkout_rule() -> None:
 
     assert "agent_runtime" in prompt
     assert "Do not switch to `main`" in prompt
+    assert "allocated worktree and checkout context as authoritative" in prompt
+    assert "change branch state inside this run" in prompt
     assert "PR base ref: origin/main" in prompt
     assert "PR head branch: codex/wi-1-1-4" in prompt
     assert "git push origin HEAD:codex/wi-1-1-4" in prompt

--- a/agent_runtime/tests/test_issue_planner_runner.py
+++ b/agent_runtime/tests/test_issue_planner_runner.py
@@ -38,6 +38,7 @@ def test_build_issue_planner_prompt_contains_role_instruction() -> None:
     )
     prompt = build_issue_planner_prompt(input_data)
     assert "Issue Planner agent" in prompt
+    assert "create a fresh branch from current `main`" in prompt
 
 
 def test_build_issue_planner_prompt_contains_work_item_id() -> None:

--- a/agent_runtime/tests/test_langgraph_readiness.py
+++ b/agent_runtime/tests/test_langgraph_readiness.py
@@ -114,6 +114,21 @@ def test_load_system_prompt_returns_governed_prompt_when_present() -> None:
     assert len(prompt) > 100
 
 
+def test_load_system_prompt_supports_all_runtime_roles() -> None:
+    repo_root = Path(__file__).resolve()
+    for _ in range(10):
+        repo_root = repo_root.parent
+        if (repo_root / "AGENTS.md").exists():
+            break
+    else:
+        return
+
+    for runner_name in (RunnerName.SPEC, RunnerName.ISSUE_PLANNER, RunnerName.DRIFT_MONITOR):
+        prompt = load_system_prompt(runner_name, repo_root)
+        assert "AGENTS.md" in prompt
+        assert len(prompt) > 100
+
+
 def test_load_system_prompt_falls_back_gracefully() -> None:
     with tempfile.TemporaryDirectory() as temp_dir:
         prompt = load_system_prompt(RunnerName.PM, Path(temp_dir))

--- a/agent_runtime/tests/test_parallel_dispatch.py
+++ b/agent_runtime/tests/test_parallel_dispatch.py
@@ -20,6 +20,7 @@ from agent_runtime.orchestrator.state import (
     TransitionDecision,
     WorkItemSnapshot,
 )
+from agent_runtime.runners.contracts import RunnerExecution, RunnerName
 
 
 def _make_defaults(tmp_dir: str) -> RuntimeDefaults:
@@ -80,22 +81,44 @@ class TestHasActiveLease:
     def test_returns_false_when_no_lease(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             defaults = _make_defaults(tmp)
+            snapshot = _make_snapshot()
             decision = TransitionDecision(
                 action=NextActionType.RUN_PM,
                 work_item_id="WI-1",
                 reason="test",
             )
-            assert _has_active_lease(defaults, decision) is False
+            assert _has_active_lease(defaults, snapshot, decision) is False
 
     def test_returns_false_for_none_work_item(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             defaults = _make_defaults(tmp)
+            snapshot = _make_snapshot()
             decision = TransitionDecision(
                 action=NextActionType.NOOP,
                 work_item_id=None,
                 reason="test",
             )
-            assert _has_active_lease(defaults, decision) is False
+            assert _has_active_lease(defaults, snapshot, decision) is False
+
+    def test_returns_false_when_active_lease_is_not_reusable_for_current_checkout(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            defaults = _make_defaults(tmp)
+            snapshot = _make_snapshot()
+            decision = TransitionDecision(
+                action=NextActionType.RUN_PM,
+                work_item_id="WI-1",
+                reason="test",
+            )
+            execution = RunnerExecution(
+                runner_name=RunnerName.PM,
+                work_item_id="WI-1",
+                prompt="test prompt",
+                metadata={"base_ref": "origin/main"},
+            )
+
+            with patch("agent_runtime.orchestrator.parallel_dispatch.build_runner_execution", return_value=execution):
+                with patch("agent_runtime.orchestrator.parallel_dispatch.has_reusable_active_worktree_lease", return_value=False):
+                    assert _has_active_lease(defaults, snapshot, decision) is False
 
 
 class TestRunParallelStep:

--- a/agent_runtime/tests/test_review_runner.py
+++ b/agent_runtime/tests/test_review_runner.py
@@ -18,11 +18,15 @@ def test_build_review_prompt_includes_runtime_managed_checkout_rule() -> None:
             work_item_id="WI-1.1.4-risk-summary-core-service",
             pr_number=71,
             base_ref="origin/main",
+            pr_head_branch="codex/wi-1-1-4",
         )
     )
 
     assert "agent_runtime" in prompt
     assert "Do not switch to `main`" in prompt
+    assert "PR base ref: origin/main" in prompt
+    assert "PR head branch: codex/wi-1-1-4" in prompt
+    assert "git push origin HEAD:codex/wi-1-1-4" in prompt
 
 
 def test_dispatch_review_execution_prepared_backend_when_explicitly_set() -> None:

--- a/agent_runtime/tests/test_review_runner.py
+++ b/agent_runtime/tests/test_review_runner.py
@@ -24,6 +24,7 @@ def test_build_review_prompt_includes_runtime_managed_checkout_rule() -> None:
 
     assert "agent_runtime" in prompt
     assert "Do not switch to `main`" in prompt
+    assert "allocated review worktree and checkout context as authoritative" in prompt
     assert "PR base ref: origin/main" in prompt
     assert "PR head branch: codex/wi-1-1-4" in prompt
     assert "git push origin HEAD:codex/wi-1-1-4" in prompt

--- a/agent_runtime/tests/test_spec_runner.py
+++ b/agent_runtime/tests/test_spec_runner.py
@@ -210,6 +210,7 @@ def test_build_spec_prompt_handles_prd_bootstrap_context() -> None:
     assert "Target PRD: PRD-5.1-v2" in prompt
     assert "Current PRD: docs/prds/phase-2/PRD-5.1-daily-risk-investigation-orchestrator-v1.md" in prompt
     assert "Requested next slice: Author PRD-5.1-v2 for multi-walker orchestration." in prompt
+    assert "create a fresh branch from current `main`" in prompt
 
 
 def test_load_prd_bootstrap_candidates_returns_actionable_now_candidate_only(tmp_path: Path) -> None:

--- a/agent_runtime/tests/test_transitions.py
+++ b/agent_runtime/tests/test_transitions.py
@@ -22,6 +22,7 @@ from agent_runtime.orchestrator.state import (
     NextActionType,
     PullRequestSnapshot,
     RuntimeSnapshot,
+    TransitionDecision,
     WorkItemSnapshot,
     WorkItemStage,
 )
@@ -837,6 +838,7 @@ def test_build_runner_execution_for_review_includes_pr_context() -> None:
                 number=52,
                 is_draft=False,
                 url="https://github.com/tomanizer/risk-manager/pull/52",
+                head_ref_name="codex/wi-1-1-4",
                 unresolved_review_threads=1,
             ),
         ),
@@ -886,6 +888,43 @@ def test_build_runner_execution_for_coding_includes_base_ref() -> None:
     assert "PR head branch: codex/wi-1-1-4" in execution.prompt
     assert execution.metadata["checkout_detached"] == "true"
     assert execution.metadata["branch_owned_by_runtime"] == "false"
+
+
+def test_build_runner_execution_for_issue_planner_keeps_pr_head_checkout_metadata_off() -> None:
+    snapshot = RuntimeSnapshot(
+        work_items=(
+            WorkItemSnapshot(
+                id="WI-1.1.4-risk-summary-core-service",
+                title="WI-1.1.4",
+                path=Path("work_items/ready/WI-1.1.4-risk-summary-core-service.md"),
+                stage=WorkItemStage.READY,
+            ),
+        ),
+        pull_requests=(
+            PullRequestSnapshot(
+                work_item_id="WI-1.1.4-risk-summary-core-service",
+                number=52,
+                is_draft=False,
+                url="https://github.com/tomanizer/risk-manager/pull/52",
+                head_ref_name="codex/wi-1-1-4",
+                base_ref_name="main",
+            ),
+        ),
+    )
+
+    decision = TransitionDecision(
+        action=NextActionType.RUN_ISSUE_PLANNER,
+        work_item_id="WI-1.1.4-risk-summary-core-service",
+        reason="Need to split this work item.",
+    )
+    execution = build_runner_execution(snapshot, decision)
+
+    assert execution is not None
+    assert execution.runner_name is RunnerName.ISSUE_PLANNER
+    assert execution.metadata["base_ref"] == "origin/main"
+    assert "pr_head_branch" not in execution.metadata
+    assert "checkout_ref" not in execution.metadata
+    assert "checkout_detached" not in execution.metadata
 
 
 def test_build_runner_execution_preserves_decision_metadata() -> None:

--- a/agent_runtime/tests/test_transitions.py
+++ b/agent_runtime/tests/test_transitions.py
@@ -38,6 +38,7 @@ from agent_runtime.storage.sqlite import (
     WorkflowRunRecord,
     initialize_database,
     load_telemetry_events,
+    load_worktree_lease,
     load_workflow_run_by_run_id,
     load_workflow_run,
     load_workflow_runs,
@@ -510,6 +511,78 @@ def test_initialize_database_migrates_missing_updated_at_column() -> None:
         assert actual_columns == EXPECTED_WORKFLOW_RUN_COLUMNS
 
 
+def test_initialize_database_migrates_missing_worktree_branch_ownership_column() -> None:
+    with tempfile.TemporaryDirectory() as temp_dir:
+        db_path = Path(temp_dir) / "runtime" / "state.db"
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+
+        with sqlite3.connect(db_path) as connection:
+            connection.executescript(
+                """
+                CREATE TABLE workflow_runs (
+                    work_item_id TEXT PRIMARY KEY,
+                    run_id TEXT,
+                    branch_name TEXT,
+                    pr_number INTEGER,
+                    status TEXT NOT NULL,
+                    blocked_reason TEXT,
+                    last_action TEXT,
+                    runner_name TEXT,
+                    runner_status TEXT,
+                    outcome_status TEXT,
+                    outcome_summary TEXT,
+                    details_json TEXT NOT NULL DEFAULT '{}',
+                    result_json TEXT NOT NULL DEFAULT '{}',
+                    outcome_details_json TEXT NOT NULL DEFAULT '{}',
+                    completed_at TEXT
+                );
+                CREATE TABLE worktree_leases (
+                    run_id TEXT PRIMARY KEY,
+                    work_item_id TEXT NOT NULL,
+                    runner_name TEXT NOT NULL,
+                    branch_name TEXT NOT NULL,
+                    base_ref TEXT NOT NULL,
+                    worktree_path TEXT NOT NULL UNIQUE,
+                    status TEXT NOT NULL,
+                    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                    released_at TEXT
+                );
+                INSERT INTO worktree_leases (
+                    run_id,
+                    work_item_id,
+                    runner_name,
+                    branch_name,
+                    base_ref,
+                    worktree_path,
+                    status
+                )
+                VALUES (
+                    'review-run-1',
+                    'WI-1.1.4-risk-summary-core-service',
+                    'review',
+                    'codex/review-wi-1-1-4',
+                    'origin/main',
+                    '/tmp/runtime-review-worktree',
+                    'active'
+                );
+                """
+            )
+            connection.commit()
+
+        initialize_database(db_path)
+
+        with sqlite3.connect(db_path) as connection:
+            worktree_rows = connection.execute("PRAGMA table_info(worktree_leases)").fetchall()
+
+        actual_worktree_columns = tuple(row[1] for row in worktree_rows)
+        lease = load_worktree_lease(db_path, "review-run-1")
+
+        assert set(actual_worktree_columns) == set(EXPECTED_WORKTREE_LEASE_COLUMNS)
+        assert "branch_owned_by_runtime" in actual_worktree_columns
+        assert lease is not None
+        assert lease.branch_owned_by_runtime is True
+
+
 def test_upsert_workflow_run_round_trips_extended_columns() -> None:
     with tempfile.TemporaryDirectory() as temp_dir:
         db_path = Path(temp_dir) / "runtime" / "state.db"
@@ -688,6 +761,7 @@ def test_build_pull_request_snapshots_maps_live_payload() -> None:
                             "url": "https://github.com/tomanizer/risk-manager/pull/44",
                             "isDraft": False,
                             "headRefName": "codex/WI-1.1.3-risk-summary-history-service",
+                            "baseRefName": "main",
                             "updatedAt": "2026-04-06T10:00:00Z",
                             "title": "Implement WI-1.1.3",
                             "body": "Implements history service.",
@@ -722,6 +796,7 @@ def test_build_pull_request_snapshots_maps_live_payload() -> None:
     assert snapshots[0].review_decision == "APPROVED"
     assert snapshots[0].updated_at == "2026-04-06T10:00:00Z"
     assert snapshots[0].ci_status == "SUCCESS"
+    assert snapshots[0].base_ref_name == "main"
 
 
 def test_build_runner_execution_for_pm_uses_work_item_context() -> None:
@@ -774,7 +849,7 @@ def test_build_runner_execution_for_review_includes_pr_context() -> None:
     assert execution is not None
     assert execution.runner_name is RunnerName.REVIEW
     assert "PR #52" in execution.prompt
-    assert "Base ref: origin/main" in execution.prompt
+    assert "PR base ref: origin/main" in execution.prompt
     assert execution.metadata["pr_number"] == "52"
 
 
@@ -795,6 +870,7 @@ def test_build_runner_execution_for_coding_includes_base_ref() -> None:
                 is_draft=False,
                 url="https://github.com/tomanizer/risk-manager/pull/52",
                 head_ref_name="codex/wi-1-1-4",
+                base_ref_name="main",
                 ci_status="FAILURE",
             ),
         ),
@@ -806,7 +882,10 @@ def test_build_runner_execution_for_coding_includes_base_ref() -> None:
     assert decision.action is NextActionType.RUN_CODING
     assert execution is not None
     assert execution.runner_name is RunnerName.CODING
-    assert "Base ref: origin/codex/wi-1-1-4" in execution.prompt
+    assert "PR base ref: origin/main" in execution.prompt
+    assert "PR head branch: codex/wi-1-1-4" in execution.prompt
+    assert execution.metadata["checkout_detached"] == "true"
+    assert execution.metadata["branch_owned_by_runtime"] == "false"
 
 
 def test_build_runner_execution_preserves_decision_metadata() -> None:

--- a/agent_runtime/tests/test_worktree_manager.py
+++ b/agent_runtime/tests/test_worktree_manager.py
@@ -13,7 +13,12 @@ from agent_runtime.orchestrator.worktree_manager import (
     release_worktree,
 )
 from agent_runtime.runners.contracts import RunnerExecution, RunnerName
-from agent_runtime.storage.sqlite import load_active_worktree_lease, load_worktree_lease
+from agent_runtime.storage.sqlite import (
+    WorktreeLeaseRecord,
+    insert_worktree_lease,
+    load_active_worktree_lease,
+    load_worktree_lease,
+)
 
 
 def _git(cwd: Path, *args: str) -> None:
@@ -102,3 +107,104 @@ def test_release_worktree_reports_missing_or_already_released() -> None:
         assert release_worktree(defaults, db_path, lease.run_id) == "released"
         assert release_worktree(defaults, db_path, lease.run_id) == "already_released"
         assert release_worktree(defaults, db_path, "missing-run") == "not_found"
+
+
+def test_allocate_worktree_replaces_stale_gitdir_stub() -> None:
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_path = Path(temp_dir)
+        repo_root = temp_path / "repo"
+        repo_root.mkdir()
+
+        _git(repo_root, "init")
+        _git(repo_root, "config", "user.email", "test@example.com")
+        _git(repo_root, "config", "user.name", "Test User")
+        (repo_root / "README.md").write_text("runtime test\n", encoding="utf-8")
+        _git(repo_root, "add", "README.md")
+        _git(repo_root, "commit", "-m", "init")
+
+        defaults = RuntimeDefaults(repo_root=repo_root, worktree_root_dirname="repo-worktrees")
+        db_path = repo_root / ".agent_runtime" / "state.db"
+        execution = RunnerExecution(
+            runner_name=RunnerName.PM,
+            work_item_id="WI-1.1.4-risk-summary-core-service",
+            prompt="Act only as the PM agent.",
+            metadata={"base_ref": "HEAD"},
+        )
+
+        stale_worktree = temp_path / "stale-worktree"
+        stale_worktree.mkdir()
+        (stale_worktree / ".git").write_text("gitdir: /tmp/missing-runtime-gitdir\n", encoding="utf-8")
+        stale_run_id = "pm-wi-1-1-4-risk-summary-core-service-stale"
+        insert_worktree_lease(
+            db_path,
+            WorktreeLeaseRecord(
+                run_id=stale_run_id,
+                work_item_id=execution.work_item_id,
+                runner_name=execution.runner_name.value,
+                branch_name="codex/pm-wi-1-1-4-stale",
+                base_ref="HEAD",
+                worktree_path=str(stale_worktree),
+                status="active",
+            ),
+        )
+
+        lease = allocate_worktree(defaults, db_path, execution)
+        stale = load_worktree_lease(db_path, stale_run_id)
+
+        assert lease.run_id != stale_run_id
+        assert stale is not None
+        assert stale.status == "released"
+
+        rev_parse = subprocess.run(
+            ["git", "rev-parse", "--is-inside-work-tree"],
+            cwd=lease.worktree_path,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        assert rev_parse.stdout.strip() == "true"
+
+
+def test_release_worktree_keeps_non_runtime_owned_branch() -> None:
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_path = Path(temp_dir)
+        repo_root = temp_path / "repo"
+        repo_root.mkdir()
+
+        _git(repo_root, "init")
+        _git(repo_root, "config", "user.email", "test@example.com")
+        _git(repo_root, "config", "user.name", "Test User")
+        (repo_root / "README.md").write_text("runtime test\n", encoding="utf-8")
+        _git(repo_root, "add", "README.md")
+        _git(repo_root, "commit", "-m", "init")
+        _git(repo_root, "branch", "pr/head")
+
+        defaults = RuntimeDefaults(repo_root=repo_root, worktree_root_dirname="repo-worktrees")
+        db_path = repo_root / ".agent_runtime" / "state.db"
+        execution = RunnerExecution(
+            runner_name=RunnerName.REVIEW,
+            work_item_id="WI-1.1.4-risk-summary-core-service",
+            prompt="Act only as the review agent.",
+            metadata={
+                "base_ref": "HEAD",
+                "checkout_ref": "HEAD",
+                "checkout_detached": "true",
+                "branch_owned_by_runtime": "false",
+                "pr_head_branch": "pr/head",
+            },
+        )
+
+        lease = allocate_worktree(defaults, db_path, execution)
+        assert lease.branch_name == "pr/head"
+        assert lease.branch_owned_by_runtime is False
+
+        assert release_worktree(defaults, db_path, lease.run_id) == "released"
+
+        branch_check = subprocess.run(
+            ["git", "rev-parse", "--verify", "refs/heads/pr/head"],
+            cwd=repo_root,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        assert branch_check.returncode == 0

--- a/agent_runtime/tests/test_worktree_manager.py
+++ b/agent_runtime/tests/test_worktree_manager.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from pathlib import Path
 import subprocess
 import tempfile
+from unittest.mock import patch
+import sqlite3
 
 from agent_runtime.config.defaults import RuntimeDefaults
 from agent_runtime.orchestrator.worktree_manager import (
@@ -208,3 +210,135 @@ def test_release_worktree_keeps_non_runtime_owned_branch() -> None:
             text=True,
         )
         assert branch_check.returncode == 0
+
+
+def test_allocate_worktree_replaces_stale_detached_checkout_when_target_ref_advances() -> None:
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_path = Path(temp_dir)
+        repo_root = temp_path / "repo"
+        repo_root.mkdir()
+
+        _git(repo_root, "init")
+        _git(repo_root, "config", "user.email", "test@example.com")
+        _git(repo_root, "config", "user.name", "Test User")
+        (repo_root / "README.md").write_text("runtime test\n", encoding="utf-8")
+        _git(repo_root, "add", "README.md")
+        _git(repo_root, "commit", "-m", "init")
+        _git(repo_root, "branch", "pr/head")
+
+        defaults = RuntimeDefaults(repo_root=repo_root, worktree_root_dirname="repo-worktrees")
+        db_path = repo_root / ".agent_runtime" / "state.db"
+        execution = RunnerExecution(
+            runner_name=RunnerName.REVIEW,
+            work_item_id="WI-1.1.4-risk-summary-core-service",
+            prompt="Act only as the review agent.",
+            metadata={
+                "base_ref": "HEAD",
+                "checkout_ref": "pr/head",
+                "checkout_detached": "true",
+                "branch_owned_by_runtime": "false",
+                "pr_head_branch": "pr/head",
+            },
+        )
+
+        initial_lease = allocate_worktree(defaults, db_path, execution)
+        initial_worktree_path = Path(initial_lease.worktree_path)
+
+        initial_head = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=initial_worktree_path,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+
+        (repo_root / "README.md").write_text("runtime test advanced\n", encoding="utf-8")
+        _git(repo_root, "add", "README.md")
+        _git(repo_root, "commit", "-m", "advance pr head")
+        _git(repo_root, "branch", "-f", "pr/head", "HEAD")
+
+        updated_target = subprocess.run(
+            ["git", "rev-parse", "pr/head"],
+            cwd=repo_root,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        assert updated_target != initial_head
+
+        refreshed_lease = allocate_worktree(defaults, db_path, execution)
+        released_initial = load_worktree_lease(db_path, initial_lease.run_id)
+
+        assert refreshed_lease.run_id != initial_lease.run_id
+        assert released_initial is not None
+        assert released_initial.status == "released"
+        assert not initial_worktree_path.exists()
+
+        refreshed_head = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=refreshed_lease.worktree_path,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        assert refreshed_head == updated_target
+
+
+def test_allocate_worktree_cleans_orphaned_worktree_when_lease_insert_loses_race() -> None:
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_path = Path(temp_dir)
+        repo_root = temp_path / "repo"
+        repo_root.mkdir()
+
+        _git(repo_root, "init")
+        _git(repo_root, "config", "user.email", "test@example.com")
+        _git(repo_root, "config", "user.name", "Test User")
+        (repo_root / "README.md").write_text("runtime test\n", encoding="utf-8")
+        _git(repo_root, "add", "README.md")
+        _git(repo_root, "commit", "-m", "init")
+
+        defaults = RuntimeDefaults(repo_root=repo_root, worktree_root_dirname="repo-worktrees")
+        db_path = repo_root / ".agent_runtime" / "state.db"
+        execution = RunnerExecution(
+            runner_name=RunnerName.PM,
+            work_item_id="WI-1.1.4-risk-summary-core-service",
+            prompt="Act only as the PM agent.",
+            metadata={"base_ref": "HEAD"},
+        )
+        concurrent_lease = WorktreeLeaseRecord(
+            run_id="pm-wi-1-1-4-concurrent",
+            work_item_id=execution.work_item_id,
+            runner_name=execution.runner_name.value,
+            branch_name="codex/pm-wi-1-1-4-concurrent",
+            base_ref="HEAD",
+            worktree_path=str(temp_path / "other-worktree"),
+            status="active",
+        )
+        load_calls = 0
+
+        def fake_load_active(*args: object, **kwargs: object) -> WorktreeLeaseRecord | None:
+            del args, kwargs
+            nonlocal load_calls
+            load_calls += 1
+            if load_calls == 1:
+                return None
+            return concurrent_lease
+
+        with patch("agent_runtime.orchestrator.worktree_manager.load_active_worktree_lease", side_effect=fake_load_active):
+            with patch(
+                "agent_runtime.orchestrator.worktree_manager.insert_worktree_lease",
+                side_effect=sqlite3.IntegrityError("active runner lease already exists"),
+            ):
+                reused_lease = allocate_worktree(defaults, db_path, execution)
+
+        assert reused_lease == concurrent_lease
+        assert not defaults.worktree_root_path.exists() or tuple(defaults.worktree_root_path.iterdir()) == ()
+
+        branch_listing = subprocess.run(
+            ["git", "branch", "--list", "codex/*"],
+            cwd=repo_root,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        assert branch_listing.stdout.strip() == ""

--- a/docs/guides/agent_framework.md
+++ b/docs/guides/agent_framework.md
@@ -178,7 +178,7 @@ The simplest way to use the agents is to copy an invocation template, fill in th
 
 ### The freshness rule
 
-Before any agent pass, sync to the latest `main`:
+Before any manual direct-mode agent pass, sync the control checkout to the latest `main`:
 
 ```bash
 git fetch origin
@@ -186,7 +186,21 @@ git switch main
 git pull --ff-only origin main
 ```
 
-For reviews, then checkout the PR head. For coding, create a fresh branch from `main`. Agents must not work from stale local state.
+Manual direct mode then follows the old split:
+
+- for reviews, checkout the PR head in an isolated review checkout
+- for coding, create a fresh branch from current `main`
+
+Runtime-managed mode is different:
+
+- refresh the control checkout before dispatch
+- let `agent_runtime` allocate the authoritative worktree
+- do the real agent work only inside that allocated worktree
+- do not switch a runtime-managed session back to `main`
+- do not allocate another worktree or create another branch inside a runtime-managed session
+- for PR-linked coding or review, use the runtime-provided PR-head checkout or push target exactly as given
+
+Agents must not work from stale local state.
 
 ## Local environment setup
 

--- a/docs/guides/overnight_agent_runbook.md
+++ b/docs/guides/overnight_agent_runbook.md
@@ -30,13 +30,13 @@ That collapses the governance model.
 
 ## Freshness rule
 
-Before any PM, coding, review, or drift-monitor cycle:
+Before any manual direct-mode PM, coding, review, or drift-monitor cycle:
 
 1. git fetch origin
 2. git switch main
 3. git pull --ff-only origin main
 
-For reviews, then checkout the latest PR head. For coding, create a fresh branch from main.
+For manual review work, then checkout the latest PR head. For manual coding, create a fresh branch from main.
 
 New work must begin from up-to-date `main`.
 
@@ -45,6 +45,11 @@ Each bounded slice should use its own fresh branch created from current `main`.
 Agents must not rely on stale local state when the repository, PRs, or canon documents may have changed.
 
 Repo-health audits should also run from current `main` so they do not report drift against stale local guidance.
+
+In runtime-managed mode, refresh the control checkout before dispatch and then
+do the real PM/spec/issue-planner/coding/review/drift-monitor work only inside
+the runtime-allocated worktree. Do not switch a runtime-managed session back to
+`main`, do not allocate another worktree, and do not create another branch.
 
 ## Canonical handoff chain
 

--- a/prompts/agents/coding_agent_instruction.md
+++ b/prompts/agents/coding_agent_instruction.md
@@ -50,10 +50,15 @@ If the work belongs in a deterministic service, do not introduce AI behavior or 
 
 ### Use the runtime-managed checkout when present
 
-If the handoff came from `agent_runtime`, the allocated worktree and branch are
-authoritative for the run. Do not switch the runtime-managed session back to
-`main`, do not allocate another worktree, and do not create a second feature
-branch inside that session.
+If the handoff came from `agent_runtime`, the allocated worktree and checkout
+context are authoritative for the run. Do not switch the runtime-managed
+session back to `main`, do not allocate another worktree, and do not create a
+second feature branch inside that session.
+
+For PR follow-up coding, the runtime may place you on a detached checkout at
+the PR head instead of a local branch. In that case, keep working in the
+detached checkout and use the runtime-provided PR head push target exactly as
+given rather than creating a new branch.
 
 ### Prefer established libraries
 
@@ -155,7 +160,10 @@ Suggested commands for runtime-managed mode:
 git status --short --branch
 git mv work_items/ready/{WI-ID}-*.md work_items/in_progress/
 git commit -m "chore: move {WI-ID} to in_progress [coding start]"
+# If the runtime checkout is on a local branch:
 git push origin HEAD
+# If the runtime checkout is detached at the PR head:
+git push origin HEAD:{PR_HEAD_BRANCH}
 ```
 
 Suggested commands for manual direct mode:
@@ -206,7 +214,11 @@ Paste this into a FRESH Review Agent session (new chat / new Codex session):
 
 You are the Review Agent for this repository.
 
-Work from current `main`, then checkout the PR head.
+Work from the governed execution checkout for this task.
+
+Execution mode:
+- If this handoff is run through agent_runtime, the runtime-managed review worktree for this run is authoritative. Use the provided checkout context exactly as given, including any PR-head checkout or push target. Do not switch to main. Do not create another worktree. Do not create another branch.
+- If this handoff is run manually outside `agent_runtime`, refresh the control checkout on current `main` and then inspect the PR head in an isolated review checkout.
 
 Read:
 - AGENTS.md

--- a/prompts/agents/drift_monitor_agent_instruction.md
+++ b/prompts/agents/drift_monitor_agent_instruction.md
@@ -88,6 +88,12 @@ Focus on contradictions, trust problems, and governance decay before naming ligh
 
 Do not make merge decisions, implementation decisions, or policy decisions that belong to PM, coding, review, spec, or humans.
 
+### Use the runtime-managed checkout when present
+
+If the handoff came from `agent_runtime`, the allocated worktree for the run is
+authoritative. Do not switch that session back to `main`, do not allocate
+another worktree, and do not create another branch inside that session.
+
 ### Classify the drift
 
 For each material finding, say whether it is mainly:

--- a/prompts/agents/invocation_templates/README.md
+++ b/prompts/agents/invocation_templates/README.md
@@ -12,6 +12,11 @@ They bridge the standing instruction files (in `prompts/agents/`) with the per-t
 
 The agent's standing instruction file is referenced in each template. The agent should read it first, then apply the task-specific context from the invocation prompt.
 
+Every template now carries explicit execution-mode guidance:
+
+- manual direct mode starts from refreshed current `main`
+- runtime-managed mode uses the `agent_runtime`-allocated worktree and checkout context exactly as provided
+
 When a task touches cross-cutting infrastructure, include:
 
 - `docs/shared_infra/index.md`

--- a/prompts/agents/invocation_templates/coding_invocation.md
+++ b/prompts/agents/invocation_templates/coding_invocation.md
@@ -5,7 +5,7 @@ You are the Coding Agent for this repository.
 Work from the governed execution checkout for this task.
 
 Execution mode:
-- If this handoff is run through agent_runtime, the runtime-managed worktree and branch for this run are authoritative. Do not switch to main. Do not create another worktree. Do not create another branch.
+- If this handoff is run through agent_runtime, the runtime-managed worktree for this run is authoritative. Use the provided checkout context exactly as given, including any PR-head checkout or push target. Do not switch to main. Do not create another worktree. Do not create another branch.
 - If this handoff is run manually outside `agent_runtime`, refresh the control checkout on current `main` and create a fresh feature branch from current `main` before coding.
 
 Read:
@@ -36,7 +36,7 @@ Stop conditions:
 <BULLETED_STOP_CONDITIONS — when the agent should stop and report a blocker>
 
 Execution notes:
-- in `agent_runtime` mode, use the allocated worktree and branch exactly as provided
+- in `agent_runtime` mode, use the allocated worktree and checkout context exactly as provided
 - in manual mode, create a fresh branch from current `main`
 - keep the PR narrow and reviewable
 - include tests

--- a/prompts/agents/invocation_templates/drift_monitor_invocation.md
+++ b/prompts/agents/invocation_templates/drift_monitor_invocation.md
@@ -2,7 +2,11 @@
 
 You are the Drift Monitor agent for this repository.
 
-Work from current `main`.
+Work from the governed execution checkout for this task.
+
+Execution mode:
+- If this handoff is run through agent_runtime, the runtime-managed worktree for this run is authoritative. Do not switch to `main`. Do not create another worktree. Do not create another branch.
+- If this handoff is run manually outside `agent_runtime`, use the refreshed control checkout on current `main`.
 
 Read:
 - AGENTS.md

--- a/prompts/agents/invocation_templates/issue_planner_invocation.md
+++ b/prompts/agents/invocation_templates/issue_planner_invocation.md
@@ -2,7 +2,11 @@
 
 You are the Issue Planner agent for this repository.
 
-Work from current `main`.
+Work from the governed execution checkout for this task.
+
+Execution mode:
+- If this handoff is run through agent_runtime, the runtime-managed worktree for this run is authoritative. Do not switch to `main`. Do not create another worktree. Do not create another branch.
+- If this handoff is run manually outside `agent_runtime`, refresh the control checkout on current `main` and create a fresh branch from current `main` before editing work items.
 
 Read:
 - AGENTS.md

--- a/prompts/agents/invocation_templates/phase2_prd_kickoff.md
+++ b/prompts/agents/invocation_templates/phase2_prd_kickoff.md
@@ -5,7 +5,11 @@
 
 You are the PRD / Spec Author agent for this repository.
 
-Work from current `main`.
+Work from the governed execution checkout for this task.
+
+Execution mode:
+- If this handoff is run through agent_runtime, the runtime-managed worktree for this run is authoritative. Do not switch to `main`. Do not create another worktree. Do not create another branch.
+- If this handoff is run manually outside `agent_runtime`, refresh the control checkout on current `main` and create a fresh branch from current `main` before authoring the PRD.
 
 Read:
 

--- a/prompts/agents/invocation_templates/prd_spec_invocation.md
+++ b/prompts/agents/invocation_templates/prd_spec_invocation.md
@@ -2,7 +2,11 @@
 
 You are the PRD / Spec Author agent for this repository.
 
-Work from current `main`.
+Work from the governed execution checkout for this task.
+
+Execution mode:
+- If this handoff is run through agent_runtime, the runtime-managed worktree for this run is authoritative. Do not switch to `main`. Do not create another worktree. Do not create another branch.
+- If this handoff is run manually outside `agent_runtime`, refresh the control checkout on current `main` and create a fresh branch from current `main` before authoring the PRD/spec update.
 
 Read:
 - AGENTS.md

--- a/prompts/agents/invocation_templates/review_invocation.md
+++ b/prompts/agents/invocation_templates/review_invocation.md
@@ -5,7 +5,7 @@ You are the Review Agent for this repository.
 Work from the governed execution checkout for this task.
 
 Execution mode:
-- If this handoff is run through agent_runtime, the runtime-managed review worktree for this run is authoritative. Do not switch to main. Do not create another worktree. Do not create another branch.
+- If this handoff is run through agent_runtime, the runtime-managed review worktree for this run is authoritative. Use the provided checkout context exactly as given, including any PR-head checkout or push target. Do not switch to main. Do not create another worktree. Do not create another branch.
 - If this handoff is run manually outside `agent_runtime`, refresh the control checkout on current `main` and then inspect the PR head in an isolated review checkout.
 
 Read:

--- a/prompts/agents/issue_planner_instruction.md
+++ b/prompts/agents/issue_planner_instruction.md
@@ -48,6 +48,12 @@ reference the prerequisite shared slice explicitly before dependent items.
 
 The reviewer should be able to answer pass or fail without inferring hidden intent.
 
+### Use the runtime-managed checkout when present
+
+If the handoff came from `agent_runtime`, the allocated worktree for the run is
+authoritative. Do not switch that session back to `main`, do not allocate
+another worktree, and do not create another branch inside that session.
+
 ## Stop conditions
 
 Stop and escalate rather than producing a work item when:

--- a/prompts/agents/prd_spec_agent_instruction.md
+++ b/prompts/agents/prd_spec_agent_instruction.md
@@ -100,6 +100,12 @@ When the capability depends on shared infrastructure, specify required shared
 contracts explicitly and reference relevant `docs/shared_infra/` canon files.
 Do not leave shared-infra assumptions implicit for downstream coding.
 
+### Use the runtime-managed checkout when present
+
+If the handoff came from `agent_runtime`, the allocated worktree for the run is
+authoritative. Do not switch that session back to `main`, do not allocate
+another worktree, and do not create another branch inside that session.
+
 ## Stop conditions
 
 Stop and escalate rather than producing a vague PRD when:

--- a/prompts/agents/review_agent_instruction.md
+++ b/prompts/agents/review_agent_instruction.md
@@ -68,6 +68,17 @@ Stop and escalate rather than issuing a pass/fail when:
 
 In these cases, flag the review as incomplete, describe the blocker, and route it to PM, PRD/spec, or human decision.
 
+## Runtime-managed checkout rule
+
+If the handoff came from `agent_runtime`, the allocated review worktree and
+checkout context are authoritative for the run. Do not switch the session back
+to `main`, do not allocate another worktree, and do not create another branch.
+
+For PR-linked review work, the runtime may place you on a detached checkout at
+the PR head. In that case, keep working in the detached checkout and use the
+runtime-provided PR head push target exactly as given rather than creating a
+local branch.
+
 ## GitHub actions required during review
 
 Before issuing a pass/fail, the review agent must complete all of these steps using the `gh` CLI and GitHub API:
@@ -160,7 +171,10 @@ Runtime-managed mode:
 git status --short --branch
 git mv work_items/in_progress/{WI-ID}-*.md work_items/done/ 2>/dev/null || git mv work_items/ready/{WI-ID}-*.md work_items/done/
 git commit -m "chore: move {WI-ID} to done [review PASS]"
+# If the runtime checkout is on a local branch:
 git push origin HEAD
+# If the runtime checkout is detached at the PR head:
+git push origin HEAD:{PR_HEAD_BRANCH}
 ```
 
 Manual direct mode:

--- a/skills/deliver-wi/SKILL.md
+++ b/skills/deliver-wi/SKILL.md
@@ -46,7 +46,11 @@ Recommended model: Sonnet (or equivalent mid-tier)
 
 You are the PM / Coordination Agent for this repository.
 
-Work from current `main`.
+Work from the governed execution checkout for this task.
+
+Execution mode:
+- If this handoff is run through agent_runtime, the runtime-managed worktree and branch for this run are authoritative. Do not switch to main. Do not create another worktree. Do not create another branch.
+- If this handoff is run manually outside `agent_runtime`, use the refreshed control checkout on current `main`.
 
 Read in order:
 - AGENTS.md
@@ -166,9 +170,10 @@ Before the agent starts, refresh the control checkout:
   git fetch origin && git switch main && git pull --ff-only origin main
 If using agent_runtime:
   python -m agent_runtime --dispatch
-  Then use only the returned worktree path and branch for that run.
+  Then use only the returned worktree path and checkout context for that run.
 If running manually outside agent_runtime:
-  For coding: create a fresh branch from main.
+  For coding, PRD/spec authoring, or issue-planner edits: create a fresh branch from main.
+  For PM or drift-monitor analysis: use the refreshed control checkout on main.
   For review: inspect the PR head in an isolated checkout.
 ```
 

--- a/skills/new-prd/SKILL.md
+++ b/skills/new-prd/SKILL.md
@@ -107,7 +107,11 @@ The user opens a new chat, selects the recommended model, then pastes the whole 
 After the prompt block, always print:
 
 ```text
-Before the agent starts:
+Before the agent starts, refresh the control checkout:
   git fetch origin && git switch main && git pull --ff-only origin main
-For PRD authoring: work from a fresh branch created from main.
+If using agent_runtime:
+  python -m agent_runtime --dispatch
+  Then use only the returned worktree path and checkout context for that run.
+If running manually outside agent_runtime:
+  For PRD authoring: work from a fresh branch created from main.
 ```

--- a/skills/run-drift/SKILL.md
+++ b/skills/run-drift/SKILL.md
@@ -60,8 +60,13 @@ Recommended model: Sonnet (or equivalent mid-tier)
 After the prompt block, always print:
 
 ```text
-Before the agent starts:
+Before the agent starts, refresh the control checkout:
   git fetch origin && git switch main && git pull --ff-only origin main
+If using agent_runtime:
+  python -m agent_runtime --dispatch
+  Then use only the returned worktree path and checkout context for that run.
+If running manually outside agent_runtime:
+  Run the drift monitor from the refreshed control checkout on main.
 ```
 
 ## Hard stops

--- a/tests/unit/agent_runtime/test_drift_suite.py
+++ b/tests/unit/agent_runtime/test_drift_suite.py
@@ -513,15 +513,30 @@ def _write_instruction_surfaces(root: Path) -> None:
             "Execution mode:\n"
             "- If this handoff is run through agent_runtime, the runtime-managed worktree and branch for this run are authoritative. Do not switch to main. Do not create another worktree. Do not create another branch.\n"
         ),
+        "prd_spec_invocation.md": (
+            "You are the PRD / Spec Author agent.\n"
+            "Execution mode:\n"
+            "- If this handoff is run through agent_runtime, the runtime-managed worktree for this run is authoritative. Do not switch to `main`. Do not create another worktree. Do not create another branch.\n"
+        ),
+        "issue_planner_invocation.md": (
+            "You are the Issue Planner agent.\n"
+            "Execution mode:\n"
+            "- If this handoff is run through agent_runtime, the runtime-managed worktree for this run is authoritative. Do not switch to `main`. Do not create another worktree. Do not create another branch.\n"
+        ),
         "coding_invocation.md": (
             "You are the Coding Agent.\n"
             "Execution mode:\n"
-            "- If this handoff is run through agent_runtime, the runtime-managed worktree and branch for this run are authoritative. Do not switch to main. Do not create another worktree. Do not create another branch.\n"
+            "- If this handoff is run through agent_runtime, the runtime-managed worktree for this run is authoritative. Use the provided checkout context exactly as given, including any PR-head checkout or push target. Do not switch to main. Do not create another worktree. Do not create another branch.\n"
         ),
         "review_invocation.md": (
             "You are the Review Agent.\n"
             "Execution mode:\n"
-            "- If this handoff is run through agent_runtime, the runtime-managed review worktree for this run is authoritative. Do not switch to main. Do not create another worktree. Do not create another branch.\n"
+            "- If this handoff is run through agent_runtime, the runtime-managed review worktree for this run is authoritative. Use the provided checkout context exactly as given, including any PR-head checkout or push target. Do not switch to main. Do not create another worktree. Do not create another branch.\n"
+        ),
+        "drift_monitor_invocation.md": (
+            "You are the Drift Monitor agent.\n"
+            "Execution mode:\n"
+            "- If this handoff is run through agent_runtime, the runtime-managed worktree for this run is authoritative. Do not switch to `main`. Do not create another worktree. Do not create another branch.\n"
         ),
     }
     for filename, content in invocation_template_contents.items():

--- a/tests/unit/agent_runtime/test_instruction_surfaces.py
+++ b/tests/unit/agent_runtime/test_instruction_surfaces.py
@@ -295,15 +295,30 @@ def _write_instruction_surfaces(root: Path) -> None:
             "Execution mode:\n"
             "- If this handoff is run through agent_runtime, the runtime-managed worktree and branch for this run are authoritative. Do not switch to main. Do not create another worktree. Do not create another branch.\n"
         ),
+        "prd_spec_invocation.md": (
+            "You are the PRD / Spec Author agent.\n"
+            "Execution mode:\n"
+            "- If this handoff is run through agent_runtime, the runtime-managed worktree for this run is authoritative. Do not switch to `main`. Do not create another worktree. Do not create another branch.\n"
+        ),
+        "issue_planner_invocation.md": (
+            "You are the Issue Planner agent.\n"
+            "Execution mode:\n"
+            "- If this handoff is run through agent_runtime, the runtime-managed worktree for this run is authoritative. Do not switch to `main`. Do not create another worktree. Do not create another branch.\n"
+        ),
         "coding_invocation.md": (
             "You are the Coding Agent.\n"
             "Execution mode:\n"
-            "- If this handoff is run through agent_runtime, the runtime-managed worktree and branch for this run are authoritative. Do not switch to main. Do not create another worktree. Do not create another branch.\n"
+            "- If this handoff is run through agent_runtime, the runtime-managed worktree for this run is authoritative. Use the provided checkout context exactly as given, including any PR-head checkout or push target. Do not switch to main. Do not create another worktree. Do not create another branch.\n"
         ),
         "review_invocation.md": (
             "You are the Review Agent.\n"
             "Execution mode:\n"
-            "- If this handoff is run through agent_runtime, the runtime-managed review worktree for this run is authoritative. Do not switch to main. Do not create another worktree. Do not create another branch.\n"
+            "- If this handoff is run through agent_runtime, the runtime-managed review worktree for this run is authoritative. Use the provided checkout context exactly as given, including any PR-head checkout or push target. Do not switch to main. Do not create another worktree. Do not create another branch.\n"
+        ),
+        "drift_monitor_invocation.md": (
+            "You are the Drift Monitor agent.\n"
+            "Execution mode:\n"
+            "- If this handoff is run through agent_runtime, the runtime-managed worktree for this run is authoritative. Do not switch to `main`. Do not create another worktree. Do not create another branch.\n"
         ),
     }
     for filename, content in invocation_template_contents.items():


### PR DESCRIPTION
## Summary
- validate reused worktrees with `git rev-parse --is-inside-work-tree` instead of trusting a `.git` entry
- only reuse an active lease when its checkout state still matches the requested target, including detached PR-head refreshes
- persist lease branch ownership and avoid deleting non-runtime-owned branches on release
- clean up unclaimed worktrees and runtime-owned branches when lease insert races lose the active-run uniqueness check
- align runtime prompts, invocation templates, docs, agent profiles, and generated skill mirrors around manual vs runtime-managed checkout rules
- add regression coverage for stale worktree reuse, lease migration, prompt loading, execution metadata, instruction-surface drift, and parallel-dispatch lease checks

## Testing
- `PYTHONPATH=. pytest agent_runtime/tests/test_worktree_manager.py agent_runtime/tests/test_parallel_dispatch.py agent_runtime/tests/test_transitions.py agent_runtime/tests/test_coding_runner.py agent_runtime/tests/test_review_runner.py agent_runtime/tests/test_issue_planner_runner.py agent_runtime/tests/test_spec_runner.py agent_runtime/tests/test_langgraph_readiness.py tests/unit/agent_runtime/test_instruction_surfaces.py tests/unit/agent_runtime/test_drift_suite.py`
- `git fsck --full`