### PR TITLE
Migrate manual invocation tool to shared handoff bundle

### DIFF
--- a/.claude/commands/deliver-wi.md
+++ b/.claude/commands/deliver-wi.md
@@ -105,7 +105,9 @@ Default to **PM** when in doubt — it is always safe to run PM first.
 
 ## Step 4 — Fill the template
 
-Read the selected template file. Replace the **exact bracketed placeholder string as written in the template** — including any descriptive suffix. Do not assume differently worded placeholders are interchangeable across templates.
+You may run `python scripts/invoke.py --role <ROLE> --work-item <WI_ID>` to automatically generate the prompt filled with the shared handoff bundle data.
+
+If filling manually, read the selected template file and replace the **exact bracketed placeholder string as written in the template** — including any descriptive suffix. Do not assume differently worded placeholders are interchangeable across templates.
 
 ### PM placeholder mapping
 

--- a/.cursor/skills/deliver-wi/SKILL.md
+++ b/.cursor/skills/deliver-wi/SKILL.md
@@ -105,7 +105,9 @@ Default to **PM** when in doubt — it is always safe to run PM first.
 
 ## Step 4 — Fill the template
 
-Read the selected template file. Replace the **exact bracketed placeholder string as written in the template** — including any descriptive suffix. Do not assume differently worded placeholders are interchangeable across templates.
+You may run `python scripts/invoke.py --role <ROLE> --work-item <WI_ID>` to automatically generate the prompt filled with the shared handoff bundle data.
+
+If filling manually, read the selected template file and replace the **exact bracketed placeholder string as written in the template** — including any descriptive suffix. Do not assume differently worded placeholders are interchangeable across templates.
 
 ### PM placeholder mapping
 

--- a/.github/skills/deliver-wi/SKILL.md
+++ b/.github/skills/deliver-wi/SKILL.md
@@ -105,7 +105,9 @@ Default to **PM** when in doubt — it is always safe to run PM first.
 
 ## Step 4 — Fill the template
 
-Read the selected template file. Replace the **exact bracketed placeholder string as written in the template** — including any descriptive suffix. Do not assume differently worded placeholders are interchangeable across templates.
+You may run `python scripts/invoke.py --role <ROLE> --work-item <WI_ID>` to automatically generate the prompt filled with the shared handoff bundle data.
+
+If filling manually, read the selected template file and replace the **exact bracketed placeholder string as written in the template** — including any descriptive suffix. Do not assume differently worded placeholders are interchangeable across templates.
 
 ### PM placeholder mapping
 

--- a/fix_mypy.py
+++ b/fix_mypy.py
@@ -1,8 +1,0 @@
-import sys
-import re
-
-with open("tests/unit/scripts/test_invoke_parity.py", "r") as f:
-    content = f.read()
-
-# Add missing type annotations and unused imports cleanup if any
-pass # handled above, just check mypy

--- a/fix_mypy.py
+++ b/fix_mypy.py
@@ -1,0 +1,8 @@
+import sys
+import re
+
+with open("tests/unit/scripts/test_invoke_parity.py", "r") as f:
+    content = f.read()
+
+# Add missing type annotations and unused imports cleanup if any
+pass # handled above, just check mypy

--- a/scripts/invoke.py
+++ b/scripts/invoke.py
@@ -22,6 +22,13 @@ import argparse
 import re
 import sys
 from pathlib import Path
+
+# Ensure the repository root is in sys.path
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from agent_runtime.handoff_bundle import build_handoff_bundle, HandoffBundle
 from typing import Optional
 
 # ---------------------------------------------------------------------------
@@ -77,182 +84,46 @@ def list_work_items() -> list[Path]:
 
 
 # ---------------------------------------------------------------------------
-# Section extraction from markdown
-# ---------------------------------------------------------------------------
-
-
-def _split_sections(text: str) -> dict[str, str]:
-    """Return a dict mapping lowercased section heading → section body text."""
-    headings = [(m.start(), m.group(1).strip()) for m in _SECTION_RE.finditer(text)]
-    sections: dict[str, str] = {}
-    for i, (start, heading) in enumerate(headings):
-        end = headings[i + 1][0] if i + 1 < len(headings) else len(text)
-        # find() avoids ValueError when the heading is the last line of the file
-        nl = text.find("\n", start)
-        body_start = nl + 1 if nl != -1 else len(text)
-        sections[heading.lower()] = text[body_start:end].strip()
-    return sections
-
-
-def _extract_section(sections: dict[str, str], *keys: str) -> str:
-    """Return the first matching section body, or empty string.
-
-    Uses exact heading lookup so that e.g. 'scope' does not match 'out of scope'.
-    """
-    for k in keys:
-        body = sections.get(k.lower())
-        if body is not None:
-            return body
-    return ""
-
-
-# ---------------------------------------------------------------------------
 # PRD / ADR path resolution
 # ---------------------------------------------------------------------------
 
 
-def _find_prd(prd_ref: str) -> Optional[Path]:
-    """Resolve a PRD reference like 'PRD-1.1-v2' to a file path.
+def _fill_template(template: str, bundle: Optional[HandoffBundle], extra: dict[str, str]) -> str:
+    """Replace known <PLACEHOLDER> tokens in template with resolved values."""
 
-    Handles both compact refs (PRD-1.1-v2) and descriptive filenames
-    (PRD-1.1-risk-summary-service-v2.md) by trying progressively broader patterns.
-    """
-    if not prd_ref:
-        return None
-    # Try verbatim substring match first (fastest, works for exact filenames)
-    candidates = sorted(DOCS_DIR.rglob(f"*{prd_ref}*.md"))
-    if candidates:
-        return candidates[0]
-    # For refs like 'PRD-X.Y-vN', the actual filename may include a descriptive slug
-    # between the base number and version (e.g. PRD-1.1-risk-summary-service-v2.md).
-    m = re.match(r"^(PRD-[\d.]+)(?:-.+?)?(?:-v(\d+))?$", prd_ref, re.IGNORECASE)
-    if m:
-        base_part = m.group(1)  # e.g. "PRD-1.1"
-        ver_part = m.group(2)  # e.g. "2"
-        if ver_part:
-            candidates = sorted(DOCS_DIR.rglob(f"*{base_part}*-v{ver_part}*.md"))
-            if candidates:
-                return candidates[0]
-        # Final fallback: match by base number only (picks latest on sorted order)
-        candidates = sorted(DOCS_DIR.rglob(f"*{base_part}*.md"))
-        if candidates:
-            return candidates[0]
-    return None
-
-
-def _find_adr(adr_ref: str) -> Optional[Path]:
-    """Resolve an ADR reference like 'ADR-001' to a file path."""
-    candidates = list(ADR_DIR.rglob(f"*{adr_ref}*.md"))
-    return candidates[0] if candidates else None
-
-
-def _repo_relative(path: Path) -> str:
-    try:
-        return str(path.relative_to(REPO_ROOT))
-    except ValueError:
-        return str(path)
-
-
-# ---------------------------------------------------------------------------
-# Work-item parsing
-# ---------------------------------------------------------------------------
-
-
-class WorkItemInfo:
-    """Parsed representation of a WI-*.md file."""
-
-    def __init__(self, path: Path) -> None:
-        self.path = path
-        self.raw = path.read_text(encoding="utf-8")
-        self._sections = _split_sections(self.raw)
-
-        # Work item ID from the H1 heading; re.search + MULTILINE handles files with front-matter
-        m = re.search(r"^#\s+(WI-\S+)", self.raw, re.MULTILINE)
-        self.wi_id: str = m.group(1) if m else path.stem
-
-        self.linked_prd_raw: str = _extract_section(self._sections, "linked prd")
-        self.purpose: str = _extract_section(self._sections, "purpose")
-        self.scope: str = _extract_section(self._sections, "scope")
-        self.out_of_scope: str = _extract_section(self._sections, "out of scope")
-        self.dependencies_raw: str = _extract_section(self._sections, "dependencies")
-        self.target_area: str = _extract_section(self._sections, "target area")
-        self.acceptance_criteria: str = _extract_section(self._sections, "acceptance criteria")
-        self.stop_conditions: str = _extract_section(self._sections, "stop conditions")
-        self.review_focus: str = _extract_section(self._sections, "review focus")
-        self.suggested_agent: str = _extract_section(self._sections, "suggested agent")
-
-        # Resolve linked PRD path
-        prd_id = self.linked_prd_raw.strip().splitlines()[0].strip() if self.linked_prd_raw else ""
-        self.prd_path: Optional[Path] = _find_prd(prd_id)
-
-        # Resolve ADR paths from dependencies section
-        adr_refs = re.findall(r"ADR-\d+", self.dependencies_raw)
-        self.adr_paths: list[Path] = []
-        for ref in dict.fromkeys(adr_refs):  # deduplicate, preserve order
-            p = _find_adr(ref)
-            if p:
-                self.adr_paths.append(p)
-
-    def prd_path_str(self) -> str:
-        return _repo_relative(self.prd_path) if self.prd_path else f"<PRD not found: {self.linked_prd_raw.strip()}>"
-
-    def adr_paths_str(self) -> str:
-        if not self.adr_paths:
-            return "<no ADRs found>"
-        return "\n".join(_repo_relative(p) for p in self.adr_paths)
-
-    def wi_path_str(self) -> str:
-        return _repo_relative(self.path)
-
-
-# ---------------------------------------------------------------------------
-# Template filling
-# ---------------------------------------------------------------------------
-
-
-def _fill_template(template: str, wi: Optional[WorkItemInfo], extra: dict[str, str]) -> str:
-    """Replace known <PLACEHOLDER> tokens in template with resolved values.
-
-    Inline placeholders (single path or short text) are replaced in-place.
-    List placeholders (ADRs, multi-path areas) that appear as the sole content
-    on a ``- <TOKEN>`` line are expanded into properly indented bullet lists.
-    """
-
-    # Inline token → replacement text (no leading bullet; template provides it)
     inline: dict[str, str] = {}
-    # List tokens that may expand to multiple bullet lines
-    # key = token text inside the angle brackets, value = newline-joined paths
     list_tokens: dict[str, str] = {}
 
-    if wi:
-        inline["<LINKED_PRD>"] = wi.prd_path_str()
-        inline["<ASSIGNED_WORK_ITEM>"] = wi.wi_path_str()
-        inline["<TARGET_WORK_ITEM>"] = wi.wi_path_str()
-        inline["<WORK_ITEM_ID>"] = wi.wi_id
-        inline["<RELEVANT_WORK_ITEMS>"] = wi.wi_path_str()
-        # LINKED_ADRS may expand to multiple lines
-        list_tokens["<LINKED_ADRS>"] = wi.adr_paths_str()
-        # Multi-line block replacements (body sections already contain bullets)
-        inline["<BULLETED_SCOPE_LIST — what the coding agent must build>"] = wi.scope or "<scope not found>"
-        inline["<TARGET_FILES — exact file paths the agent should create or modify>"] = wi.target_area or "<target area not found>"
-        inline["<BULLETED_OUT_OF_SCOPE — explicit reminders of what not to touch>"] = wi.out_of_scope or "<out of scope not found>"
-        inline["<BULLETED_ACCEPTANCE_CRITERIA — what must be true when the slice is complete>"] = (
-            wi.acceptance_criteria or "<acceptance criteria not found>"
-        )
-        inline["<BULLETED_STOP_CONDITIONS — when the agent should stop and report a blocker>"] = (
-            wi.stop_conditions or "<stop conditions not found in work item>"
-        )
+    if bundle:
+        inline["<LINKED_PRD>"] = bundle.linked_prd.resolved_path if bundle.linked_prd and bundle.linked_prd.resolved_path else f"<PRD not found: {bundle.linked_prd.reference_text if bundle.linked_prd else 'none'}>"
+        inline["<ASSIGNED_WORK_ITEM>"] = bundle.work_item_path
+        inline["<TARGET_WORK_ITEM>"] = bundle.work_item_path
+        inline["<WORK_ITEM_ID>"] = bundle.work_item_id
+        inline["<RELEVANT_WORK_ITEMS>"] = bundle.work_item_path
+
+        adr_paths = []
+        for adr in bundle.linked_adrs:
+            if adr.resolved_path:
+                adr_paths.append(adr.resolved_path)
+            else:
+                adr_paths.append(f"<ADR not found: {adr.reference_text}>")
+
+        list_tokens["<LINKED_ADRS>"] = "\n".join(adr_paths) if adr_paths else "<no ADRs found>"
+
+        inline["<BULLETED_SCOPE_LIST — what the coding agent must build>"] = bundle.scope or "<scope not found>"
+        inline["<TARGET_FILES — exact file paths the agent should create or modify>"] = bundle.target_area or "<target area not found>"
+        inline["<BULLETED_OUT_OF_SCOPE — explicit reminders of what not to touch>"] = bundle.out_of_scope or "<out of scope not found>"
+        inline["<BULLETED_ACCEPTANCE_CRITERIA — what must be true when the slice is complete>"] = bundle.acceptance_criteria or "<acceptance criteria not found>"
+        inline["<BULLETED_STOP_CONDITIONS — when the agent should stop and report a blocker>"] = bundle.stop_conditions or "<stop conditions not found in work item>"
 
     inline.update(extra)
 
-    # Pass 1: expand list tokens that appear as "- <TOKEN>" on their own line
     lines = template.splitlines()
     out_lines: list[str] = []
     for line in lines:
         stripped = line.strip()
         matched = False
         for token, multiline_value in list_tokens.items():
-            # Match both "- <TOKEN>" (token as list item) and bare "<TOKEN>"
             if stripped == token or stripped == f"- {token}":
                 indent = line[: len(line) - len(line.lstrip())]
                 for path in multiline_value.splitlines():
@@ -264,11 +135,20 @@ def _fill_template(template: str, wi: Optional[WorkItemInfo], extra: dict[str, s
 
     result = "\n".join(out_lines)
 
-    # Pass 2: inline token substitution
     for token, value in inline.items():
         result = result.replace(token, value)
 
     return result
+
+
+
+def _repo_relative(path: Optional[Path]) -> str:
+    if not path:
+        return ""
+    try:
+        return path.resolve().relative_to(_REPO_ROOT).as_posix()
+    except ValueError:
+        return path.as_posix()
 
 
 # ---------------------------------------------------------------------------
@@ -370,18 +250,18 @@ def main() -> int:
     template_text = template_path.read_text(encoding="utf-8")
 
     # Load work item (optional for drift / spec)
-    wi: Optional[WorkItemInfo] = None
+    wi: Optional['HandoffBundle'] = None
     if args.work_item:
         wi_file = find_work_item_file(args.work_item)
         if not wi_file:
             print(f"error: no work item file found matching '{args.work_item}'", file=sys.stderr)
             return 1
-        wi = WorkItemInfo(wi_file)
+        wi = build_handoff_bundle(role=args.role, work_item_path=wi_file, repo_root=Path(__file__).resolve().parents[1])
         print(f"# Resolved work item: {_repo_relative(wi_file)}", file=sys.stderr)
-        if wi.prd_path:
-            print(f"# Resolved PRD:       {_repo_relative(wi.prd_path)}", file=sys.stderr)
-        if wi.adr_paths:
-            print(f"# Resolved ADRs:      {', '.join(_repo_relative(p) for p in wi.adr_paths)}", file=sys.stderr)
+        if wi.linked_prd and wi.linked_prd.resolved_path:
+            print(f"# Resolved PRD:       {wi.linked_prd.resolved_path}", file=sys.stderr)
+        if wi.linked_adrs:
+            print(f"# Resolved ADRs:      {', '.join(p.resolved_path for p in wi.linked_adrs if p.resolved_path)}", file=sys.stderr)
     elif args.role not in {"drift", "spec", "prd"}:
         print(f"warning: no --work-item supplied; role '{args.role}' may need one", file=sys.stderr)
 

--- a/scripts/invoke.py
+++ b/scripts/invoke.py
@@ -22,14 +22,14 @@ import argparse
 import re
 import sys
 from pathlib import Path
+from typing import Optional
 
 # Ensure the repository root is in sys.path
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
 
-from agent_runtime.handoff_bundle import build_handoff_bundle, HandoffBundle
-from typing import Optional
+from agent_runtime.handoff_bundle import build_handoff_bundle, HandoffBundle  # noqa: E402
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -95,7 +95,11 @@ def _fill_template(template: str, bundle: Optional[HandoffBundle], extra: dict[s
     list_tokens: dict[str, str] = {}
 
     if bundle:
-        inline["<LINKED_PRD>"] = bundle.linked_prd.resolved_path if bundle.linked_prd and bundle.linked_prd.resolved_path else f"<PRD not found: {bundle.linked_prd.reference_text if bundle.linked_prd else 'none'}>"
+        inline["<LINKED_PRD>"] = (
+            bundle.linked_prd.resolved_path
+            if bundle.linked_prd and bundle.linked_prd.resolved_path
+            else f"<PRD not found: {bundle.linked_prd.reference_text if bundle.linked_prd else 'none'}>"
+        )
         inline["<ASSIGNED_WORK_ITEM>"] = bundle.work_item_path
         inline["<TARGET_WORK_ITEM>"] = bundle.work_item_path
         inline["<WORK_ITEM_ID>"] = bundle.work_item_id
@@ -113,8 +117,12 @@ def _fill_template(template: str, bundle: Optional[HandoffBundle], extra: dict[s
         inline["<BULLETED_SCOPE_LIST — what the coding agent must build>"] = bundle.scope or "<scope not found>"
         inline["<TARGET_FILES — exact file paths the agent should create or modify>"] = bundle.target_area or "<target area not found>"
         inline["<BULLETED_OUT_OF_SCOPE — explicit reminders of what not to touch>"] = bundle.out_of_scope or "<out of scope not found>"
-        inline["<BULLETED_ACCEPTANCE_CRITERIA — what must be true when the slice is complete>"] = bundle.acceptance_criteria or "<acceptance criteria not found>"
-        inline["<BULLETED_STOP_CONDITIONS — when the agent should stop and report a blocker>"] = bundle.stop_conditions or "<stop conditions not found in work item>"
+        inline["<BULLETED_ACCEPTANCE_CRITERIA — what must be true when the slice is complete>"] = (
+            bundle.acceptance_criteria or "<acceptance criteria not found>"
+        )
+        inline["<BULLETED_STOP_CONDITIONS — when the agent should stop and report a blocker>"] = (
+            bundle.stop_conditions or "<stop conditions not found in work item>"
+        )
 
     inline.update(extra)
 
@@ -139,7 +147,6 @@ def _fill_template(template: str, bundle: Optional[HandoffBundle], extra: dict[s
         result = result.replace(token, value)
 
     return result
-
 
 
 def _repo_relative(path: Optional[Path]) -> str:
@@ -250,7 +257,7 @@ def main() -> int:
     template_text = template_path.read_text(encoding="utf-8")
 
     # Load work item (optional for drift / spec)
-    wi: Optional['HandoffBundle'] = None
+    wi: Optional["HandoffBundle"] = None
     if args.work_item:
         wi_file = find_work_item_file(args.work_item)
         if not wi_file:

--- a/scripts/invoke.py
+++ b/scripts/invoke.py
@@ -22,14 +22,10 @@ import argparse
 import re
 import sys
 from pathlib import Path
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
-# Ensure the repository root is in sys.path
-_REPO_ROOT = Path(__file__).resolve().parents[1]
-if str(_REPO_ROOT) not in sys.path:
-    sys.path.insert(0, str(_REPO_ROOT))
-
-from agent_runtime.handoff_bundle import build_handoff_bundle, HandoffBundle  # noqa: E402
+if TYPE_CHECKING:
+    from agent_runtime.handoff_bundle import HandoffBundle
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -153,7 +149,7 @@ def _repo_relative(path: Optional[Path]) -> str:
     if not path:
         return ""
     try:
-        return path.resolve().relative_to(_REPO_ROOT).as_posix()
+        return path.resolve().relative_to(REPO_ROOT).as_posix()
     except ValueError:
         return path.as_posix()
 
@@ -224,6 +220,11 @@ def parse_args() -> argparse.Namespace:
 
 
 def main() -> int:
+    _repo_root = Path(__file__).resolve().parents[1]
+    if str(_repo_root) not in sys.path:
+        sys.path.insert(0, str(_repo_root))
+    from agent_runtime.handoff_bundle import build_handoff_bundle  # noqa: PLC0415
+
     args = parse_args()
 
     if args.list_roles:

--- a/skills/deliver-wi/SKILL.md
+++ b/skills/deliver-wi/SKILL.md
@@ -104,7 +104,9 @@ Default to **PM** when in doubt — it is always safe to run PM first.
 
 ## Step 4 — Fill the template
 
-Read the selected template file. Replace the **exact bracketed placeholder string as written in the template** — including any descriptive suffix. Do not assume differently worded placeholders are interchangeable across templates.
+You may run `python scripts/invoke.py --role <ROLE> --work-item <WI_ID>` to automatically generate the prompt filled with the shared handoff bundle data.
+
+If filling manually, read the selected template file and replace the **exact bracketed placeholder string as written in the template** — including any descriptive suffix. Do not assume differently worded placeholders are interchangeable across templates.
 
 ### PM placeholder mapping
 

--- a/tests/unit/scripts/test_invoke_parity.py
+++ b/tests/unit/scripts/test_invoke_parity.py
@@ -1,17 +1,17 @@
-import sys
 from pathlib import Path
-from unittest.mock import patch, MagicMock
 
 import pytest
 
 from agent_runtime.handoff_bundle import build_handoff_bundle
-from scripts.invoke import _fill_template, _repo_relative
+from scripts.invoke import _fill_template
+
 
 @pytest.fixture
 def dummy_wi_path(tmp_path: Path) -> Path:
     wi_path = tmp_path / "work_items" / "ready" / "WI-TEST-1.1.md"
     wi_path.parent.mkdir(parents=True, exist_ok=True)
-    wi_path.write_text("""# WI-TEST-1.1
+    wi_path.write_text(
+        """# WI-TEST-1.1
 
 ## Purpose
 Test manual handoff parity.
@@ -42,7 +42,9 @@ PRD-1.1
 
 ## Stop Conditions
 - if it breaks
-""", encoding="utf-8")
+""",
+        encoding="utf-8",
+    )
 
     prd_path = tmp_path / "docs" / "prds" / "PRD-1.1-test.md"
     prd_path.parent.mkdir(parents=True, exist_ok=True)
@@ -57,6 +59,7 @@ PRD-1.1
     adr_path2.write_text("# ADR 002")
 
     return wi_path
+
 
 def test_template_filling_parity(dummy_wi_path: Path) -> None:
     repo_root = dummy_wi_path.parents[2]

--- a/tests/unit/scripts/test_invoke_parity.py
+++ b/tests/unit/scripts/test_invoke_parity.py
@@ -1,0 +1,98 @@
+import sys
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from agent_runtime.handoff_bundle import build_handoff_bundle
+from scripts.invoke import _fill_template, _repo_relative
+
+@pytest.fixture
+def dummy_wi_path(tmp_path: Path) -> Path:
+    wi_path = tmp_path / "work_items" / "ready" / "WI-TEST-1.1.md"
+    wi_path.parent.mkdir(parents=True, exist_ok=True)
+    wi_path.write_text("""# WI-TEST-1.1
+
+## Purpose
+Test manual handoff parity.
+
+## Linked PRD
+PRD-1.1
+
+## Linked ADRs
+- ADR-001
+- ADR-002
+
+## Dependencies
+- WI-1.1.0
+
+## Scope
+- build things
+- fix things
+
+## Target Area
+- src/test/
+
+## Out Of Scope
+- breaking things
+
+## Acceptance Criteria
+- things are built
+- things are fixed
+
+## Stop Conditions
+- if it breaks
+""", encoding="utf-8")
+
+    prd_path = tmp_path / "docs" / "prds" / "PRD-1.1-test.md"
+    prd_path.parent.mkdir(parents=True, exist_ok=True)
+    prd_path.write_text("# PRD 1.1")
+
+    adr_path1 = tmp_path / "docs" / "adr" / "ADR-001-test.md"
+    adr_path1.parent.mkdir(parents=True, exist_ok=True)
+    adr_path1.write_text("# ADR 001")
+
+    adr_path2 = tmp_path / "docs" / "adr" / "ADR-002-test.md"
+    adr_path2.parent.mkdir(parents=True, exist_ok=True)
+    adr_path2.write_text("# ADR 002")
+
+    return wi_path
+
+def test_template_filling_parity(dummy_wi_path: Path) -> None:
+    repo_root = dummy_wi_path.parents[2]
+
+    bundle = build_handoff_bundle(role="pm", work_item_path=dummy_wi_path, repo_root=repo_root)
+
+    template = """
+Here is the spec:
+<LINKED_PRD>
+
+And ADRs:
+- <LINKED_ADRS>
+
+Scope:
+- <BULLETED_SCOPE_LIST — what the coding agent must build>
+
+Target:
+- <TARGET_FILES — exact file paths the agent should create or modify>
+
+Out:
+- <BULLETED_OUT_OF_SCOPE — explicit reminders of what not to touch>
+
+Ac:
+- <BULLETED_ACCEPTANCE_CRITERIA — what must be true when the slice is complete>
+
+Stop:
+- <BULLETED_STOP_CONDITIONS — when the agent should stop and report a blocker>
+"""
+
+    filled = _fill_template(template, bundle, extra={})
+
+    assert "docs/prds/PRD-1.1-test.md" in filled
+    assert "docs/adr/ADR-001-test.md" in filled
+    assert "docs/adr/ADR-002-test.md" in filled
+    assert "- build things" in filled
+    assert "- src/test/" in filled
+    assert "- breaking things" in filled
+    assert "- things are built" in filled
+    assert "- if it breaks" in filled


### PR DESCRIPTION
Migrate the manual invocation tooling (`scripts/invoke.py`) to the shared handoff-bundle builder to close the field-parity gap between manual and runtime execution context. Adds tests to compare the core fields for the same WI across manual and runtime paths. Completes `WI-MAINT-2C`.

---
*PR created automatically by Jules for task [8492334270071806623](https://jules.google.com/task/8492334270071806623) started by @tomanizer*