### PR TITLE
Mark WI-MAINT-3A done after PR #194

### DIFF
--- a/docs/delivery/plans/agent_runtime_modernization_plan.md
+++ b/docs/delivery/plans/agent_runtime_modernization_plan.md
@@ -259,7 +259,7 @@ Materialized work items on `2026-04-21`:
 - [WI-MAINT-2A](../../../work_items/ready/WI-MAINT-2A-shared-handoff-bundle-contract.md) - ready
 - [WI-MAINT-2B](../../../work_items/blocked/WI-MAINT-2B-runtime-shared-handoff-migration.md) - blocked on `WI-MAINT-2A`
 - [WI-MAINT-2C](../../../work_items/blocked/WI-MAINT-2C-manual-handoff-surface-parity.md) - blocked on `WI-MAINT-2A` and `WI-MAINT-2B`
-- [WI-MAINT-3A](../../../work_items/ready/WI-MAINT-3A-runtime-pr-followup-checkout-semantics.md) - ready
+- [WI-MAINT-3A](../../../work_items/done/WI-MAINT-3A-runtime-pr-followup-checkout-semantics.md) - done via [PR #194](https://github.com/tomanizer/risk-manager/pull/194)
 
 ## 11. Suggested Wave 1 Work-Item Granularity
 
@@ -331,7 +331,7 @@ Expected decomposition after Wave 1 midpoint:
 
 ### Next Step
 
-Run a PM / readiness pass for [WI-MAINT-2A](../../../work_items/ready/WI-MAINT-2A-shared-handoff-bundle-contract.md) and [WI-MAINT-3A](../../../work_items/ready/WI-MAINT-3A-runtime-pr-followup-checkout-semantics.md), then start coding on the selected first slice.
+Run a PM / readiness pass for [WI-MAINT-2A](../../../work_items/ready/WI-MAINT-2A-shared-handoff-bundle-contract.md), then start coding on that slice. Treat [WI-MAINT-3A](../../../work_items/done/WI-MAINT-3A-runtime-pr-followup-checkout-semantics.md) as completed foundation work on `main`.
 
 ### After Issue Creation
 

--- a/work_items/done/WI-MAINT-3A-runtime-pr-followup-checkout-semantics.md
+++ b/work_items/done/WI-MAINT-3A-runtime-pr-followup-checkout-semantics.md
@@ -2,11 +2,11 @@
 
 ## Status
 
-**READY** - GitHub issue `#197` is open, the checkout-correctness scope is explicit, and this slice can land independently of the shared handoff-bundle work.
+**DONE** - Merged to `main` via [PR #194](https://github.com/tomanizer/risk-manager/pull/194). Runtime-managed checkout semantics now distinguish fresh-slice versus PR-follow-up execution and preserve safe release behavior for non-runtime-owned branches.
 
 ## Blocker
 
-- None. PM can assign this slice to Coding Agent.
+- None. Work complete.
 
 ## Linked PRD
 
@@ -25,6 +25,14 @@ None.
 ## Purpose
 
 Make runtime-managed checkout semantics branch-correct by distinguishing fresh-slice runs from PR-follow-up runs and ensuring follow-up coding stays on the authoritative PR head branch instead of creating a sibling feature branch.
+
+## Completion evidence on `main`
+
+- Merge: [PR #194](https://github.com/tomanizer/risk-manager/pull/194)
+- `agent_runtime/orchestrator/execution.py` now persists PR-head checkout metadata including `pr_head_branch`, `checkout_ref`, `checkout_detached`, and `branch_owned_by_runtime` for PR-linked coding and review runs.
+- `agent_runtime/orchestrator/worktree_manager.py` now allocates detached PR-head worktrees when appropriate and skips branch deletion for non-runtime-owned branches on release.
+- `agent_runtime/storage/sqlite.py` now persists `branch_owned_by_runtime` in `worktree_leases`.
+- Targeted verification on current `main`: `python -m pytest agent_runtime/tests/test_worktree_manager.py agent_runtime/tests/test_transitions.py -q` -> `50 passed`
 
 ## Scope
 

--- a/work_items/done/WI-MAINT-3A-runtime-pr-followup-checkout-semantics.md
+++ b/work_items/done/WI-MAINT-3A-runtime-pr-followup-checkout-semantics.md
@@ -32,7 +32,7 @@ Make runtime-managed checkout semantics branch-correct by distinguishing fresh-s
 - `agent_runtime/orchestrator/execution.py` now persists PR-head checkout metadata including `pr_head_branch`, `checkout_ref`, `checkout_detached`, and `branch_owned_by_runtime` for PR-linked coding and review runs.
 - `agent_runtime/orchestrator/worktree_manager.py` now allocates detached PR-head worktrees when appropriate and skips branch deletion for non-runtime-owned branches on release.
 - `agent_runtime/storage/sqlite.py` now persists `branch_owned_by_runtime` in `worktree_leases`.
-- Targeted verification on current `main`: `python -m pytest agent_runtime/tests/test_worktree_manager.py agent_runtime/tests/test_transitions.py -q` -> `50 passed`
+- Targeted verification at merge time for [PR #194](https://github.com/tomanizer/risk-manager/pull/194): `python -m pytest agent_runtime/tests/test_worktree_manager.py agent_runtime/tests/test_transitions.py -q`
 
 ## Scope
 


### PR DESCRIPTION
## Summary
- move `WI-MAINT-3A` from `work_items/ready/` to `work_items/done/`
- record that the checkout-semantics work landed via PR #194
- update the runtime modernization plan so `WI-MAINT-2A` is the next active Wave 1 slice

## Verification
- `python -m pytest agent_runtime/tests/test_worktree_manager.py agent_runtime/tests/test_transitions.py -q`
- `python scripts/work_items_validate.py --ref HEAD`

## Notes
- full push-gate pytest is currently red due to unrelated existing failures outside this doc/work-item correction
