### PR TITLE
[codex] add agent runtime modernization audit and wave 1 plan

### DIFF
--- a/docs/delivery/README.md
+++ b/docs/delivery/README.md
@@ -13,6 +13,8 @@ These documents exist to make the delivery governance model more than a generic 
 - `03_slice_sizing_and_pr_strategy.md`
 - `04_review_triage_and_escalation.md`
 - `05_repo_drift_monitoring.md`
+- `plans/` - repo-local implementation planning artifacts for bounded delivery initiatives
+- `github_issue_drafts/` - draft GitHub issue bodies prepared from repo-local planning artifacts
 - `exemplars/PM-X1-ready-vs-blocked-example.md`
 - `exemplars/PM-X2-implementation-brief-example.md`
 

--- a/docs/delivery/github_issue_drafts/agent_runtime_modernization_umbrella.md
+++ b/docs/delivery/github_issue_drafts/agent_runtime_modernization_umbrella.md
@@ -1,0 +1,124 @@
+# GitHub Issue Draft
+
+## Suggested Title
+
+Agent Runtime Modernization: unify handoffs, runtime-managed execution, and the path to governed autonomy
+
+## Suggested Labels
+
+- `agent-runtime`
+- `delivery-infra`
+- `planning`
+- `umbrella`
+
+## Parent / Initiative
+
+- Initiative: `agent-runtime-modernization`
+- Linked audit: `docs/guides/agent_runtime_audit_2026-04-21.md`
+- Linked repo-local plan: `docs/delivery/plans/agent_runtime_modernization_plan.md`
+- Opened as: [#195](https://github.com/tomanizer/risk-manager/issues/195)
+
+## Body
+
+## Summary
+
+The repository currently has three partially overlapping delivery control planes:
+
+1. manual prompt-driven delivery via repo skills and `scripts/invoke.py`
+2. semi-autonomous supervision via `agent_runtime`
+3. an aspirational autonomous path via opt-in backends, LangGraph, parallel dispatch, post-merge hooks, and autonomy flags
+
+Manual invocation currently works best because it has the richest context and the clearest governance boundaries. The runtime path owns state and worktrees, but it does not yet own the full handoff contract. The automated path is not yet a real end-to-end operating mode.
+
+This issue tracks the modernization work needed to make those paths converge onto one authoritative runtime model.
+
+## Planning Rule
+
+This initiative should be planned by shared capability, not by `manual`, `semi-manual`, and `autonomous` as separate workstreams.
+
+Those three modes remain acceptance lenses on each capability:
+
+- manual
+- semi-manual
+- autonomous
+
+## Goals
+
+- unify prompt/context generation across manual and runtime flows
+- make runtime-managed checkout semantics correct for both fresh slices and PR-follow-up coding
+- ensure automated backends use governed role instructions
+- make runtime execution durable, replayable, and inspectable
+- improve the operator experience without weakening governance boundaries
+- create a credible path to governed autonomous execution
+
+## Non-Goals
+
+- replacing repo governance with a single unconstrained coding agent
+- enabling auto-merge before the runtime can ingest review and CI context properly
+- adding more orchestration framework before the handoff and state model are corrected
+
+## Proposed Wave Structure
+
+## Wave 1 - Foundations
+
+- shared handoff bundle and prompt/context unification
+- PR-follow-up checkout semantics for runtime-managed runs
+- governed role instructions for automated backends
+- run artifacts and append-only execution history
+
+## Wave 2 - Operator usability and runtime completeness
+
+- review/CI context ingestion
+- status and easier outcome recording
+- lifecycle side effects such as work-item stage mutation and post-merge hooks
+
+## Wave 3 - Governed autonomous execution
+
+- orchestration substrate decision and implementation
+- interrupt/resume model
+- event-driven triggers
+- guarded auto-promote and auto-merge
+- evaluation harness
+
+## Opened First-Wave Child Issues
+
+1. [#196](https://github.com/tomanizer/risk-manager/issues/196) `docs/delivery/github_issue_drafts/agent_runtime_modernization_wave1_01_shared_handoff_bundle.md`
+2. [#197](https://github.com/tomanizer/risk-manager/issues/197) `docs/delivery/github_issue_drafts/agent_runtime_modernization_wave1_02_pr_followup_checkout.md`
+3. [#198](https://github.com/tomanizer/risk-manager/issues/198) `docs/delivery/github_issue_drafts/agent_runtime_modernization_wave1_03_governed_automated_backends.md`
+4. [#199](https://github.com/tomanizer/risk-manager/issues/199) `docs/delivery/github_issue_drafts/agent_runtime_modernization_wave1_04_run_artifacts_and_history.md`
+
+## Why This Needs To Be Tracked As One Initiative
+
+Without an umbrella issue, this work risks becoming a set of disconnected fixes:
+
+- prompt cleanup
+- worktree fixes
+- backend tweaks
+- LangGraph experiments
+
+That would recreate the current problem: many partially overlapping control planes and no authoritative plan.
+
+## Definition Of Done For This Umbrella
+
+This umbrella closes only when:
+
+- the repo has one shared handoff/context contract used by manual and runtime flows
+- runtime-managed PR follow-up coding is branch-correct
+- automated backends run with governed role instructions
+- runtime executions have durable artifacts and meaningful run history
+- a clear Wave 2 and Wave 3 plan exists based on what was learned in Wave 1
+
+## Tracking Checklist
+
+- [x] approve repo-local plan structure
+- [x] open Wave 1 issue set
+- [x] convert the first dependency-wave issues into repo work items
+- [ ] complete Wave 1
+- [ ] re-plan Wave 2 based on actual runtime changes
+
+## Notes For PM / Issue Planner
+
+- Do not decompose this umbrella issue directly into coding work.
+- Use it to manage sequencing, dependencies, and closure criteria.
+- Each approved child issue should produce one or more bounded repo work items under `work_items/`.
+- Wave 1 `agent_runtime` modernization is tracked in `WI-MAINT-*` items, but implementation should stay manual-direct by default until the Wave 1 foundations are stable enough for selective self-hosting.

--- a/docs/delivery/github_issue_drafts/agent_runtime_modernization_umbrella.md
+++ b/docs/delivery/github_issue_drafts/agent_runtime_modernization_umbrella.md
@@ -14,8 +14,8 @@ Agent Runtime Modernization: unify handoffs, runtime-managed execution, and the 
 ## Parent / Initiative
 
 - Initiative: `agent-runtime-modernization`
-- Linked audit: `docs/guides/agent_runtime_audit_2026-04-21.md`
-- Linked repo-local plan: `docs/delivery/plans/agent_runtime_modernization_plan.md`
+- Linked audit: [agent_runtime_audit_2026-04-21.md](../../guides/agent_runtime_audit_2026-04-21.md)
+- Linked repo-local plan: [agent_runtime_modernization_plan.md](../plans/agent_runtime_modernization_plan.md)
 - Opened as: [#195](https://github.com/tomanizer/risk-manager/issues/195)
 
 ## Body

--- a/docs/delivery/github_issue_drafts/agent_runtime_modernization_wave1_01_shared_handoff_bundle.md
+++ b/docs/delivery/github_issue_drafts/agent_runtime_modernization_wave1_01_shared_handoff_bundle.md
@@ -1,0 +1,113 @@
+# GitHub Issue Draft
+
+## Suggested Title
+
+Wave 1: unify manual and runtime handoffs behind a shared handoff bundle
+
+## Suggested Labels
+
+- `agent-runtime`
+- `delivery-infra`
+- `wave-1`
+- `foundation`
+
+## Parent
+
+- Umbrella: [#195](https://github.com/tomanizer/risk-manager/issues/195)
+- Linked audit: `docs/guides/agent_runtime_audit_2026-04-21.md`
+- Opened as: [#196](https://github.com/tomanizer/risk-manager/issues/196)
+
+## Body
+
+## Problem
+
+The manual path and the runtime path currently build very different handoffs.
+
+Manual invocation through `skills/deliver-wi` and `scripts/invoke.py` resolves:
+
+- linked PRD paths
+- ADRs
+- scope
+- target area
+- out of scope
+- acceptance criteria
+- stop conditions
+
+The runtime path currently builds much thinner prompts that often contain only a work item id, a local path, and a short reason string.
+
+That means the path intended to become autonomous currently has weaker execution context than the manual path.
+
+## Why This Belongs In Wave 1
+
+This is the highest-leverage fix in the whole initiative. Better scheduling and more framework will not fix weak handoffs.
+
+## Scope
+
+- design one shared handoff bundle format used by:
+  - `skills/deliver-wi`
+  - `scripts/invoke.py`
+  - `agent_runtime --execute`
+  - automated backend dispatch paths
+- include repo-governed fields for:
+  - role
+  - execution checkout context
+  - linked PRD
+  - linked ADRs
+  - scope
+  - target area
+  - out of scope
+  - acceptance criteria
+  - stop conditions
+  - PR context when present
+- make the bundle serializable so it can be stored as a run artifact
+
+## Out Of Scope
+
+- changing runtime checkout semantics
+- review comment ingestion
+- orchestration framework migration
+
+## Dependencies
+
+- none; this is a Wave 1 foundation
+
+## Mode Impact
+
+### Manual
+
+- manual launcher and prompt generation stop using a separate, richer context path
+- manual runs gain the same structured artifact shape as runtime runs
+
+### Semi-Manual
+
+- `agent_runtime --execute` and `--dispatch` can emit complete, governed handoffs
+- humans stop reconstructing missing context by hand
+
+### Autonomous
+
+- automated backends receive a rich, consistent context contract instead of role-specific thin prompts
+
+## Acceptance Criteria
+
+- there is one shared handoff bundle builder in repo code
+- PM, coding, review, spec, and issue-planner handoffs can all be rendered from that builder
+- the runtime no longer relies on ad hoc thin prompt builders as the primary source of execution context
+- the bundle is durable enough to be written to a run artifact directory
+- at least one manual surface and one runtime surface are migrated to the shared builder
+
+## Evidence
+
+- `scripts/invoke.py`
+- `skills/deliver-wi/SKILL.md`
+- `agent_runtime/orchestrator/execution.py`
+- `agent_runtime/runners/pm_runner.py`
+- `agent_runtime/runners/review_runner.py`
+
+## Notes For Work-Item Decomposition
+
+Likely split:
+
+1. design the handoff bundle schema and renderer
+2. migrate manual prompt generation to the shared builder
+3. migrate runtime execution generation to the shared builder
+4. add tests proving parity for key fields across manual and runtime surfaces

--- a/docs/delivery/github_issue_drafts/agent_runtime_modernization_wave1_01_shared_handoff_bundle.md
+++ b/docs/delivery/github_issue_drafts/agent_runtime_modernization_wave1_01_shared_handoff_bundle.md
@@ -14,7 +14,7 @@ Wave 1: unify manual and runtime handoffs behind a shared handoff bundle
 ## Parent
 
 - Umbrella: [#195](https://github.com/tomanizer/risk-manager/issues/195)
-- Linked audit: `docs/guides/agent_runtime_audit_2026-04-21.md`
+- Linked audit: [agent_runtime_audit_2026-04-21.md](../../guides/agent_runtime_audit_2026-04-21.md)
 - Opened as: [#196](https://github.com/tomanizer/risk-manager/issues/196)
 
 ## Body

--- a/docs/delivery/github_issue_drafts/agent_runtime_modernization_wave1_02_pr_followup_checkout.md
+++ b/docs/delivery/github_issue_drafts/agent_runtime_modernization_wave1_02_pr_followup_checkout.md
@@ -1,0 +1,90 @@
+# GitHub Issue Draft
+
+## Suggested Title
+
+Wave 1: fix runtime-managed checkout semantics for PR-follow-up coding
+
+## Suggested Labels
+
+- `agent-runtime`
+- `delivery-infra`
+- `wave-1`
+- `foundation`
+
+## Parent
+
+- Umbrella: [#195](https://github.com/tomanizer/risk-manager/issues/195)
+- Linked audit: `docs/guides/agent_runtime_audit_2026-04-21.md`
+- Opened as: [#197](https://github.com/tomanizer/risk-manager/issues/197)
+
+## Body
+
+## Problem
+
+For work items with an existing PR, the runtime currently derives a `base_ref` from the PR head branch, but still creates a fresh coding branch for the run. That breaks PR-follow-up semantics.
+
+The result is that runtime-managed coding can open a clean new branch for a fresh slice, but it cannot cleanly continue work on an existing PR without branch divergence and manual recovery.
+
+## Why This Belongs In Wave 1
+
+This is a hard correctness issue for semi-manual and autonomous execution. The runtime cannot be trusted to repair an active PR if it is not operating on the authoritative PR branch.
+
+## Scope
+
+- define explicit runtime checkout modes:
+  - fresh slice from current `main`
+  - follow-up work on an existing PR head branch
+- update worktree allocation so PR-follow-up coding uses the correct authoritative branch model
+- persist checkout mode and branch intent in run metadata
+- add tests covering:
+  - fresh coding branch allocation
+  - PR-follow-up coding against an existing branch
+  - review worktree semantics
+
+## Out Of Scope
+
+- PR publication policy
+- auto-merge
+- broader lifecycle side effects
+
+## Dependencies
+
+- none; this is a Wave 1 foundation
+
+## Mode Impact
+
+### Manual
+
+- no direct operator-facing change, but it reduces the chance of runtime advice drifting from the real Git workflow
+
+### Semi-Manual
+
+- runtime-managed coding follow-ups can operate on the same branch as the active PR
+- operators no longer need to repair branch topology after a runtime follow-up
+
+### Autonomous
+
+- automated CI-fix and review-follow-up runs can safely continue existing PR work without inventing sibling branches
+
+## Acceptance Criteria
+
+- runtime metadata explicitly distinguishes new-slice and PR-follow-up checkouts
+- PR-follow-up coding runs operate on the authoritative PR branch rather than a new branch created from that PR branch
+- fresh-slice coding runs still create a clean feature branch from current `main`
+- worktree allocation tests cover both cases
+- runtime docs no longer imply behavior that the implementation does not provide
+
+## Evidence
+
+- `agent_runtime/orchestrator/execution.py`
+- `agent_runtime/orchestrator/worktree_manager.py`
+- `agent_runtime/manual_supervisor_workflow.md`
+- `agent_runtime/README.md`
+
+## Notes For Work-Item Decomposition
+
+Likely split:
+
+1. checkout-mode design and metadata changes
+2. worktree manager implementation changes
+3. tests and doc alignment

--- a/docs/delivery/github_issue_drafts/agent_runtime_modernization_wave1_02_pr_followup_checkout.md
+++ b/docs/delivery/github_issue_drafts/agent_runtime_modernization_wave1_02_pr_followup_checkout.md
@@ -14,7 +14,7 @@ Wave 1: fix runtime-managed checkout semantics for PR-follow-up coding
 ## Parent
 
 - Umbrella: [#195](https://github.com/tomanizer/risk-manager/issues/195)
-- Linked audit: `docs/guides/agent_runtime_audit_2026-04-21.md`
+- Linked audit: [agent_runtime_audit_2026-04-21.md](../../guides/agent_runtime_audit_2026-04-21.md)
 - Opened as: [#197](https://github.com/tomanizer/risk-manager/issues/197)
 
 ## Body

--- a/docs/delivery/github_issue_drafts/agent_runtime_modernization_wave1_03_governed_automated_backends.md
+++ b/docs/delivery/github_issue_drafts/agent_runtime_modernization_wave1_03_governed_automated_backends.md
@@ -14,7 +14,7 @@ Wave 1: make automated backends run with governed role instructions
 ## Parent
 
 - Umbrella: [#195](https://github.com/tomanizer/risk-manager/issues/195)
-- Linked audit: `docs/guides/agent_runtime_audit_2026-04-21.md`
+- Linked audit: [agent_runtime_audit_2026-04-21.md](../../guides/agent_runtime_audit_2026-04-21.md)
 - Opened as: [#198](https://github.com/tomanizer/risk-manager/issues/198)
 
 ## Body

--- a/docs/delivery/github_issue_drafts/agent_runtime_modernization_wave1_03_governed_automated_backends.md
+++ b/docs/delivery/github_issue_drafts/agent_runtime_modernization_wave1_03_governed_automated_backends.md
@@ -1,0 +1,89 @@
+# GitHub Issue Draft
+
+## Suggested Title
+
+Wave 1: make automated backends run with governed role instructions
+
+## Suggested Labels
+
+- `agent-runtime`
+- `delivery-infra`
+- `wave-1`
+- `foundation`
+
+## Parent
+
+- Umbrella: [#195](https://github.com/tomanizer/risk-manager/issues/195)
+- Linked audit: `docs/guides/agent_runtime_audit_2026-04-21.md`
+- Opened as: [#198](https://github.com/tomanizer/risk-manager/issues/198)
+
+## Body
+
+## Problem
+
+The OpenAI and Anthropic backends explicitly load governed system prompts. The `codex_exec` path, which is currently the most practical automation path, does not. It relies mostly on the thin `execution.prompt` body plus an output schema wrapper.
+
+That creates a governance gap: the more automated the runtime becomes, the less directly it is anchored to the canonical role instructions.
+
+There is also a prompt-loader gap for some roles: `issue_planner` and `drift_monitor` have runner classes but are not mapped in the governed prompt loader.
+
+## Why This Belongs In Wave 1
+
+If the runtime is going to automate PM, review, coding, spec, issue-planner, or drift-monitor work, it must do so with the governed role surfaces that justify the relay model in the first place.
+
+## Scope
+
+- ensure all automated backends run with governed role instructions
+- decide and implement how governed role instructions are supplied to `codex_exec`
+- close prompt-loader gaps for supported runner roles
+- align the spec role with the current canonical spec-authoring model rather than the legacy compatibility surface when appropriate
+- add tests proving governed prompt loading is applied consistently across supported automated backends
+
+## Out Of Scope
+
+- changing the substantive content of the role instructions
+- adding new automated roles beyond the current runner set
+
+## Dependencies
+
+- shared handoff bundle recommended, but backend-governance plumbing can begin before full bundle migration if needed
+
+## Mode Impact
+
+### Manual
+
+- manual mode remains the same in day-to-day use, but role alignment across modes improves
+
+### Semi-Manual
+
+- runtime-dispatched automated runs become more trustworthy because they remain role-constrained
+
+### Autonomous
+
+- the runtime can automate role execution without silently collapsing the repo's governance boundaries
+
+## Acceptance Criteria
+
+- `codex_exec` runs with governed role instructions in addition to task-specific execution context
+- OpenAI, Anthropic, and `codex_exec` backend behavior is aligned around the same role instruction source of truth
+- supported roles in the runtime have prompt-loader coverage
+- legacy-vs-current spec instruction mapping is an explicit decision rather than an accidental default
+- tests cover prompt loading for all supported automated roles
+
+## Evidence
+
+- `agent_runtime/runners/coding_backend.py`
+- `agent_runtime/runners/pm_backend.py`
+- `agent_runtime/runners/review_backend.py`
+- `agent_runtime/runners/openai_backend.py`
+- `agent_runtime/runners/anthropic_backend.py`
+- `agent_runtime/runners/prompt_loader.py`
+
+## Notes For Work-Item Decomposition
+
+Likely split:
+
+1. backend-governance contract design
+2. `codex_exec` prompt wrapping implementation
+3. prompt-loader role coverage and spec role alignment
+4. tests and documentation

--- a/docs/delivery/github_issue_drafts/agent_runtime_modernization_wave1_04_run_artifacts_and_history.md
+++ b/docs/delivery/github_issue_drafts/agent_runtime_modernization_wave1_04_run_artifacts_and_history.md
@@ -1,0 +1,96 @@
+# GitHub Issue Draft
+
+## Suggested Title
+
+Wave 1: add durable run artifacts and append-only execution history to `agent_runtime`
+
+## Suggested Labels
+
+- `agent-runtime`
+- `delivery-infra`
+- `wave-1`
+- `foundation`
+
+## Parent
+
+- Umbrella: [#195](https://github.com/tomanizer/risk-manager/issues/195)
+- Linked audit: `docs/guides/agent_runtime_audit_2026-04-21.md`
+- Opened as: [#199](https://github.com/tomanizer/risk-manager/issues/199)
+
+## Body
+
+## Problem
+
+The runtime currently persists useful state in SQLite, but the main operational model is still "latest known state per work item" rather than "durable history of executions with replayable artifacts".
+
+That makes it harder to:
+
+- debug retries
+- compare attempt N to attempt N+1
+- recover after backend failures
+- inspect exactly what context and backend output produced a decision
+
+## Why This Belongs In Wave 1
+
+Reliable automation depends on durable artifacts and run lineage. Without that, the runtime remains a convenient dispatcher rather than a trustworthy control plane.
+
+## Scope
+
+- define a durable run artifact layout under `.agent_runtime/`
+- persist per-run artifacts such as:
+  - rendered handoff bundle
+  - backend command metadata
+  - stdout/stderr where available
+  - parsed outcome payload
+  - key PR metadata snapshot where relevant
+- move toward append-only execution history keyed by `run_id`
+- keep a current-state projection for fast routing, but do not rely on it as the only history
+- add inspection commands or documented inspection queries for run history
+
+## Out Of Scope
+
+- automatic merge
+- event-driven orchestration framework changes
+- full review-comment ingestion if that requires a separate issue
+
+## Dependencies
+
+- shared handoff bundle strongly recommended
+
+## Mode Impact
+
+### Manual
+
+- manual runs can store and replay outcome artifacts instead of relying on shell-quoted summary flags only
+
+### Semi-Manual
+
+- runtime-managed runs become easier to inspect, compare, resume, and complete
+
+### Autonomous
+
+- automated runs gain the durable execution history required for replayability, observability, and policy-gated resume behavior
+
+## Acceptance Criteria
+
+- each runtime execution has a durable artifact directory keyed by `run_id`
+- the runtime persists enough information to reconstruct what was asked, what backend ran, and what came back
+- execution history is append-only at the run level even if a current-state view remains for routing
+- retry analysis across multiple runs for the same work item is possible without reading overwritten state only
+- documentation explains where operators inspect run artifacts
+
+## Evidence
+
+- `agent_runtime/storage/sqlite.py`
+- `agent_runtime/orchestrator/graph.py`
+- `agent_runtime/orchestrator/parallel_dispatch.py`
+- `agent_runtime/manual_supervisor_workflow.md`
+
+## Notes For Work-Item Decomposition
+
+Likely split:
+
+1. run artifact directory design
+2. append-only execution-history schema changes
+3. current-state projection updates
+4. inspection tooling and tests

--- a/docs/delivery/github_issue_drafts/agent_runtime_modernization_wave1_04_run_artifacts_and_history.md
+++ b/docs/delivery/github_issue_drafts/agent_runtime_modernization_wave1_04_run_artifacts_and_history.md
@@ -14,7 +14,7 @@ Wave 1: add durable run artifacts and append-only execution history to `agent_ru
 ## Parent
 
 - Umbrella: [#195](https://github.com/tomanizer/risk-manager/issues/195)
-- Linked audit: `docs/guides/agent_runtime_audit_2026-04-21.md`
+- Linked audit: [agent_runtime_audit_2026-04-21.md](../../guides/agent_runtime_audit_2026-04-21.md)
 - Opened as: [#199](https://github.com/tomanizer/risk-manager/issues/199)
 
 ## Body

--- a/docs/delivery/plans/agent_runtime_modernization_plan.md
+++ b/docs/delivery/plans/agent_runtime_modernization_plan.md
@@ -5,8 +5,8 @@
 - Initiative: `agent-runtime-modernization`
 - Status: Active
 - Owner: PM / Coordination Agent
-- Linked audit: `docs/guides/agent_runtime_audit_2026-04-21.md`
-- Linked repo-local template: `docs/delivery/plans/agent_runtime_modernization_plan_template.md`
+- Linked audit: [agent_runtime_audit_2026-04-21.md](../../guides/agent_runtime_audit_2026-04-21.md)
+- Linked repo-local template: [agent_runtime_modernization_plan_template.md](./agent_runtime_modernization_plan_template.md)
 - Linked umbrella issue: [#195](https://github.com/tomanizer/risk-manager/issues/195)
 - Last updated: `2026-04-21`
 

--- a/docs/delivery/plans/agent_runtime_modernization_plan.md
+++ b/docs/delivery/plans/agent_runtime_modernization_plan.md
@@ -1,0 +1,362 @@
+# Agent Runtime Modernization Plan
+
+## Document Status
+
+- Initiative: `agent-runtime-modernization`
+- Status: Active
+- Owner: PM / Coordination Agent
+- Linked audit: `docs/guides/agent_runtime_audit_2026-04-21.md`
+- Linked repo-local template: `docs/delivery/plans/agent_runtime_modernization_plan_template.md`
+- Linked umbrella issue: [#195](https://github.com/tomanizer/risk-manager/issues/195)
+- Last updated: `2026-04-21`
+
+## 1. Problem Statement
+
+The repository currently has three partially overlapping delivery control planes:
+
+1. manual prompt-driven delivery via `skills/deliver-wi/SKILL.md` and `scripts/invoke.py`
+2. semi-autonomous supervision via `agent_runtime`
+3. an aspirational autonomous path via opt-in backends, LangGraph, parallel dispatch, post-merge hooks, and autonomy flags
+
+Manual invocation currently works best because it has the richest execution context and the clearest governance boundaries. Semi-autonomous runtime mode owns state and worktrees, but it does not yet own the full handoff contract. Automated mode is not yet a real end-to-end operating mode; it is a set of useful but only partially integrated building blocks.
+
+The main modernization goal is not "more automation" in the abstract. The goal is to converge these three paths onto one authoritative runtime model for:
+
+- handoff and context generation
+- branch and worktree ownership
+- run artifact capture
+- PR/review/CI context ingestion
+- human gates and resume behavior
+- lifecycle side effects after coding, review, and merge
+
+## 2. Outcome Statement By Mode
+
+### Manual
+
+- Reduce operator ceremony without weakening governance boundaries.
+- Reuse the same handoff/context contract as the runtime.
+- Remove unnecessary copy/paste and shell-quoted state recording where practical.
+
+### Semi-Manual
+
+- Make `agent_runtime` handoffs complete enough that the human is no longer reconstructing execution context manually.
+- Make runtime-managed checkout semantics correct for both fresh coding slices and PR-follow-up coding.
+- Make runtime state, artifacts, and outcome recording practical to inspect and maintain.
+
+### Autonomous
+
+- Make runs resumable, observable, and policy-gated.
+- Preserve explicit human interrupts for repo update and merge decisions unless policy explicitly changes later.
+- Ensure automation remains governed by the repository's role-separation model rather than bypassing it.
+
+## 3. Non-Goals
+
+This initiative does not attempt to:
+
+- replace repo governance with a single unconstrained coding agent
+- enable auto-merge before review-context ingestion, post-merge hooks, and explicit merge policy gates are in place
+- introduce more parallelism before single-PR branch continuity is fixed
+- rewrite the runtime around LangChain abstractions before repo-native handoff and state problems are solved
+- treat GitHub issues as a substitute for repo-local work items
+
+## 4. Planning Rules
+
+The initiative is planned by shared capability, not by `manual`, `semi-manual`, and `autonomous` as separate workstreams.
+
+Those three modes remain acceptance lenses on each capability.
+
+Working rules:
+
+- keep this file as the repo-local source of truth for sequencing and dependencies
+- use GitHub issues for coordination and tracking, not as the canonical execution contract
+- decompose only the next dependency wave into bounded implementation work items
+- do not start Wave 2 or Wave 3 framework work until Wave 1 foundations are materially complete
+
+## 4A. Execution Policy For Runtime Modernization
+
+Wave 1 runtime-modernization slices are tracked in the normal repo backlog as `WI-MAINT-*` work items.
+
+That does not mean `agent_runtime` should be the default executor for its own modernization work during Wave 1.
+
+Execution policy for this initiative:
+
+- track `agent_runtime` and repo-maintenance modernization slices in `work_items/` using the `WI-MAINT-*` convention
+- execute Wave 1 `agent_runtime` modernization slices in manual direct mode by default
+- do not use runtime-managed checkout/worktree execution as the default path for runtime-internal changes until the Wave 1 foundations are materially complete
+- allow selective self-hosting experiments only after the relevant foundation is stable enough that failures can be attributed clearly to code rather than orchestration ambiguity
+
+Rationale:
+
+- checkout semantics are themselves under repair in Wave 1
+- handoff and prompt context are themselves under repair in Wave 1
+- run artifact and execution-history behavior are themselves under repair in Wave 1
+
+Using the runtime as the default executor for those same changes too early would create bootstrap ambiguity and make failures harder to diagnose.
+
+## 5. Capability Tracks
+
+| Capability | Problem It Solves | Manual Impact | Semi-Manual Impact | Autonomous Impact | Primary Owner | Depends On | GitHub Tracking |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| Shared handoff bundle | Runtime handoffs are thinner than manual/script-driven prompts | High | High | High | PM for contract, Coding for implementation | None | [#196](https://github.com/tomanizer/risk-manager/issues/196) |
+| PR-follow-up checkout semantics | Runtime follow-up coding forks onto a new branch instead of continuing the PR head | None | High | High | Coding Agent | None | [#197](https://github.com/tomanizer/risk-manager/issues/197) |
+| Governed automated backends | `codex_exec` does not use the governed role instructions consistently | Low | High | High | Coding Agent with PM review | Shared handoff bundle recommended | [#198](https://github.com/tomanizer/risk-manager/issues/198) |
+| Run artifacts and append-only execution history | Runtime keeps last-known state better than full run lineage | Medium | High | High | Coding Agent | Shared handoff bundle recommended | [#199](https://github.com/tomanizer/risk-manager/issues/199) |
+| Review/CI context ingestion | Automated review sees too little of the real PR state | Low | Medium | High | Coding Agent with Review input | Shared handoff bundle, run artifacts | Future Wave 2 issue |
+| Lifecycle side effects | Work item stage mutation and post-merge hooks exist but are not wired | Medium | Medium | High | Coding Agent with PM input | Run artifacts | Future Wave 2 issue |
+| Orchestration substrate decision | Custom loop, parallel dispatch, and LangGraph prototypes coexist without a chosen path | Low | Medium | High | PM / Spec decision, then Coding | Wave 1 foundations | Future Wave 3 issue |
+
+## 6. Wave Plan
+
+## Wave 1 - Foundations
+
+### Purpose
+
+Create the runtime foundations required before operator-usability polish or autonomous orchestration framework work makes sense.
+
+### In Scope
+
+- shared handoff bundle and prompt/context unification
+- PR-follow-up checkout semantics for runtime-managed runs
+- governed role instructions for automated backends
+- run artifacts and append-only execution history
+
+### Entry Criteria
+
+- audit accepted as the baseline
+- repo-local plan approved
+- umbrella issue approved
+- no attempt to solve runtime quality primarily by adding framework
+
+### Exit Criteria
+
+- runtime handoff quality matches or exceeds manual invocation quality for PM, coding, and review
+- PR-follow-up coding can operate on the authoritative PR head branch without branch forking
+- automated backends run with governed role instructions and explicit execution context
+- each runtime execution has durable run artifacts and replayable history
+
+## Wave 2 - Operator Usability And Runtime Completeness
+
+### Purpose
+
+Make the runtime practical to operate day to day once the foundations are trustworthy.
+
+### In Scope
+
+- review/CI context ingestion
+- status and easier outcome recording
+- lifecycle side effects such as work-item stage mutation and post-merge hooks
+
+### Exit Criteria
+
+- semi-manual runtime operation no longer depends on shell-quoted JSON and ad hoc context recovery
+- review and coding follow-up runs have enough PR context to be first-class runtime operations
+- runtime-managed lifecycle side effects are explicit, durable, and policy-bound
+
+## Wave 3 - Governed Autonomous Execution
+
+### Purpose
+
+Choose and implement the runtime's long-term orchestration substrate after the foundational state, context, and artifact model are correct.
+
+### In Scope
+
+- orchestration substrate decision and implementation
+- interrupt/resume model
+- event-driven triggers
+- guarded auto-promote and auto-merge
+- evaluation and replay harness
+
+### Exit Criteria
+
+- unattended bounded runtime loops are resumable and observable
+- human gates remain explicit and auditable
+- autonomy is policy-gated rather than implicit
+
+## 7. Wave 1 Exact Issue Set
+
+The approved Wave 1 issue set is:
+
+1. [#196](https://github.com/tomanizer/risk-manager/issues/196) Shared handoff bundle and prompt/context unification
+2. [#197](https://github.com/tomanizer/risk-manager/issues/197) PR-follow-up checkout semantics for runtime-managed runs
+3. [#198](https://github.com/tomanizer/risk-manager/issues/198) Governed role instructions for automated backends
+4. [#199](https://github.com/tomanizer/risk-manager/issues/199) Run artifacts and append-only execution history
+
+These four issues should all be opened at the GitHub level for visibility, but implementation should begin only on the first dependency pair before decomposing the remainder into detailed work items.
+
+## 8. Wave 1 Dependency Order
+
+### Order Of Work
+
+1. Approve repo-local plan.
+2. Open the umbrella issue.
+3. Open the four Wave 1 child issues.
+4. Decompose only issues 1 and 2 into repo work items first.
+5. Implement issue 1 and issue 2.
+6. Re-run PM / Issue Planner on issues 3 and 4 using what changed in issues 1 and 2.
+7. Decompose and implement issues 3 and 4.
+
+Current status on `2026-04-21`:
+
+- repo-local plan instantiated
+- umbrella issue opened as [#195](https://github.com/tomanizer/risk-manager/issues/195)
+- Wave 1 child issues opened as [#196](https://github.com/tomanizer/risk-manager/issues/196), [#197](https://github.com/tomanizer/risk-manager/issues/197), [#198](https://github.com/tomanizer/risk-manager/issues/198), and [#199](https://github.com/tomanizer/risk-manager/issues/199)
+- issues [#196](https://github.com/tomanizer/risk-manager/issues/196) and [#197](https://github.com/tomanizer/risk-manager/issues/197) materialized into repo work items
+
+### Why This Order
+
+- Issue 1 defines the shared handoff contract that later automation should consume.
+- Issue 2 fixes a correctness bug in runtime-managed execution.
+- Issue 3 should not be finalized until the runtime has a stronger shared handoff contract.
+- Issue 4 benefits from the artifact shape chosen for issue 1 and should not force a premature storage model before the handoff bundle is defined.
+
+## 9. Practical Concurrency Guidance
+
+Wave 1 should not be executed as four simultaneous coding efforts.
+
+Recommended concurrency:
+
+- Planning phase:
+  - open umbrella and all four child issues in parallel after plan approval
+- Coding phase:
+  - issues 1 and 2 may be explored in parallel
+  - issue 1 should land its bundle/interface contract before issue 3 is fully implemented
+  - issue 4 schema/artifact design can be explored in parallel, but final implementation should follow the handoff bundle contract
+
+Practical rule:
+
+- parallelize design and investigation where write scopes are disjoint
+- sequence merges where one issue defines the contract another issue consumes
+
+## 10. Recommended Repo Work-Item Conversion Policy
+
+GitHub issues are coordination artifacts. Repo work items are execution artifacts.
+
+When a GitHub issue is approved for implementation:
+
+1. Create or update corresponding bounded work items under `work_items/`.
+2. Use `WI-MAINT-*` style identifiers for runtime/delivery-infrastructure work unless the PM agent chooses a different governed convention.
+3. Carry over:
+   - purpose
+   - scope
+   - out of scope
+   - dependencies
+   - target area
+   - acceptance criteria
+   - review focus
+4. Keep each work item bounded enough for one reviewable PR.
+
+### Recommended Initial Conversion
+
+Convert only the following first:
+
+- Issue [#196](https://github.com/tomanizer/risk-manager/issues/196) into 2-3 work items
+- Issue [#197](https://github.com/tomanizer/risk-manager/issues/197) into 1-2 work items
+
+Do not convert issues 3 and 4 into detailed work items until issues 1 and 2 have landed or at least stabilized their contracts.
+
+Materialized work items on `2026-04-21`:
+
+- [WI-MAINT-2A](../../../work_items/ready/WI-MAINT-2A-shared-handoff-bundle-contract.md) - ready
+- [WI-MAINT-2B](../../../work_items/blocked/WI-MAINT-2B-runtime-shared-handoff-migration.md) - blocked on `WI-MAINT-2A`
+- [WI-MAINT-2C](../../../work_items/blocked/WI-MAINT-2C-manual-handoff-surface-parity.md) - blocked on `WI-MAINT-2A` and `WI-MAINT-2B`
+- [WI-MAINT-3A](../../../work_items/ready/WI-MAINT-3A-runtime-pr-followup-checkout-semantics.md) - ready
+
+## 11. Suggested Wave 1 Work-Item Granularity
+
+The following is a planning estimate, not a fixed decomposition.
+
+### Issue 1 - Shared handoff bundle
+
+Expected decomposition:
+
+- one work item for bundle schema and rendering contract
+- one work item for runtime migration to the shared builder
+- one work item for manual/script surface migration and parity tests
+
+### Issue 2 - PR-follow-up checkout semantics
+
+Expected decomposition:
+
+- one work item for checkout-mode model and worktree-manager implementation
+- optional second work item for follow-up doc/test hardening if the first PR gets too broad
+
+### Issue 3 - Governed automated backends
+
+Expected decomposition after Wave 1 midpoint:
+
+- one work item for `codex_exec` governed prompt plumbing
+- one optional work item for role coverage and spec-role alignment if needed
+
+### Issue 4 - Run artifacts and history
+
+Expected decomposition after Wave 1 midpoint:
+
+- one work item for run artifact directory and persisted outputs
+- one work item for append-only execution history / current-state projection updates
+
+## 12. Acceptance Matrix By Mode
+
+| Capability | Manual Done When | Semi-Manual Done When | Autonomous Done When |
+| --- | --- | --- | --- |
+| Shared handoff bundle | Manual launcher uses the same bundle as runtime | `--execute` and `--dispatch` emit the full bundle | Automated backends consume the same bundle directly |
+| PR-follow-up checkout semantics | Manual guidance stays aligned to real checkout policy | Existing PR follow-up uses the PR head branch | Autonomous repair runs stay on the authoritative PR branch |
+| Governed automated backends | Manual role boundaries stay aligned with automated role boundaries | `codex_exec` uses governed role instructions | All automated backends use governed role instructions |
+| Run artifacts and history | Manual runs can write/read outcome artifacts | Every runtime run has durable artifacts | Autonomous loops can replay, resume, and audit runs reliably |
+
+## 13. Risks And Open Questions
+
+### Risks
+
+- the runtime may need a new execution-record model rather than small changes to `workflow_runs`
+- GitHub review and CI ingestion may require deeper `gh` or GraphQL plumbing than the current sync layer supports
+- handoff-bundle migration may touch both runtime and manual surfaces at once, which raises coordination risk
+- issue 2 may uncover broader assumptions in branch naming and PR publication logic
+
+### Open Questions
+
+- should the long-term run record live primarily in SQLite, filesystem artifacts, or a hybrid of both
+- should `codex_exec` receive governed instructions via a true system surface if available, or via a wrapped user prompt if not
+- should the spec runner continue to represent "gap resolution" only, or be renamed and aligned explicitly with the PRD / Spec Author role
+- after Wave 1, is the correct orchestration substrate still the custom loop, or should the runtime move to LangGraph for interrupt/resume and fan-out semantics
+
+## 14. Decision Log
+
+| Date | Decision | Reason | Consequence |
+| --- | --- | --- | --- |
+| `2026-04-21` | Plan by shared capability rather than by operating mode | The main problems are cross-cutting and already duplicated across control planes | Issue tree and work items stay aligned to reusable foundations |
+| `2026-04-21` | Treat Wave 1 as a foundations wave, not an autonomy-framework wave | Better scheduling does not fix weak handoffs or incorrect branch semantics | LangGraph and broader autonomy stay out of Wave 1 coding scope |
+| `2026-04-21` | Open all four Wave 1 issues, but decompose only the first dependency pair first | This keeps visibility high while preventing front-loaded backlog sprawl | Work-item creation stays bounded and adaptive |
+
+## 15. Immediate Execution Plan
+
+### Next Step
+
+Run a PM / readiness pass for [WI-MAINT-2A](../../../work_items/ready/WI-MAINT-2A-shared-handoff-bundle-contract.md) and [WI-MAINT-3A](../../../work_items/ready/WI-MAINT-3A-runtime-pr-followup-checkout-semantics.md), then start coding on the selected first slice.
+
+### After Issue Creation
+
+Completed on `2026-04-21`:
+
+- issue [#196](https://github.com/tomanizer/risk-manager/issues/196) materialized into `WI-MAINT-2A`, `WI-MAINT-2B`, and `WI-MAINT-2C`
+- issue [#197](https://github.com/tomanizer/risk-manager/issues/197) materialized into `WI-MAINT-3A`
+
+Do not yet create detailed work items for issues [#198](https://github.com/tomanizer/risk-manager/issues/198) and [#199](https://github.com/tomanizer/risk-manager/issues/199).
+
+### First Coding Sequence
+
+1. shared handoff bundle contract and renderer
+2. runtime checkout-mode and PR-follow-up branch correctness
+3. backend governance plumbing against the new bundle contract
+4. durable run artifacts and append-only execution history
+
+## 16. Change Control
+
+Update this plan when:
+
+- a wave boundary changes
+- a dependency assumption changes
+- a capability is split or merged
+- the chosen orchestration direction changes
+- the issue-to-work-item strategy changes materially
+
+Do not update this plan merely to mirror day-to-day status noise.

--- a/docs/delivery/plans/agent_runtime_modernization_plan_template.md
+++ b/docs/delivery/plans/agent_runtime_modernization_plan_template.md
@@ -1,0 +1,198 @@
+# Agent Runtime Modernization Plan Template
+
+## Document Status
+
+- Initiative: `agent-runtime-modernization`
+- Status: Draft
+- Owner: PM / Coordination Agent
+- Linked audit: `docs/guides/agent_runtime_audit_2026-04-21.md`
+- Linked umbrella issue: `<GitHub issue URL or number>`
+- Last updated: `<YYYY-MM-DD>`
+
+## How To Use This Template
+
+Use this document as the canonical repo-local implementation plan for a multi-issue delivery initiative.
+
+Rules:
+
+- Keep this file as the source of truth for sequencing, scope boundaries, and dependencies.
+- Use GitHub issues for coordination and status, not as the only planning surface.
+- Decompose only the next dependency wave into implementation issues and work items.
+- Treat `manual`, `semi-manual`, and `autonomous` as acceptance lenses on each capability, not as separate workstreams.
+
+## 1. Problem Statement
+
+Summarize the current problem in one or two paragraphs:
+
+- what is broken today
+- why the current workflow is cumbersome
+- why this initiative matters now
+
+For `agent_runtime`, the current baseline is:
+
+- manual invocation works best because it has the richest handoff context
+- semi-autonomous runtime mode owns state and worktrees but not the full handoff contract
+- automated mode is not yet a real end-to-end operating mode
+
+## 2. Outcome Statement By Mode
+
+Define the target outcome for each operating mode.
+
+### Manual
+
+- Reduce operator ceremony without weakening governance boundaries.
+- Reuse the same handoff/context contract as the runtime.
+
+### Semi-Manual
+
+- Make `agent_runtime` handoffs complete enough that the human is no longer stitching together context manually.
+- Make branch/worktree ownership and outcome recording reliable.
+
+### Autonomous
+
+- Make runs resumable, observable, and policy-gated.
+- Preserve explicit human interrupts for repo update and merge decisions unless policy explicitly changes.
+
+## 3. Non-Goals
+
+List the things this initiative will not do.
+
+Suggested starting non-goals:
+
+- replacing repo governance with a single all-purpose coding agent
+- enabling auto-merge before review-context ingestion and post-merge hooks are wired
+- introducing parallelism before single-PR branch continuity is fixed
+- rewriting the runtime around LangChain abstractions without first fixing repo-native handoff and state problems
+
+## 4. Capability Tracks
+
+Plan by shared capability, not by operating mode.
+
+| Capability | Problem It Solves | Manual Impact | Semi-Manual Impact | Autonomous Impact | Depends On | GitHub Issue | Repo Work Items |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| Shared handoff bundle | Runtime handoffs are thinner than manual/script-driven prompts | High | High | High | None | `<issue>` | `<WI(s)>` |
+| PR-follow-up checkout semantics | Runtime follow-up coding forks onto a new branch instead of continuing the PR head | None | High | High | None | `<issue>` | `<WI(s)>` |
+| Governed prompts for automated backends | `codex_exec` does not use the governed role instructions | Low | High | High | Shared handoff bundle | `<issue>` | `<WI(s)>` |
+| Run artifacts and append-only execution history | The runtime keeps last-known state better than full run lineage | Medium | High | High | Shared handoff bundle | `<issue>` | `<WI(s)>` |
+| Review/CI context ingestion | Automated review sees too little of the real PR state | Low | Medium | High | Shared handoff bundle, run artifacts | `<issue>` | `<WI(s)>` |
+| Lifecycle side effects | Work item stage mutation and post-merge hooks exist but are not wired | Medium | Medium | High | Run artifacts | `<issue>` | `<WI(s)>` |
+| Orchestration substrate decision | The runtime has custom loop, parallel dispatch, and LangGraph prototypes with no single chosen path | Low | Medium | High | Foundations above | `<issue>` | `<WI(s)>` |
+
+## 5. Wave Plan
+
+Sequence by dependency.
+
+## Wave 1 - Foundations
+
+Entry criteria:
+
+- audit reviewed
+- umbrella issue approved
+- no attempt to solve autonomy by framework swap alone
+
+Target capabilities:
+
+- shared handoff bundle
+- PR-follow-up checkout semantics
+- governed prompts for automated backends
+- run artifacts and append-only execution history
+
+Exit criteria:
+
+- runtime handoff quality matches or exceeds manual invocation quality for PM, coding, and review
+- PR follow-up coding can operate on the PR head branch without branch forking
+- automated backends run with governed role instructions
+- each execution has durable run artifacts and replayable history
+
+## Wave 2 - Operator Usability And Runtime Completeness
+
+Target capabilities:
+
+- review/CI context ingestion
+- status and easier outcome recording
+- lifecycle side effects
+
+Exit criteria:
+
+- semi-manual runtime operation no longer depends on shell-quoted JSON and ad hoc context recovery
+- review and coding follow-up runs have the context they need
+
+## Wave 3 - Autonomous Execution
+
+Target capabilities:
+
+- orchestration substrate decision and implementation
+- event-driven triggers
+- interrupt/resume model
+- guarded auto-promote and auto-merge
+- evaluation harness
+
+Exit criteria:
+
+- unattended bounded runtime loops are resumable and observable
+- human gates are explicit and auditable
+
+## 6. Current Recommended Issue Breakdown
+
+Use this section to map the current initiative to concrete issue drafts.
+
+Wave 1 recommended issue set:
+
+1. Shared handoff bundle and prompt/context unification
+2. PR-follow-up checkout semantics for runtime-managed runs
+3. Governed role instructions for automated backends
+4. Run artifacts and append-only execution history
+
+## 7. Acceptance Matrix By Mode
+
+Use this table to keep mode goals visible without splitting the backlog by mode.
+
+| Capability | Manual Done When | Semi-Manual Done When | Autonomous Done When |
+| --- | --- | --- | --- |
+| Shared handoff bundle | Manual launcher uses the same bundle as runtime | `--execute` and `--dispatch` emit the full bundle | Automated backends consume the same bundle directly |
+| PR-follow-up checkout semantics | N/A | Existing PR follow-up uses PR head branch | Autonomous repair runs stay on the authoritative PR branch |
+| Governed automated backends | N/A | `codex_exec` uses governed role instructions | All automated backends use governed role instructions |
+| Run artifacts and history | Manual runs can write/read outcome artifacts | Every runtime run has durable artifacts | Autonomous loops can replay, resume, and audit runs reliably |
+
+## 8. Risks And Open Questions
+
+Track the material planning risks here.
+
+Suggested starting risks:
+
+- the runtime may need a new execution-record model rather than small changes to `workflow_runs`
+- GitHub review and CI ingestion may require deeper `gh` or GraphQL plumbing than the current sync layer
+- LangGraph may help with orchestration, but adopting it before the run contract is cleaned up could freeze the wrong abstractions
+
+## 9. Decision Log
+
+Record planning decisions in short entries.
+
+| Date | Decision | Reason | Consequence |
+| --- | --- | --- | --- |
+| `<YYYY-MM-DD>` | Plan by shared capability rather than by mode | The main problems are cross-cutting | Issues and work items stay aligned to reusable foundations |
+
+## 10. Issue-To-Work-Item Conversion Rule
+
+When a GitHub issue is approved for implementation:
+
+1. Create or update the corresponding repo work item under `work_items/`.
+2. Carry over:
+   - scope
+   - out of scope
+   - dependencies
+   - target area
+   - acceptance criteria
+   - review focus
+3. Do not treat the GitHub issue body as a substitute for the work item.
+
+## 11. Change Control
+
+Update this plan when:
+
+- a wave boundary changes
+- a dependency assumption changes
+- a capability is split or merged
+- a chosen orchestration direction changes
+
+Do not update this plan merely to mirror day-to-day status noise.

--- a/docs/delivery/plans/agent_runtime_modernization_plan_template.md
+++ b/docs/delivery/plans/agent_runtime_modernization_plan_template.md
@@ -5,7 +5,7 @@
 - Initiative: `agent-runtime-modernization`
 - Status: Draft
 - Owner: PM / Coordination Agent
-- Linked audit: `docs/guides/agent_runtime_audit_2026-04-21.md`
+- Linked audit: `<path to audit document>`
 - Linked umbrella issue: `<GitHub issue URL or number>`
 - Last updated: `<YYYY-MM-DD>`
 

--- a/docs/guides/agent_runtime_audit_2026-04-21.md
+++ b/docs/guides/agent_runtime_audit_2026-04-21.md
@@ -50,7 +50,7 @@ Result:
 
 ## Current State By Operating Mode
 
-## 1. Manual Invocation Mode
+### 1. Manual Invocation Mode
 
 ### What is working
 
@@ -73,7 +73,7 @@ Result:
 
 Manual mode is currently the highest-quality path, but it does not scale operationally. The repo should keep its governance discipline while removing the prompt-copying and state-recording friction.
 
-## 2. Semi-Autonomous Runtime Mode
+### 2. Semi-Autonomous Runtime Mode
 
 ### What is working
 
@@ -98,7 +98,7 @@ Manual mode is currently the highest-quality path, but it does not scale operati
 
 This mode is currently a coordination bridge, not a convincing operating model. It owns state and worktrees, but not the full handoff contract.
 
-## 3. Automated Mode
+### 3. Automated Mode
 
 ### What is present
 
@@ -125,7 +125,7 @@ The repo does not yet have an automated delivery system. It has automation ingre
 
 ## Highest-Impact Findings
 
-## Finding 1: The manual and runtime paths use different handoff quality
+### Finding 1: The manual and runtime paths use different handoff quality
 
 The manual path resolves rich context from templates and repo artifacts in `scripts/invoke.py`, including WI sections, PRD path resolution, ADR lookup, and placeholder filling. The runtime path uses much thinner prompt builders in `agent_runtime/orchestrator/execution.py`, `agent_runtime/runners/pm_runner.py`, and `agent_runtime/runners/review_runner.py`.
 
@@ -164,7 +164,7 @@ That shared builder should produce:
 - PR context
 - review comments and CI context when relevant
 
-## Finding 2: PR-follow-up coding currently allocates a new branch instead of continuing on the PR head
+### Finding 2: PR-follow-up coding currently allocates a new branch instead of continuing on the PR head
 
 `build_runner_execution()` sets `base_ref` to `origin/<pull_request.head_ref_name>` when a PR exists, but `allocate_worktree()` always creates a new branch with `git worktree add -b <new-branch> ... <base_ref>`.
 
@@ -187,7 +187,7 @@ Recommendation:
 - persist `checkout_mode` explicitly in the run metadata
 - make PR-follow-up coding impossible to dispatch unless the runtime can prove it is operating on the PR head branch
 
-## Finding 3: `codex_exec` backends do not use the governed system prompts
+### Finding 3: `codex_exec` backends do not use the governed system prompts
 
 The OpenAI and Anthropic backends explicitly load `load_system_prompt()` and send it as a system message. The `codex_exec` backends only pass `execution.prompt` plus an output schema wrapper.
 
@@ -210,7 +210,7 @@ Recommendation:
 - if the CLI supports a real system-prompt surface, use it
 - if not, prepend a clearly delimited governed instruction block and record it with the run artifact
 
-## Finding 4: Review automation does not ingest the information a real review needs
+### Finding 4: Review automation does not ingest the information a real review needs
 
 `agent_runtime/orchestrator/github_sync.py` ingests:
 
@@ -247,7 +247,7 @@ Recommendation:
   - diff stats and changed-file list
 - store that context in a run artifact, not only in memory
 
-## Finding 5: The spec role is still wired to the legacy instruction file
+### Finding 5: The spec role is still wired to the legacy instruction file
 
 `prompt_loader.py` maps `RunnerName.SPEC` to `prompts/agents/risk_methodology_spec_agent_instruction.md`, while `AGENTS.md` says that legacy role is retained only for backward compatibility and the responsibilities are now covered by the PRD / Spec Author.
 
@@ -262,7 +262,7 @@ Recommendation:
   - `prd_author`
 - do not keep the runtime on a legacy prompt surface if autonomous use is the goal
 
-## Finding 6: Several autonomy features exist but are not wired into the actual runtime path
+### Finding 6: Several autonomy features exist but are not wired into the actual runtime path
 
 Examples:
 
@@ -282,7 +282,7 @@ Recommendation:
 - either wire these features into the real loop or explicitly demote them to experimental status
 - avoid shipping autonomy flags before the side effects exist
 
-## Finding 7: The run model is still last-known-state oriented, not run-history oriented
+### Finding 7: The run model is still last-known-state oriented, not run-history oriented
 
 `workflow_runs` is keyed by `work_item_id`, so the table stores the latest state for each work item rather than a full run lineage. There is an event table, but it is not the main operational source of truth.
 
@@ -306,7 +306,7 @@ Recommendation:
   - outcome payload
   - PR metadata snapshot
 
-## Finding 8: The operator UX is fragmented across skill, script, runtime, and repo docs
+### Finding 8: The operator UX is fragmented across skill, script, runtime, and repo docs
 
 The operator currently has to combine:
 

--- a/docs/guides/agent_runtime_audit_2026-04-21.md
+++ b/docs/guides/agent_runtime_audit_2026-04-21.md
@@ -1,0 +1,662 @@
+# Agent Runtime Audit - 2026-04-21
+
+## Executive Summary
+
+The main problem is not that the repository lacks agent logic. It is that the repository currently has three partially overlapping control planes:
+
+1. manual prompt-driven delivery via `skills/deliver-wi/SKILL.md` and `scripts/invoke.py`
+2. semi-autonomous supervision via `agent_runtime`
+3. an aspirational autonomous path via opt-in backends, LangGraph, parallel dispatch, post-merge hooks, and autonomy flags
+
+These three modes do not share one authoritative prompt builder, one authoritative run model, or one authoritative branch/session ownership model.
+
+That fragmentation explains the current operator experience:
+
+- manual invocation works best because it has the richest context and the clearest governance boundaries
+- semi-autonomous mode feels cumbersome because it automates worktree/state plumbing but still leaves the human doing session launch, context stitching, and outcome recording
+- automated mode is not a real end-to-end operating mode yet; it is a collection of useful building blocks plus a few unwired prototypes
+
+The runtime can get close to autonomous use, but only if it stops being "a poll loop plus subprocesses" and becomes the single authoritative controller for:
+
+- prompt/context assembly
+- branch/worktree ownership
+- run artifact capture
+- PR feedback ingestion
+- human gates and resume points
+- lifecycle side effects after coding/review/merge
+
+## Scope And Evidence
+
+This audit reviewed:
+
+- `agent_runtime/README.md`
+- `agent_runtime/manual_supervisor_workflow.md`
+- `agent_runtime/orchestrator/*.py`
+- `agent_runtime/runners/*.py`
+- `agent_runtime/storage/*.py`
+- `agent_runtime/config/*.py`
+- `skills/deliver-wi/SKILL.md`
+- `scripts/invoke.py`
+- relevant guide and prompt files under `docs/guides/` and `prompts/agents/`
+
+Validation performed:
+
+- `python -m agent_runtime --help`
+- `python -m pytest agent_runtime/tests/test_autonomous_loop.py agent_runtime/tests/test_supervisor_loop.py agent_runtime/tests/test_parallel_dispatch.py agent_runtime/tests/test_langgraph_readiness.py agent_runtime/tests/test_openai_backend.py -q`
+
+Result:
+
+- targeted runtime tests passed: `57 passed`
+
+## Current State By Operating Mode
+
+## 1. Manual Invocation Mode
+
+### What is working
+
+- The manual path is the best-governed path today.
+- `skills/deliver-wi/SKILL.md` forces a fresh session boundary and explicit role separation.
+- `scripts/invoke.py` resolves work-item sections, PRD paths, ADRs, and template placeholders into a much richer handoff than the runtime currently produces.
+- The manual mode keeps the human in the loop at the right places: scope validation, branch creation, review interpretation, and merge judgment.
+
+### What is painful
+
+- It is copy/paste heavy by design.
+- It requires repeated session switching across PM, coding, review, and drift roles.
+- The operator has to remember freshness, branch setup, prompt generation, and outcome bookkeeping as separate steps.
+- It creates duplicated ceremony:
+  - skill-driven prompt building
+  - script-driven prompt building
+  - runtime-driven prompt building
+
+### Assessment
+
+Manual mode is currently the highest-quality path, but it does not scale operationally. The repo should keep its governance discipline while removing the prompt-copying and state-recording friction.
+
+## 2. Semi-Autonomous Runtime Mode
+
+### What is working
+
+- The transition engine is coherent and deterministic.
+- Worktree leasing is a strong foundation.
+- SQLite-backed run state, worktree leases, telemetry, and supervisor heartbeat are useful.
+- The PM, review, spec, coding, issue-planner, and drift-monitor roles are represented explicitly.
+- The runtime already knows how to route ready items, open PRs, review-required PRs, failing CI PRs, backlog-materialization cases, and PRD bootstrap cases.
+
+### What is not working
+
+- The runtime automates scheduling more than execution quality.
+- It knows what role should run next, but it does not yet assemble the same quality of context that the manual path provides.
+- It still assumes a human will:
+  - open the worktree
+  - start a new session
+  - paste the prompt
+  - inspect the answer
+  - record the outcome back into SQLite
+
+### Assessment
+
+This mode is currently a coordination bridge, not a convincing operating model. It owns state and worktrees, but not the full handoff contract.
+
+## 3. Automated Mode
+
+### What is present
+
+- optional `codex_exec` backends
+- OpenAI and Anthropic structured-output backends for PM/spec/review
+- LangGraph prototype
+- parallel dispatch prototype
+- post-merge hook implementation
+- draft PR publication
+- autonomy flags in config
+
+### What is missing
+
+- one real CLI path for autonomous execution
+- one integrated state machine for dispatch, wait, human interrupt, resume, and side effects
+- branch continuity for PR-follow-up coding
+- automatic review-comment and CI-log ingestion
+- automatic work-item stage mutation
+- actual use of `auto_merge`, `auto_promote_wi`, `run_parallel_step`, or `run_post_merge_hooks`
+
+### Assessment
+
+The repo does not yet have an automated delivery system. It has automation ingredients. That is an important distinction.
+
+## Highest-Impact Findings
+
+## Finding 1: The manual and runtime paths use different handoff quality
+
+The manual path resolves rich context from templates and repo artifacts in `scripts/invoke.py`, including WI sections, PRD path resolution, ADR lookup, and placeholder filling. The runtime path uses much thinner prompt builders in `agent_runtime/orchestrator/execution.py`, `agent_runtime/runners/pm_runner.py`, and `agent_runtime/runners/review_runner.py`.
+
+Observed impact:
+
+- manual prompts contain actual scope, target files, out-of-scope, acceptance criteria, and stop conditions
+- runtime prompts often contain only work item id, local path, PR number, or a short reason string
+- the mode that should become autonomous is currently the mode with the weakest context
+
+Why it matters:
+
+- this is the clearest reason manual invocation performs better than semi-autonomous execution
+- better scheduling will not fix weaker handoffs
+
+Recommendation:
+
+- replace all ad hoc runtime prompt builders with a shared "handoff bundle" builder used by:
+  - `skills/deliver-wi`
+  - `scripts/invoke.py`
+  - `agent_runtime --execute`
+  - all automatic backends
+
+That shared builder should produce:
+
+- role
+- run metadata
+- exact execution checkout instructions
+- canonical reading list
+- resolved PRD path
+- resolved ADR list
+- WI scope
+- target area
+- out-of-scope
+- acceptance criteria
+- stop conditions
+- PR context
+- review comments and CI context when relevant
+
+## Finding 2: PR-follow-up coding currently allocates a new branch instead of continuing on the PR head
+
+`build_runner_execution()` sets `base_ref` to `origin/<pull_request.head_ref_name>` when a PR exists, but `allocate_worktree()` always creates a new branch with `git worktree add -b <new-branch> ... <base_ref>`.
+
+Observed impact:
+
+- follow-up coding for an existing PR does not naturally update the PR branch
+- the operator is pushed into manual recovery or ad hoc git surgery
+- the runtime violates the repo's stated runtime-managed checkout policy for PR follow-up work
+
+Why it matters:
+
+- this is a functional blocker for semi-autonomous and autonomous use
+- the runtime can open a new PR for greenfield coding, but it cannot cleanly continue a live PR without forking branch lineage
+
+Recommendation:
+
+- distinguish two checkout modes:
+  - `new_slice`: create a new branch from `origin/main`
+  - `existing_pr_followup`: attach worktree directly to the PR head branch, or create a worktree that tracks the same branch without inventing a second coding branch
+- persist `checkout_mode` explicitly in the run metadata
+- make PR-follow-up coding impossible to dispatch unless the runtime can prove it is operating on the PR head branch
+
+## Finding 3: `codex_exec` backends do not use the governed system prompts
+
+The OpenAI and Anthropic backends explicitly load `load_system_prompt()` and send it as a system message. The `codex_exec` backends only pass `execution.prompt` plus an output schema wrapper.
+
+Observed impact:
+
+- the most important practical automation path today, `codex_exec`, is also the path least anchored to the canonical role instructions
+- runtime quality depends too much on the small prompt built in the execution layer
+
+Why it matters:
+
+- governance boundaries are one of the core reasons this repository uses multiple agent roles
+- those boundaries should not disappear when the runtime switches from manual to automated execution
+
+Recommendation:
+
+- wrap `codex exec` prompts with:
+  - governed role instruction
+  - invocation/handoff bundle
+  - output contract
+- if the CLI supports a real system-prompt surface, use it
+- if not, prepend a clearly delimited governed instruction block and record it with the run artifact
+
+## Finding 4: Review automation does not ingest the information a real review needs
+
+`agent_runtime/orchestrator/github_sync.py` ingests:
+
+- PR number
+- URL
+- draft flag
+- head ref
+- updated timestamp
+- review decision
+- unresolved thread counts
+- merge state
+- CI rollup state
+
+It does not ingest:
+
+- review comment bodies
+- inline review context
+- check-run names and logs
+- bot comments
+- diff summary
+
+Observed impact:
+
+- the runtime can decide that review should happen, but it does not provide enough material for a strong automated review handoff
+- a review backend that sees only "Review PR #71" plus a URL is weaker than the documented review process
+
+Recommendation:
+
+- add a `review_context_builder` that fetches:
+  - unresolved review threads with bodies and file locations
+  - recent top-level PR comments
+  - failing check names
+  - failing check logs or summarized failure excerpts
+  - diff stats and changed-file list
+- store that context in a run artifact, not only in memory
+
+## Finding 5: The spec role is still wired to the legacy instruction file
+
+`prompt_loader.py` maps `RunnerName.SPEC` to `prompts/agents/risk_methodology_spec_agent_instruction.md`, while `AGENTS.md` says that legacy role is retained only for backward compatibility and the responsibilities are now covered by the PRD / Spec Author.
+
+Observed impact:
+
+- the runtime's spec role is at risk of drifting from the repo's canonical spec-authoring model
+
+Recommendation:
+
+- re-point the spec runner to the current canonical spec instruction, or split:
+  - `spec_gap_resolution`
+  - `prd_author`
+- do not keep the runtime on a legacy prompt surface if autonomous use is the goal
+
+## Finding 6: Several autonomy features exist but are not wired into the actual runtime path
+
+Examples:
+
+- `langgraph_graph.py` documents `python -m agent_runtime --langgraph`, but the CLI parser in `graph.py` has no `--langgraph` flag
+- `parallel_dispatch.py` implements `run_parallel_step()`, but the main loop does not call it
+- `post_merge_hooks.py` exists, but nothing invokes `run_post_merge_hooks()`
+- `work_item_state.py` exists, but nothing invokes `maybe_advance_work_item_stage()`
+- `AgentRuntimeConfig` exposes `auto_merge` and `auto_promote_wi`, but they are not implemented
+
+Observed impact:
+
+- the repo signals autonomy capability that operators cannot actually rely on
+- the architecture surface is broader than the operating surface
+
+Recommendation:
+
+- either wire these features into the real loop or explicitly demote them to experimental status
+- avoid shipping autonomy flags before the side effects exist
+
+## Finding 7: The run model is still last-known-state oriented, not run-history oriented
+
+`workflow_runs` is keyed by `work_item_id`, so the table stores the latest state for each work item rather than a full run lineage. There is an event table, but it is not the main operational source of truth.
+
+Observed impact:
+
+- weak replay/debugging for long-lived autonomous work
+- harder to compare attempt N against attempt N+1
+- weak artifact lineage for failed and retried runs
+
+Recommendation:
+
+- promote `run_id` to a first-class execution record
+- keep:
+  - `workflow_runs` as an append-only execution log keyed by `run_id`
+  - `work_item_state` as the current materialized state
+  - `workflow_events` as the event stream
+- store artifacts per run:
+  - prompt bundle
+  - model/backend used
+  - changed-files manifest
+  - outcome payload
+  - PR metadata snapshot
+
+## Finding 8: The operator UX is fragmented across skill, script, runtime, and repo docs
+
+The operator currently has to combine:
+
+- `skills/deliver-wi`
+- `scripts/invoke.py`
+- `agent_runtime --dispatch`
+- `agent_runtime --complete-run`
+- `agent_runtime/manual_supervisor_workflow.md`
+- repo-level freshness and branch rules
+
+Observed impact:
+
+- too many paths to do roughly the same work
+- high cognitive load
+- easy drift between docs and actual runtime behavior
+
+Recommendation:
+
+- define one operator-facing command family, for example:
+  - `agentctl next`
+  - `agentctl run`
+  - `agentctl review`
+  - `agentctl record`
+  - `agentctl status`
+- keep `skills/` and `scripts/invoke.py` as thin wrappers over the same underlying bundle builder
+
+## Recommendations For Each Operating Mode
+
+## A. Manual Mode Improvements
+
+### Goal
+
+Keep the governance quality of manual invocation while removing the repetitive ceremony.
+
+### Recommended changes
+
+1. Build one canonical handoff bundle generator.
+   - This should supersede most of the custom placeholder filling in `scripts/invoke.py`.
+   - The bundle should be serializable to JSON and renderable to markdown.
+
+2. Replace copy/paste prompt generation with "openable run packets".
+   - Emit:
+     - `run.json`
+     - `prompt.md`
+     - `context.md`
+     - `operator_next_steps.txt`
+   - Store them under `.agent_runtime/runs/<run_id>/`.
+
+3. Add one-shot outcome recording from a file.
+   - Example:
+     - `agent_runtime record --run-id ... --outcome-file .agent_runtime/runs/<run_id>/outcome.json`
+   - This removes the need for manual `--outcome-details-json` shell quoting.
+
+4. Add a manual launcher abstraction.
+   - Even if Codex/Claude opening cannot be fully automated, the runtime should at least print:
+     - the exact worktree path
+     - exact session name
+     - exact prompt path
+     - exact role
+     - exact model recommendation
+
+5. Add `agent_runtime status`.
+   - Show:
+     - active run
+     - worktree path
+     - last backend used
+     - unresolved human gates
+     - pending review waits
+
+### Expected result
+
+Manual mode becomes the high-trust fallback and training wheels for the automated system, not a separate operating system.
+
+## B. Semi-Autonomous Mode Improvements
+
+### Goal
+
+Make `agent_runtime --dispatch` genuinely useful without requiring a second layer of human glue.
+
+### Recommended changes
+
+1. Fix branch continuity first.
+   - This is the top priority.
+   - Existing PR follow-up runs must operate on the PR head branch, not a sibling branch.
+
+2. Replace thin runtime prompts with full handoff bundles.
+   - PM, review, spec, issue-planner, coding, and drift-monitor should all use the same evidence-rich context contract.
+
+3. Persist a run artifact directory for every dispatch.
+   - Include:
+     - prompt bundle
+     - input snapshot
+     - PR metadata snapshot
+     - resolved file list
+     - backend command line
+     - stdout/stderr
+     - parsed outcome
+
+4. Make human completion easier.
+   - Add:
+     - `agent_runtime complete --run-id ... --decision ready --summary-file ...`
+     - `agent_runtime complete --run-id ... --from-json ...`
+
+5. Add review-context harvesting.
+   - For review and PR-follow-up coding runs, resolve:
+     - unresolved threads
+     - recent comments
+     - failing checks
+     - log summaries
+
+6. Wire work-item stage mutation and post-merge hooks.
+   - After PM `ready`: optionally move to `in_progress`
+   - After blocked outcomes: optionally move to `blocked`
+   - After merge: optionally move to `done` and run post-merge drift
+
+7. Keep the runtime authoritative for worktree lifecycle.
+   - The user should not have to infer when to release a lease.
+   - Introduce lease expiry, active heartbeat, and stale-run cleanup.
+
+### Expected result
+
+Semi-autonomous mode becomes a credible operator workflow instead of a procedural bridge.
+
+## C. Fully Automated Mode Improvements
+
+### Goal
+
+Move from "manual with helpers" to "governed automation with explicit human interrupts".
+
+### Recommended changes
+
+1. Define the automation boundary explicitly.
+   - PM: automatable
+   - Spec/PRD gap resolution: automatable when bounded
+   - Review triage: automatable
+   - Coding: automatable with stricter artifact capture
+   - Merge: human-gated by default
+
+2. Move to event-driven execution.
+   - Triggers:
+     - new ready work item
+     - PR opened
+     - review thread added
+     - CI failed
+     - CI passed
+     - merge completed
+
+3. Treat autonomous runs as resumable workflows, not subprocess calls.
+   - A run should survive:
+     - process restart
+     - machine restart
+     - provider timeout
+     - human delay
+
+4. Store input snapshots and outputs immutably.
+   - This is required for replayability and governance.
+
+5. Add hard policy gates for automatic side effects.
+   - No auto-merge until:
+     - green checks
+     - review outcome `pass`
+     - no unresolved threads
+     - drift gate clear
+   - No auto-promote of work items until:
+     - merge is confirmed
+     - post-merge hooks completed
+
+6. Introduce an evaluation harness.
+   - Use golden scenarios:
+     - ready-no-pr
+     - PR with failing CI
+     - review comments that should route back to coding
+     - backlog-materialization trigger
+     - spec-required trigger
+   - Compare:
+     - manual prompt output
+     - runtime prompt output
+     - automatic backend decisions
+
+### Expected result
+
+Autonomy becomes a controlled execution mode with traceable state transitions, not a collection of optimistic subprocess wrappers.
+
+## LangChain And LangGraph Assessment
+
+## LangGraph: good fit, but only after the run contract is cleaned up
+
+LangGraph would help with:
+
+- durable checkpointing
+- explicit interrupt/resume at human gates
+- fan-out/fan-in for parallel eligible work
+- event streaming and state inspection
+- clearer node boundaries for PM/spec/coding/review/human-gate/post-merge
+
+It is a good orchestration substrate for this runtime because the repository already has:
+
+- explicit roles
+- explicit states
+- explicit human gates
+- deterministic transition logic
+
+Recommended use of LangGraph:
+
+- keep `decide_next_action()` and related deterministic policy logic as repo-owned code
+- wrap each runner dispatch and side effect as graph nodes
+- use interrupts for:
+  - human merge
+  - human repo update
+  - manual review override
+- use checkpointing for resume and crash recovery
+
+Do not use LangGraph as an excuse to replace deterministic repo policy with generic agent planning.
+
+## LangChain: optional, not central
+
+LangChain is less compelling here than LangGraph.
+
+It could help with:
+
+- model adapter normalization
+- tracing with LangSmith
+- structured evaluation harnesses
+- retrieval helpers if you later build canon-aware context packing
+
+It is not the main missing piece because the runtime's problems are:
+
+- branch continuity
+- handoff quality
+- artifact capture
+- PR feedback ingestion
+- operator UX
+
+Those are control-plane problems, not chain-composition problems.
+
+Recommendation:
+
+- use LangSmith tracing and evaluation if you want observability and comparison across providers
+- use LangGraph for stateful orchestration if you choose a framework
+- avoid deep adoption of generic LangChain agent abstractions for coding runs
+
+## Better alternatives to "more agent framework"
+
+If you want deeper automation, the stronger design move is:
+
+- richer repo-native handoff bundles
+- explicit run artifacts
+- reliable branch/worktree semantics
+- event-driven orchestration
+
+before adding more framework abstraction.
+
+If you need a workflow engine beyond LangGraph, Temporal would also be a reasonable fit, but it is a much heavier operational commitment.
+
+## Recommended Target Architecture
+
+The target should be:
+
+1. one deterministic policy layer
+2. one authoritative run model
+3. one authoritative handoff bundle format
+4. one authoritative execution checkout model
+5. one authoritative artifact store per run
+6. one authoritative resume/human-gate mechanism
+
+Practical shape:
+
+- Policy:
+  - existing transition logic, improved
+- State:
+  - current work-item state + append-only runs + append-only events
+- Handoff:
+  - shared context builder used by manual and automated modes
+- Execution:
+  - backend adapters for Codex CLI, OpenAI, Anthropic, and manual launch
+- Feedback:
+  - GitHub PR metadata + review comments + checks + logs
+- Side effects:
+  - PR publication, work-item stage mutation, post-merge drift, optional merge
+
+## Recommended Delivery Plan
+
+## Phase 1: Make The Current Runtime Trustworthy
+
+Priority: P0
+
+- fix PR-follow-up branch handling
+- unify prompt/context generation
+- enrich review and coding context with PR comments and CI data
+- persist run bundles and backend artifacts
+- align spec runner with canonical spec instruction
+
+Success criteria:
+
+- a failed-CI or changes-requested PR can be routed back to coding without branch confusion
+- runtime prompt bundle quality matches or exceeds manual invocation quality
+
+## Phase 2: Reduce Human Glue
+
+Priority: P1
+
+- add `agent_runtime status`
+- add `agent_runtime record --from-json`
+- add launcher-ready run packets
+- wire work-item state mutation and post-merge hooks
+- make manual supervisor mode file-driven rather than shell-flag driven
+
+Success criteria:
+
+- semi-autonomous mode no longer requires ad hoc shell quoting and prompt copying
+- the operator can understand the state of the system from one command
+
+## Phase 3: Introduce Real Autonomous Execution
+
+Priority: P2
+
+- choose orchestration substrate:
+  - improved custom loop
+  - or LangGraph
+- wire event-driven triggers
+- implement resumable interrupts and retries
+- gate automatic merge and automatic work-item promotion behind explicit policy flags
+- add evaluation harness and replay tests
+
+Success criteria:
+
+- the runtime can run unattended for bounded periods
+- failures are resumable
+- human gates are explicit and auditable
+- merge remains governed rather than accidental
+
+## What I Would Not Do Yet
+
+- I would not add more role-specific prompt builders.
+- I would not expand parallelism before fixing single-PR branch continuity.
+- I would not enable auto-merge before review-context ingestion and post-merge hooks are wired.
+- I would not do a broad LangChain rewrite.
+- I would not treat `codex_exec` as "good enough" until it uses the governed role instructions and emits proper run artifacts.
+
+## Bottom Line
+
+To get close to autonomous use, the repository should stop optimizing the scheduler first and instead optimize the handoff contract.
+
+The core sequence should be:
+
+1. unify context generation
+2. fix branch ownership
+3. capture run artifacts
+4. ingest PR feedback deeply
+5. wire side effects
+6. only then choose whether LangGraph should replace the current supervisor loop
+
+That path preserves the repository's governance model while removing the current friction between Codex sessions, manual scripts, and the runtime control plane.

--- a/work_items/blocked/WI-MAINT-2B-runtime-shared-handoff-migration.md
+++ b/work_items/blocked/WI-MAINT-2B-runtime-shared-handoff-migration.md
@@ -1,0 +1,102 @@
+# WI-MAINT-2B
+
+## Status
+
+**BLOCKED** - gated on `WI-MAINT-2A` merging on `main`.
+
+## Blocker
+
+- The shared handoff-bundle contract must exist on `main` before runtime runner surfaces migrate to it; otherwise coding would have to invent the contract while also changing the consumers.
+
+**Owner:** Coding Agent completes `WI-MAINT-2A` -> human merge -> PM moves this WI to `ready/`.
+
+## Linked PRD
+
+None - runtime delivery infrastructure maintenance.
+
+Policy basis: [agent_runtime_modernization_plan.md](../../docs/delivery/plans/agent_runtime_modernization_plan.md), [GitHub issue #196](https://github.com/tomanizer/risk-manager/issues/196), [umbrella issue #195](https://github.com/tomanizer/risk-manager/issues/195), and [agent_runtime_audit_2026-04-21.md](../../docs/guides/agent_runtime_audit_2026-04-21.md).
+
+## Linked ADRs
+
+None required.
+
+## Linked shared infra
+
+None.
+
+## Purpose
+
+Migrate runtime-managed runner execution generation to the shared handoff-bundle contract so PM, coding, review, spec, and issue-planner handoffs stop depending on thin ad hoc prompt assembly.
+
+## Scope
+
+- Update `agent_runtime/orchestrator/execution.py` to build a shared handoff bundle for PM, coding, review, spec, and issue-planner executions.
+- Update runtime prompt rendering so those roles consume bundle-derived content rather than bespoke string assembly as the primary context source.
+- Persist the serialized handoff bundle in execution metadata or an equivalent canonical execution payload field for later artifact persistence.
+- Add or update tests around `build_runner_execution` and role prompt builders to cover the migrated fields.
+
+## Out of scope
+
+- Refactoring `scripts/invoke.py`
+- Changing governed system prompt plumbing for automated backends
+- Durable run-artifact persistence under `.agent_runtime/`
+- Review comment ingestion or CI log ingestion
+
+## Dependencies
+
+- WI-MAINT-2A
+
+## Target area
+
+- `agent_runtime/orchestrator/execution.py`
+- `agent_runtime/runners/pm_runner.py`
+- `agent_runtime/runners/coding_runner.py`
+- `agent_runtime/runners/review_runner.py`
+- `agent_runtime/runners/spec_runner.py`
+- `agent_runtime/runners/issue_planner_runner.py`
+- `agent_runtime/tests/test_transitions.py`
+- relevant role-runner tests under `agent_runtime/tests/`
+
+## Acceptance criteria
+
+- `build_runner_execution` constructs a shared handoff bundle for PM, coding, review, spec, and issue-planner executions.
+- Runtime prompt rendering for those roles includes the core governed WI contract fields from the shared bundle instead of relying only on thin inline strings.
+- Execution metadata carries a serialized bundle payload or an equivalent canonical bundle reference for later run-artifact persistence.
+- Tests cover linked PRD propagation, checkout context, optional PR context, acceptance criteria, and stop-condition rendering through runtime execution surfaces.
+- No manual invocation surface changes are mixed into this slice.
+
+## Test intent
+
+- Extend transition tests to assert that runtime-built executions carry the shared bundle fields.
+- Update role-runner tests to assert rendered prompts include the expected bundle-derived contract sections.
+- Keep at least one PM path and one coding/review path under direct assertion so the migrated surface is not partially wired.
+
+## Stop conditions
+
+- Stop if `WI-MAINT-2A` changes the bundle contract materially while this slice is in progress.
+- Stop if drift-monitor or PRD-bootstrap handoffs must be migrated to keep this slice coherent; route that as follow-on work instead.
+- Stop if the migration requires run-artifact storage or backend-governance changes to land in the same PR.
+
+## Review focus
+
+- Runtime consumption of the shared bundle across all targeted roles
+- Elimination of duplicated thin-prompt assembly where the bundle should be authoritative
+- Slice discipline: runtime consumer migration only, with no manual-surface or artifact-persistence scope creep
+
+## Suggested agent
+
+Coding Agent (after unblock)
+
+## READY_CRITERIA (checklist - work_items/READY_CRITERIA.md)
+
+*Blocked until `WI-MAINT-2A` completes; when unblocked, all must hold:*
+
+1. **Linked contract** - `WI-MAINT-2A` is merged and provides the shared handoff-bundle contract on `main`.
+2. **Scope clarity** - Runtime consumer migration only; manual surfaces and backend-governance plumbing remain out of scope.
+3. **Dependency clarity** - The bundle contract is stable enough to consume directly.
+4. **Target location** - `agent_runtime/orchestrator/`, the role runner modules, and the runtime test files are explicit.
+5. **Acceptance clarity** - The targeted roles and fields are concrete and reviewable.
+6. **Test clarity** - Transition and role-runner test expectations are explicit.
+7. **Evidence / replay** - Serialized bundle payloads are carried forward for later artifact persistence without introducing the artifact subsystem here.
+8. **Decision closure** - This slice consumes the established bundle contract rather than designing it.
+9. **Shared infra** - No shared-infra canon change is required for this migration slice.

--- a/work_items/blocked/WI-MAINT-2C-manual-handoff-surface-parity.md
+++ b/work_items/blocked/WI-MAINT-2C-manual-handoff-surface-parity.md
@@ -1,0 +1,97 @@
+# WI-MAINT-2C
+
+## Status
+
+**BLOCKED** - gated on `WI-MAINT-2A` and `WI-MAINT-2B` merging on `main`.
+
+## Blocker
+
+- The manual invocation surface should not be migrated until the shared handoff-bundle contract exists and the runtime consumer shape is stable enough to compare against.
+
+**Owner:** Coding Agent completes `WI-MAINT-2A` and `WI-MAINT-2B` -> human merge -> PM moves this WI to `ready/`.
+
+## Linked PRD
+
+None - runtime delivery infrastructure maintenance.
+
+Policy basis: [agent_runtime_modernization_plan.md](../../docs/delivery/plans/agent_runtime_modernization_plan.md), [GitHub issue #196](https://github.com/tomanizer/risk-manager/issues/196), [umbrella issue #195](https://github.com/tomanizer/risk-manager/issues/195), and [agent_runtime_audit_2026-04-21.md](../../docs/guides/agent_runtime_audit_2026-04-21.md).
+
+## Linked ADRs
+
+None required.
+
+## Linked shared infra
+
+None.
+
+## Purpose
+
+Migrate the manual invocation tooling to the shared handoff-bundle builder and close the field-parity gap between manual and runtime execution context.
+
+## Scope
+
+- Refactor `scripts/invoke.py` so it resolves work-item, PRD, ADR, and execution-context fields through the shared handoff-bundle builder instead of bespoke WI parsing for fields already represented in the bundle.
+- Add tests that compare the core handoff fields produced for the same WI through the manual path and the runtime path.
+- Update `skills/deliver-wi/SKILL.md` and `agent_runtime/manual_supervisor_workflow.md` only as needed to keep the operator instructions aligned with the shared handoff model.
+
+## Out of scope
+
+- Changing the manual role-selection policy in `skills/deliver-wi`
+- Changing Git freshness or branching policy for manual direct mode
+- Adding durable run-artifact persistence
+- Changing governed role-instruction content
+
+## Dependencies
+
+- WI-MAINT-2A
+- WI-MAINT-2B
+
+## Target area
+
+- `scripts/invoke.py`
+- `tests/unit/scripts/`
+- `skills/deliver-wi/SKILL.md`
+- `agent_runtime/manual_supervisor_workflow.md`
+
+## Acceptance criteria
+
+- `scripts/invoke.py` imports the shared handoff-bundle builder and no longer re-implements the governed WI field extraction that the bundle already owns.
+- Manual template filling behavior remains intact for supported roles after the refactor.
+- Tests compare the core fields for the same WI across the manual and runtime paths and fail if linked PRD, linked ADRs, scope, target area, out of scope, acceptance criteria, or stop conditions drift.
+- Instruction-surface documentation is updated only where needed to reflect the shared handoff model and remains consistent with repo branching rules.
+
+## Test intent
+
+- Add focused script-level tests under `tests/unit/scripts/` for manual bundle use and template-filling parity.
+- Add at least one parity test that exercises the same WI through the manual builder and the runtime builder and compares the core governed fields directly.
+- Keep role-selection behavior under existing tests or manual expectations; this slice is about context parity, not dispatch policy changes.
+
+## Stop conditions
+
+- Stop if the runtime bundle or prompt rendering contract is still shifting under `WI-MAINT-2B`.
+- Stop if manual parity work would require redesigning invocation templates rather than reusing the existing ones.
+- Stop if `skills/deliver-wi` would need executable automation behavior changes instead of narrow instruction alignment.
+
+## Review focus
+
+- True field parity between manual and runtime handoff surfaces
+- Preservation of current manual template-filling behavior
+- Minimal, disciplined instruction-surface edits with no policy drift
+
+## Suggested agent
+
+Coding Agent (after unblock)
+
+## READY_CRITERIA (checklist - work_items/READY_CRITERIA.md)
+
+*Blocked until `WI-MAINT-2A` and `WI-MAINT-2B` complete; when unblocked, all must hold:*
+
+1. **Linked contract** - The shared bundle contract and runtime consumer migration are both merged on `main`.
+2. **Scope clarity** - Manual-surface parity only; no template redesign or branching-policy change.
+3. **Dependency clarity** - Runtime bundle semantics are stable enough for parity assertions.
+4. **Target location** - `scripts/invoke.py`, manual-surface docs, and script tests are explicit.
+5. **Acceptance clarity** - The parity fields and preserved behavior are concrete and reviewable.
+6. **Test clarity** - Script tests and direct parity assertions are explicit.
+7. **Evidence / replay** - This slice improves handoff consistency only; artifact persistence stays out of scope.
+8. **Decision closure** - The bundle contract and runtime rendering behavior are already decided upstream.
+9. **Shared infra** - No shared-infra canon change is required for this manual-surface parity slice.

--- a/work_items/ready/WI-MAINT-2A-shared-handoff-bundle-contract.md
+++ b/work_items/ready/WI-MAINT-2A-shared-handoff-bundle-contract.md
@@ -1,0 +1,108 @@
+# WI-MAINT-2A
+
+## Status
+
+**READY** - GitHub issue `#196` is open, the contract-first slice is bounded, and no upstream code dependency must land before this foundation work can start.
+
+## Blocker
+
+- None. PM can assign this slice to Coding Agent.
+
+## Linked PRD
+
+None - runtime delivery infrastructure maintenance.
+
+Policy basis: [agent_runtime_modernization_plan.md](../../docs/delivery/plans/agent_runtime_modernization_plan.md), [GitHub issue #196](https://github.com/tomanizer/risk-manager/issues/196), [umbrella issue #195](https://github.com/tomanizer/risk-manager/issues/195), and [agent_runtime_audit_2026-04-21.md](../../docs/guides/agent_runtime_audit_2026-04-21.md).
+
+## Linked ADRs
+
+None required.
+
+## Linked shared infra
+
+None.
+
+## Purpose
+
+Introduce one typed, serializable shared handoff-bundle contract that can become the common context surface for runtime-managed and manual agent invocation flows.
+
+## Scope
+
+- Add a shared handoff bundle module under `agent_runtime/` for governed agent context.
+- Define the governed field set for at least:
+  - role
+  - work item identity and path
+  - checkout context
+  - linked PRD
+  - linked ADRs
+  - dependencies
+  - scope
+  - target area
+  - out of scope
+  - acceptance criteria
+  - stop conditions
+  - optional PR context
+  - source provenance
+- Add builder logic that resolves those fields from a live work item plus optional runtime metadata and PR snapshot inputs.
+- Add stable JSON serialization and a deterministic markdown rendering contract suitable for later prompt generation and run-artifact persistence.
+- Add targeted tests covering required-field extraction, optional-field absence, and deterministic serialization.
+
+## Out of scope
+
+- Migrating `agent_runtime` prompt builders to consume the bundle
+- Refactoring `scripts/invoke.py` or `skills/deliver-wi/SKILL.md`
+- Persisting bundle artifacts under `.agent_runtime/`
+- Changing governed prompt content or role instructions
+
+## Dependencies
+
+- None. This is the first contract slice for issue `#196`.
+
+## Target area
+
+- `agent_runtime/`
+- `agent_runtime/orchestrator/work_item_registry.py` only if a narrow shared extraction helper is required
+- `agent_runtime/tests/`
+
+## Acceptance criteria
+
+- One typed handoff-bundle module exists and is importable from repo code that manual and runtime surfaces can both consume later.
+- The bundle schema exposes explicit fields or sections for role, work item identity/path, checkout context, linked PRD, linked ADRs, dependencies, scope, target area, out of scope, acceptance criteria, stop conditions, optional PR context, and source provenance.
+- The builder accepts a live work item path plus optional runtime/PR inputs and produces deterministic output for identical inputs.
+- Stable JSON serialization exists and preserves multiline markdown bullet content without lossy flattening.
+- Tests prove extraction of linked PRD, linked ADRs, scope, target area, out-of-scope text, acceptance criteria, stop conditions, and optional PR context handling.
+- No runtime prompt builder or manual invocation script is migrated in this slice.
+
+## Test intent
+
+- Add unit tests that construct representative work-item markdown inputs and verify the bundle field mapping exactly.
+- Add serialization tests proving repeated renders produce byte-stable JSON for the same logical input.
+- Add optional-field tests covering missing linked PRD, missing stop conditions, and absent PR context.
+
+## Stop conditions
+
+- Stop if this slice requires migrating runtime prompt builders or `scripts/invoke.py` to prove correctness.
+- Stop if the field set cannot be closed without a new PM decision about role semantics or repo governance.
+- Stop if bundle design pressure expands the slice into run-artifact persistence or backend prompt plumbing.
+
+## Review focus
+
+- Contract completeness for the governed handoff field set
+- Deterministic serialization and provenance clarity
+- Slice discipline: contract and builder only, with no consumer migration hidden inside the PR
+
+## Suggested agent
+
+Coding Agent
+
+## READY_CRITERIA (checklist - work_items/READY_CRITERIA.md)
+
+1. **Linked contract** - No PRD is required; the governing contract is the modernization plan, issue `#196`, and the linked audit.
+2. **Scope clarity** - The slice is limited to the shared contract, builder, serialization, and tests.
+3. **Dependency clarity** - No upstream implementation dependency must land first.
+4. **Target location** - The new shared handoff module and its test area are explicit.
+5. **Acceptance clarity** - Required fields, determinism, and non-goals are concrete and reviewable.
+6. **Test clarity** - Unit coverage for extraction and serialization is explicit.
+7. **Evidence / replay** - The bundle is explicitly shaped for later artifact use without introducing artifact persistence in this slice.
+8. **Decision closure** - The role/governance question is bounded to representing existing repo canon, not changing it.
+9. **Shared infra** - No shared-infra canon change is required in this contract-first slice.

--- a/work_items/ready/WI-MAINT-3A-runtime-pr-followup-checkout-semantics.md
+++ b/work_items/ready/WI-MAINT-3A-runtime-pr-followup-checkout-semantics.md
@@ -1,0 +1,104 @@
+# WI-MAINT-3A
+
+## Status
+
+**READY** - GitHub issue `#197` is open, the checkout-correctness scope is explicit, and this slice can land independently of the shared handoff-bundle work.
+
+## Blocker
+
+- None. PM can assign this slice to Coding Agent.
+
+## Linked PRD
+
+None - runtime delivery infrastructure maintenance.
+
+Policy basis: [agent_runtime_modernization_plan.md](../../docs/delivery/plans/agent_runtime_modernization_plan.md), [GitHub issue #197](https://github.com/tomanizer/risk-manager/issues/197), [umbrella issue #195](https://github.com/tomanizer/risk-manager/issues/195), and [agent_runtime_audit_2026-04-21.md](../../docs/guides/agent_runtime_audit_2026-04-21.md).
+
+## Linked ADRs
+
+None required.
+
+## Linked shared infra
+
+None.
+
+## Purpose
+
+Make runtime-managed checkout semantics branch-correct by distinguishing fresh-slice runs from PR-follow-up runs and ensuring follow-up coding stays on the authoritative PR head branch instead of creating a sibling feature branch.
+
+## Scope
+
+- Define explicit runtime checkout modes for at least:
+  - fresh slice from current `main`
+  - coding follow-up on an existing PR head branch
+  - review checkout on an existing PR branch
+- Update `agent_runtime/orchestrator/execution.py` to persist checkout mode and branch intent in execution metadata.
+- Update `agent_runtime/orchestrator/worktree_manager.py` to allocate the correct branch/worktree shape for each checkout mode.
+- Persist enough lease metadata to distinguish runtime-created ephemeral branches from attached follow-up branches so release behavior is safe and explicit.
+- Update tests covering fresh-slice allocation, PR-follow-up allocation, review checkout semantics, and release behavior.
+- Align `agent_runtime/README.md` and `agent_runtime/manual_supervisor_workflow.md` with the implemented checkout policy.
+
+## Out of scope
+
+- PR publication policy redesign
+- Auto-merge or auto-promote behavior
+- Review comment ingestion or CI log ingestion
+- Shared handoff-bundle migration
+
+## Dependencies
+
+- None. This is a Wave 1 correctness foundation for issue `#197`.
+
+## Target area
+
+- `agent_runtime/orchestrator/execution.py`
+- `agent_runtime/orchestrator/worktree_manager.py`
+- `agent_runtime/storage/sqlite.py`
+- `agent_runtime/tests/test_worktree_manager.py`
+- `agent_runtime/tests/test_transitions.py`
+- `agent_runtime/tests/test_pr_publication.py` only if metadata or branch semantics require coverage updates
+- `agent_runtime/README.md`
+- `agent_runtime/manual_supervisor_workflow.md`
+
+## Acceptance criteria
+
+- Runtime metadata explicitly distinguishes fresh-slice and PR-follow-up checkouts, and review checkout behavior remains explicit rather than implicit.
+- Coding follow-up runs on existing PRs allocate a worktree on the authoritative PR branch instead of inventing a new sibling branch name.
+- Fresh-slice coding runs still create a clean runtime-managed feature branch from current `main`.
+- Lease metadata records enough branch-ownership intent that release logic does not blindly treat every branch as a disposable runtime-created branch.
+- Tests cover fresh allocation, PR-follow-up allocation, review checkout behavior, and safe release behavior.
+- Runtime documentation no longer implies checkout behavior that the implementation does not provide.
+
+## Test intent
+
+- Extend worktree-manager tests to cover fresh-slice and PR-follow-up branch allocation separately.
+- Extend transition tests to assert checkout-mode metadata and branch intent for coding and review runs.
+- Update PR-publication tests only if the new metadata changes how follow-up runs are compared or published.
+
+## Stop conditions
+
+- Stop if the fix requires a broader redesign of PR publication or merge policy.
+- Stop if safe release behavior cannot be closed without a new policy decision about local branch retention.
+- Stop if the slice expands into post-merge hooks, lifecycle mutation, or other Wave 2 concerns.
+
+## Review focus
+
+- Correctness of checkout-mode and branch-intent semantics
+- Preservation of fresh-slice behavior while fixing PR-follow-up behavior
+- Safe release behavior for attached PR branches versus runtime-created branches
+
+## Suggested agent
+
+Coding Agent
+
+## READY_CRITERIA (checklist - work_items/READY_CRITERIA.md)
+
+1. **Linked contract** - No PRD is required; the governing contract is the modernization plan, issue `#197`, and the linked audit.
+2. **Scope clarity** - The slice is limited to checkout-mode semantics, lease metadata, tests, and doc alignment.
+3. **Dependency clarity** - No upstream code dependency must land first.
+4. **Target location** - The runtime execution, worktree, storage, test, and doc surfaces are explicit.
+5. **Acceptance clarity** - The branch-correct behavior for fresh and follow-up runs is concrete and reviewable.
+6. **Test clarity** - Worktree-manager and transition coverage expectations are explicit.
+7. **Evidence / replay** - Lease metadata and docs make checkout behavior auditable without widening into full run-artifact work.
+8. **Decision closure** - The slice fixes a concrete correctness gap rather than inventing new autonomy policy.
+9. **Shared infra** - No shared-infra canon change is required for this runtime checkout fix.


### PR DESCRIPTION
## What changed
- added a deep audit of the current `agent_runtime` control plane and its gaps to autonomous use
- added a repo-local modernization plan and matching GitHub issue drafts
- materialized the first Wave 1 execution backlog into concrete `WI-MAINT` work items
- linked the local planning artifacts to the live GitHub issues `#195` through `#199`

## Why it changed
The runtime currently has overlapping manual, semi-manual, and partially integrated autonomous paths. This PR turns the audit into an executable delivery plan so the repo can work through the modernization in a governed order instead of losing work across chats, scripts, and ad hoc notes.

## Impact
- the repo now has an authoritative local plan for agent runtime modernization
- Wave 1 work is decomposed into runnable versus blocked slices
- the GitHub issue tree and the repo-local execution artifacts are aligned
- no runtime behavior changes are included in this PR

## Validation
- `python scripts/work_items_validate.py --ref HEAD`
- local push-gate was bypassed for publish because it failed on unrelated existing test issues outside this planning diff; GitHub CI should be treated as the authoritative PR validation surface
