### PR TITLE
Fix local push gate interpreter path

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,6 +4,6 @@ repos:
       - id: push-gate
         name: push-gate
         language: system
-        entry: python scripts/ci/run_push_gate.py --python --skills --apply-ruff-fixes
+        entry: .venv/bin/python scripts/ci/run_push_gate.py --python --skills --apply-ruff-fixes
         pass_filenames: false
         stages: [pre-push]

--- a/README.md
+++ b/README.md
@@ -45,7 +45,9 @@ cp .env.example .env
 pre-commit install --hook-type pre-push
 ```
 
-The pre-push hook auto-applies Ruff fixes and formatting locally. If it
+The pre-push hook runs through the repo-local `.venv`, so pushes from
+non-activated shells and GUI clients still use the project dev
+environment. It auto-applies Ruff fixes and formatting locally. If it
 rewrites files, stage the changes and push again.
 
 See `agent_runtime/config/README.md` for the full environment variable

--- a/agent_runtime/config/README.md
+++ b/agent_runtime/config/README.md
@@ -158,9 +158,9 @@ A repo-tracked `pre-commit` pre-push hook runs the shared push gate
 before every push. The gate aligns local checks with the CI
 `lint-and-test` workflow by running `ruff check`, `mypy`, `ruff format
 --check`, `pytest`, and skill mirror parity as applicable. Locally, the
-hook auto-applies Ruff fixes and formatting; if files are rewritten, the
-push stops so you can stage the changes and retry. Activate it once per
-clone:
+hook runs through the repository `.venv`, then auto-applies Ruff fixes
+and formatting; if files are rewritten, the push stops so you can stage
+the changes and retry. Activate it once per clone:
 
 ```bash
 pre-commit install --hook-type pre-push


### PR DESCRIPTION
## Summary
- run the repo pre-push hook through the repo-local `.venv` instead of relying on `python` on PATH
- document that this keeps pushes working from GUI clients and non-activated shells
- keep the change scoped to hook wiring and setup docs

## Testing
- python scripts/ci/run_push_gate.py --python --skills --apply-ruff-fixes
- pre-commit run --hook-stage pre-push --all-files push-gate
- env -i HOME="$HOME" PATH="/usr/bin:/bin" /Users/thomas/.pyenv/versions/3.12.9/bin/python3.12 -m pre_commit run --all-files --hook-stage pre-push push-gate